### PR TITLE
Planarly Branched Signatures

### DIFF
--- a/pysiglib/branched_sig.py
+++ b/pysiglib/branched_sig.py
@@ -149,6 +149,8 @@ def branched_sig(
 
     if tree_order not in ("recursive", "canonical"):
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
+    if tree_order != "recursive" and planar:
+        raise ValueError("tree_order has no effect for planar branched signatures")
     check_type(degree, "degree", int)
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
@@ -220,6 +222,8 @@ def branched_sig_combine(
 
     if tree_order not in ("recursive", "canonical"):
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
+    if tree_order != "recursive" and planar:
+        raise ValueError("tree_order has no effect for planar branched signatures")
     check_type(dimension, "dimension", int)
     check_type(degree, "degree", int)
     check_type(planar, "planar", bool)

--- a/pysiglib/branched_sig.py
+++ b/pysiglib/branched_sig.py
@@ -52,7 +52,8 @@ def prepare_branched_sig(
         degree: int,
         use_disk: bool = False,
         time_aug: bool = False,
-        lead_lag: bool = False
+        lead_lag: bool = False,
+        planar: bool = False
 ):
     """
     Precomputes the tree enumeration and Connes-Kreimer coproduct tables
@@ -69,21 +70,23 @@ def prepare_branched_sig(
         as ``set_cache_dir()`` / ``prepare_log_sig()``.
     :param time_aug: If True, prepare for time-augmented paths (dim + 1).
     :param lead_lag: If True, prepare for lead-lag transformed paths (2 * dim).
+    :param planar: If True, prepare for planar (ordered) branched signatures.
     """
     check_type(dimension, "dimension", int)
     check_type(degree, "degree", int)
     check_type(use_disk, "use_disk", bool)
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
+    check_type(planar, "planar", bool)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
-    err_code = CPSIG.prepare_branched_sig(aug_dimension, degree, use_disk)
+    err_code = CPSIG.prepare_branched_sig(aug_dimension, degree, use_disk, planar)
     if err_code:
         raise Exception("Error in pysiglib.prepare_branched_sig: " + err_msg(err_code))
 
 
-def branched_sig_length(dimension: int, degree: int, scalar_term: bool = True) -> int:
+def branched_sig_length(dimension: int, degree: int, scalar_term: bool = True, planar: bool = False) -> int:
     """
     Returns the length of a truncated branched signature.
 
@@ -92,13 +95,14 @@ def branched_sig_length(dimension: int, degree: int, scalar_term: bool = True) -
     :param scalar_term: If True (default), includes the empty-tree scalar term at index 0
         in the length. If False, the returned length is one less (matching ``branched_sig``
         output with ``scalar_term=False``).
+    :param planar: If True, return the length for planar (ordered) branched signatures.
     :return: Length of the branched signature array.
     """
     check_type(dimension, "dimension", int)
     check_type(degree, "degree", int)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
-    out = CPSIG.branched_sig_length(dimension, degree)
+    out = CPSIG.branched_sig_length(dimension, degree, planar)
     if out == 0:
         raise ValueError("Invalid parameters or integer overflow in branched_sig_length")
     return out - (0 if scalar_term else 1)
@@ -113,6 +117,7 @@ def branched_sig(
         tree_order: str = "recursive",
         scalar_term = None,
         n_jobs: int = 1,
+        planar: bool = False,
 ) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the truncated branched signature of a path or batch of paths.
@@ -120,9 +125,9 @@ def branched_sig(
     The branched signature extends the standard path signature to iterated
     integrals indexed by decorated rooted trees, following Gubinelli (2010).
 
-    Must call ``prepare_branched_sig(dimension, degree)`` before first use,
-    where ``dimension`` is the augmented dimension (accounting for
-    ``time_aug`` and ``lead_lag``).
+    Must call ``prepare_branched_sig(dimension, degree, planar=planar)``
+    before first use, where ``dimension`` is the augmented dimension
+    (accounting for ``time_aug`` and ``lead_lag``).
 
     :param path: Path of shape ``(length, dimension)`` or ``(*batch_dims, length, dimension)``.
     :param degree: Maximum tree order (number of nodes).
@@ -137,6 +142,7 @@ def branched_sig(
         The default will change to False in pySigLib v4.0.
     :type scalar_term: bool
     :param n_jobs: Number of parallel threads for batch processing.
+    :param planar: If True, compute the planar (ordered) branched signature.
     :return: Branched signature array of shape ``(bsig_len,)`` or ``(*batch_dims, bsig_len)``.
     """
     scalar_term = resolve_scalar_term(scalar_term)
@@ -147,13 +153,14 @@ def branched_sig(
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
     check_type(end_time, "end_time", float)
+    check_type(planar, "planar", bool)
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
 
     data = PathInputHandler(path, time_aug, lead_lag, end_time, "path")
     dimension = data.data_dimension
     aug_dimension = data.dimension
-    bsig_len = CPSIG.branched_sig_length(aug_dimension, degree)
+    bsig_len = CPSIG.branched_sig_length(aug_dimension, degree, planar)
     result = SigOutputHandler(data, bsig_len)
 
     if data.batch_size == 0:
@@ -165,15 +172,15 @@ def branched_sig(
         err_code = CPSIG_BRANCHED_SIG[data.dtype](
             data.data_ptr, result.data_ptr, data.batch_size,
             dimension, data.data_length, degree, n_jobs,
-            data.time_aug, data.lead_lag, data.end_time)
+            data.time_aug, data.lead_lag, data.end_time, planar)
     else:
         err_code = CUSIG_BRANCHED_SIG_CUDA[data.dtype](
             data.data_ptr, result.data_ptr, data.batch_size,
             dimension, data.data_length, degree,
-            data.time_aug, data.lead_lag, data.end_time)
+            data.time_aug, data.lead_lag, data.end_time, planar)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig: " + err_msg(err_code))
-    if tree_order != "recursive":
+    if tree_order != "recursive" and not planar:
         _permute_bsig(result.data, aug_dimension, degree)
     if not scalar_term:
         return result.data[..., 1:]
@@ -188,6 +195,7 @@ def branched_sig_combine(
         tree_order: str = "recursive",
         scalar_term = None,
         n_jobs: int = 1,
+        planar: bool = False,
 ) -> Union[np.ndarray, torch.Tensor]:
     """
     Combines two truncated branched signatures via the Butcher product
@@ -205,6 +213,7 @@ def branched_sig_combine(
         The default will change to False in pySigLib v4.0.
     :type scalar_term: bool
     :param n_jobs: Number of parallel threads for batch processing.
+    :param planar: If True, combine planar (ordered) branched signatures.
     :return: Combined branched signature, in the same ordering as the inputs.
     """
     scalar_term = resolve_scalar_term(scalar_term)
@@ -213,15 +222,16 @@ def branched_sig_combine(
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
     check_type(dimension, "dimension", int)
     check_type(degree, "degree", int)
+    check_type(planar, "planar", bool)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
 
-    if tree_order != "recursive":
+    if tree_order != "recursive" and not planar:
         bsig1 = _inv_permute_bsig(bsig1, dimension, degree)
         bsig2 = _inv_permute_bsig(bsig2, dimension, degree)
 
-    bsig_len = CPSIG.branched_sig_length(dimension, degree)
+    bsig_len = CPSIG.branched_sig_length(dimension, degree, planar)
     data = MultipleSigInputHandler([bsig1, bsig2], bsig_len, ["bsig1", "bsig2"])
     result = SigOutputHandler(data, bsig_len)
 
@@ -233,14 +243,14 @@ def branched_sig_combine(
     if data.device == "cpu":
         err_code = CPSIG_BRANCHED_SIG_COMBINE[data.dtype](
             data.sig_ptr[0], data.sig_ptr[1], result.data_ptr,
-            data.batch_size, dimension, degree, n_jobs)
+            data.batch_size, dimension, degree, n_jobs, planar)
     else:
         err_code = CUSIG_BRANCHED_SIG_COMBINE_CUDA[data.dtype](
             data.sig_ptr[0], data.sig_ptr[1], result.data_ptr,
-            data.batch_size, dimension, degree)
+            data.batch_size, dimension, degree, planar)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_combine: " + err_msg(err_code))
-    if tree_order != "recursive":
+    if tree_order != "recursive" and not planar:
         _permute_bsig(result.data, dimension, degree)
     if not scalar_term:
         return result.data[..., 1:]

--- a/pysiglib/branched_sig_backprop.py
+++ b/pysiglib/branched_sig_backprop.py
@@ -39,7 +39,8 @@ def branched_sig_backprop(
         end_time: float = 1.0,
         tree_order: str = "recursive",
         scalar_term = None,
-        n_jobs: int = 1
+        n_jobs: int = 1,
+        planar: bool = False
 ) -> Union[np.ndarray, torch.Tensor]:
     """
     Backpropagates through the branched signature computation.
@@ -56,6 +57,7 @@ def branched_sig_backprop(
     :param lead_lag: Whether lead-lag was used in the forward pass.
     :param end_time: End time for time augmentation.
     :param n_jobs: Number of parallel threads for batch processing.
+    :param planar: If True, backpropagate through planar branched signature.
     :return: Path derivatives, same shape as ``path``.
     """
     scalar_term = resolve_scalar_term(scalar_term)
@@ -66,6 +68,7 @@ def branched_sig_backprop(
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
     check_type(end_time, "end_time", float)
+    check_type(planar, "planar", bool)
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
 
@@ -76,11 +79,11 @@ def branched_sig_backprop(
     dimension = path_data.data_dimension
     aug_dimension = path_data.dimension
 
-    if tree_order != "recursive":
+    if tree_order != "recursive" and not planar:
         bsig = _inv_permute_bsig(bsig, aug_dimension, degree)
         bsig_derivs = _inv_permute_bsig(bsig_derivs, aug_dimension, degree)
 
-    bsig_len = CPSIG.branched_sig_length(aug_dimension, degree)
+    bsig_len = CPSIG.branched_sig_length(aug_dimension, degree, planar)
     sig_data = MultipleSigInputHandler([bsig, bsig_derivs], bsig_len, ["bsig", "bsig_derivs"])
     result = PathOutputHandler(path_data.data_length, path_data.data_dimension, path_data)
 
@@ -92,13 +95,13 @@ def branched_sig_backprop(
             path_data.data_ptr, result.data_ptr,
             sig_data.sig_ptr[1], sig_data.sig_ptr[0],
             path_data.batch_size, dimension, path_data.data_length, degree, n_jobs,
-            path_data.time_aug, path_data.lead_lag, path_data.end_time)
+            path_data.time_aug, path_data.lead_lag, path_data.end_time, planar)
     else:
         err_code = CUSIG_BRANCHED_SIG_BACKPROP_CUDA[path_data.dtype](
             path_data.data_ptr, result.data_ptr,
             sig_data.sig_ptr[1], sig_data.sig_ptr[0],
             path_data.batch_size, dimension, path_data.data_length, degree,
-            path_data.time_aug, path_data.lead_lag, path_data.end_time)
+            path_data.time_aug, path_data.lead_lag, path_data.end_time, planar)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_backprop: " + err_msg(err_code))
     return result.data
@@ -112,7 +115,8 @@ def branched_sig_combine_backprop(
         degree: int,
         tree_order: str = "recursive",
         scalar_term = None,
-        n_jobs: int = 1
+        n_jobs: int = 1,
+        planar: bool = False
 ) -> tuple:
     """
     Backpropagates through the branched signature combine (Butcher product).
@@ -127,6 +131,7 @@ def branched_sig_combine_backprop(
     :param dimension: Dimension of the underlying path.
     :param degree: Maximum tree order.
     :param n_jobs: Number of parallel threads for batch processing.
+    :param planar: If True, backpropagate through planar branched sig combine.
     :return: Tuple ``(dF/d(bsig1), dF/d(bsig2))``.
     """
     scalar_term = resolve_scalar_term(scalar_term)
@@ -135,6 +140,7 @@ def branched_sig_combine_backprop(
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
     check_type(dimension, "dimension", int)
     check_type(degree, "degree", int)
+    check_type(planar, "planar", bool)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
@@ -142,12 +148,12 @@ def branched_sig_combine_backprop(
     if not scalar_term:
         derivs = prepend_scalar(derivs, 0)
 
-    if tree_order != "recursive":
+    if tree_order != "recursive" and not planar:
         derivs = _inv_permute_bsig(derivs, dimension, degree)
         bsig1 = _inv_permute_bsig(bsig1, dimension, degree)
         bsig2 = _inv_permute_bsig(bsig2, dimension, degree)
 
-    bsig_len = CPSIG.branched_sig_length(dimension, degree)
+    bsig_len = CPSIG.branched_sig_length(dimension, degree, planar)
     data = MultipleSigInputHandler([derivs, bsig1, bsig2], bsig_len, ["derivs", "bsig1", "bsig2"])
     result1 = SigOutputHandler(data, bsig_len)
     result2 = SigOutputHandler(data, bsig_len)
@@ -161,15 +167,15 @@ def branched_sig_combine_backprop(
         err_code = CPSIG_BRANCHED_SIG_COMBINE_BACKPROP[data.dtype](
             data.sig_ptr[1], data.sig_ptr[2], data.sig_ptr[0],
             result1.data_ptr, result2.data_ptr,
-            data.batch_size, dimension, degree, n_jobs)
+            data.batch_size, dimension, degree, n_jobs, planar)
     else:
         err_code = CUSIG_BRANCHED_SIG_COMBINE_BACKPROP_CUDA[data.dtype](
             data.sig_ptr[1], data.sig_ptr[2], data.sig_ptr[0],
             result1.data_ptr, result2.data_ptr,
-            data.batch_size, dimension, degree)
+            data.batch_size, dimension, degree, planar)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_combine_backprop: " + err_msg(err_code))
-    if tree_order != "recursive":
+    if tree_order != "recursive" and not planar:
         _permute_bsig(result1.data, dimension, degree)
         _permute_bsig(result2.data, dimension, degree)
     if not scalar_term:

--- a/pysiglib/branched_sig_backprop.py
+++ b/pysiglib/branched_sig_backprop.py
@@ -64,6 +64,8 @@ def branched_sig_backprop(
 
     if tree_order not in ("recursive", "canonical"):
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
+    if tree_order != "recursive" and planar:
+        raise ValueError("tree_order has no effect for planar branched signatures")
     check_type(degree, "degree", int)
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
@@ -138,6 +140,8 @@ def branched_sig_combine_backprop(
 
     if tree_order not in ("recursive", "canonical"):
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
+    if tree_order != "recursive" and planar:
+        raise ValueError("tree_order has no effect for planar branched signatures")
     check_type(dimension, "dimension", int)
     check_type(degree, "degree", int)
     check_type(planar, "planar", bool)

--- a/pysiglib/jax_api/_ffi.py
+++ b/pysiglib/jax_api/_ffi.py
@@ -436,29 +436,29 @@ def log_sig_from_path_backprop_ffi_call(cotangent, path, dimension, degree, n_jo
 # branched_sig
 # ---------------------------------------------------------------------------
 
-def _branched_sig_shape(path_shape, dimension, max_nodes, time_aug, lead_lag):
+def _branched_sig_shape(path_shape, dimension, max_nodes, time_aug, lead_lag, planar):
     aug_dim = _augmented_dim(dimension, time_aug, lead_lag)
-    out_len = branched_sig_length(aug_dim, max_nodes)
+    out_len = branched_sig_length(aug_dim, max_nodes, planar=planar)
     if out_len == 0:
         raise ValueError("Branched signature length overflow.")
     return (*path_shape[:-2], out_len)
 
 
-def branched_sig_ffi_call(path, max_nodes, time_aug, lead_lag, end_time, n_jobs):
+def branched_sig_ffi_call(path, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar):
     _normalize_dtype(path.dtype)
     dimension = path.shape[-1]
     out_type = jax.ShapeDtypeStruct(
-        _branched_sig_shape(path.shape, dimension, max_nodes, time_aug, lead_lag), path.dtype)
+        _branched_sig_shape(path.shape, dimension, max_nodes, time_aug, lead_lag, planar), path.dtype)
     call_kwargs = dict(max_nodes=np.int64(max_nodes), time_aug=np.bool_(time_aug), lead_lag=np.bool_(lead_lag),
-                       end_time=np.float64(end_time), n_jobs=np.int64(n_jobs))
+                       end_time=np.float64(end_time), n_jobs=np.int64(n_jobs), planar=np.bool_(planar))
     return _make_ffi_call("branched_sig", (path,), out_type, call_kwargs)
 
 
-def branched_sig_backprop_ffi_call(path, bsig, cotangent, max_nodes, time_aug, lead_lag, end_time, n_jobs):
+def branched_sig_backprop_ffi_call(path, bsig, cotangent, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar):
     _check_same_dtype(path, bsig, cotangent)
     out_type = jax.ShapeDtypeStruct(path.shape, path.dtype)
     call_kwargs = dict(max_nodes=np.int64(max_nodes), time_aug=np.bool_(time_aug), lead_lag=np.bool_(lead_lag),
-                       end_time=np.float64(end_time), n_jobs=np.int64(n_jobs))
+                       end_time=np.float64(end_time), n_jobs=np.int64(n_jobs), planar=np.bool_(planar))
     return _make_ffi_call("branched_sig_backprop", (path, bsig, cotangent), out_type, call_kwargs)
 
 
@@ -466,15 +466,17 @@ def branched_sig_backprop_ffi_call(path, bsig, cotangent, max_nodes, time_aug, l
 # branched_sig_combine
 # ---------------------------------------------------------------------------
 
-def branched_sig_combine_ffi_call(bsig1, bsig2, dimension, max_nodes, n_jobs):
+def branched_sig_combine_ffi_call(bsig1, bsig2, dimension, max_nodes, n_jobs, planar):
     _check_same_dtype(bsig1, bsig2)
     out_type = jax.ShapeDtypeStruct(bsig1.shape, bsig1.dtype)
-    call_kwargs = dict(dimension=np.int64(dimension), max_nodes=np.int64(max_nodes), n_jobs=np.int64(n_jobs))
+    call_kwargs = dict(dimension=np.int64(dimension), max_nodes=np.int64(max_nodes),
+                       n_jobs=np.int64(n_jobs), planar=np.bool_(planar))
     return _make_ffi_call("branched_sig_combine", (bsig1, bsig2), out_type, call_kwargs)
 
 
-def branched_sig_combine_backprop_ffi_call(cotangent, bsig1, bsig2, dimension, max_nodes, n_jobs):
+def branched_sig_combine_backprop_ffi_call(cotangent, bsig1, bsig2, dimension, max_nodes, n_jobs, planar):
     _check_same_dtype(cotangent, bsig1, bsig2)
     grad_type = jax.ShapeDtypeStruct(bsig1.shape, bsig1.dtype)
-    call_kwargs = dict(dimension=np.int64(dimension), max_nodes=np.int64(max_nodes), n_jobs=np.int64(n_jobs))
+    call_kwargs = dict(dimension=np.int64(dimension), max_nodes=np.int64(max_nodes),
+                       n_jobs=np.int64(n_jobs), planar=np.bool_(planar))
     return _make_ffi_call("branched_sig_combine_backprop", (cotangent, bsig1, bsig2), (grad_type, grad_type), call_kwargs)

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from functools import partial
 
 import numpy as np
+import kauri
 
 try:
     import jax
@@ -158,6 +159,16 @@ sig.__doc__ = sig_forward.__doc__
 def _validate_sig_shape(arr, name="signature"):
     if arr.ndim < 1:
         raise ValueError(f"{name} must have at least rank 1, got {arr.ndim}.")
+
+
+def _permute_bsig_jax(data, dimension: int, degree: int):
+    perm = np.asarray(kauri.canonical_to_recursive_permutation(dimension, degree), dtype=np.int32)
+    return jnp.concatenate([data[..., :1], jnp.take(data[..., 1:], perm, axis=-1)], axis=-1)
+
+
+def _inv_permute_bsig_jax(data, dimension: int, degree: int):
+    perm = np.asarray(kauri.recursive_to_canonical_permutation(dimension, degree), dtype=np.int32)
+    return jnp.concatenate([data[..., :1], jnp.take(data[..., 1:], perm, axis=-1)], axis=-1)
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(2, 3, 4))
@@ -987,19 +998,20 @@ def sig_coef(
 # branched_sig
 # ---------------------------------------------------------------------------
 
-@partial(jax.custom_vjp, nondiff_argnums=(1, 2, 3, 4, 5))
-def _branched_sig(path, max_nodes, time_aug, lead_lag, end_time, n_jobs):
-    return branched_sig_ffi_call(path, max_nodes, time_aug, lead_lag, end_time, n_jobs)
+@partial(jax.custom_vjp, nondiff_argnums=(1, 2, 3, 4, 5, 6))
+def _branched_sig(path, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar):
+    return branched_sig_ffi_call(path, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar)
 
 
-def _branched_sig_fwd(path, max_nodes, time_aug, lead_lag, end_time, n_jobs):
-    bsig = branched_sig_ffi_call(path, max_nodes, time_aug, lead_lag, end_time, n_jobs)
+def _branched_sig_fwd(path, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar):
+    bsig = branched_sig_ffi_call(path, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar)
     return bsig, (path, bsig)
 
 
-def _branched_sig_bwd(max_nodes, time_aug, lead_lag, end_time, n_jobs, residual, cotangent):
+def _branched_sig_bwd(max_nodes, time_aug, lead_lag, end_time, n_jobs, planar, residual, cotangent):
     path, bsig = residual
-    grad = branched_sig_backprop_ffi_call(path, bsig, cotangent, max_nodes, time_aug, lead_lag, end_time, n_jobs)
+    grad = branched_sig_backprop_ffi_call(
+        path, bsig, cotangent, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar)
     return (grad,)
 
 
@@ -1009,24 +1021,33 @@ _branched_sig.defvjp(_branched_sig_fwd, _branched_sig_bwd)
 def branched_sig(
     path,
     degree: int,
-    n_jobs: int = 1,
     time_aug: bool = False,
     lead_lag: bool = False,
     end_time: float = 1.0,
+    tree_order: str = "recursive",
+    n_jobs: int = 1,
+    planar: bool = False,
 ):
     ensure_registered()
 
     path = jnp.asarray(path)
     _validate_shape(path)
 
+    if tree_order not in ("recursive", "canonical"):
+        raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
     check_type(degree, "degree", int)
     check_non_neg(degree, "degree")
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
     check_type(end_time, "end_time", float)
+    check_type(planar, "planar", bool)
     check_n_jobs(n_jobs)
 
-    return _branched_sig(path, degree, time_aug, lead_lag, end_time, n_jobs)
+    result = _branched_sig(path, degree, time_aug, lead_lag, end_time, n_jobs, planar)
+    if tree_order != "recursive" and not planar:
+        aug_dim = _augmented_dim(path.shape[-1], time_aug, lead_lag)
+        result = _permute_bsig_jax(result, aug_dim, degree)
+    return result
 
 
 branched_sig.__doc__ = branched_sig_forward.__doc__
@@ -1036,20 +1057,20 @@ branched_sig.__doc__ = branched_sig_forward.__doc__
 # branched_sig_combine
 # ---------------------------------------------------------------------------
 
-@partial(jax.custom_vjp, nondiff_argnums=(2, 3, 4))
-def _branched_sig_combine(bsig1, bsig2, dimension, max_nodes, n_jobs):
-    return branched_sig_combine_ffi_call(bsig1, bsig2, dimension, max_nodes, n_jobs)
+@partial(jax.custom_vjp, nondiff_argnums=(2, 3, 4, 5))
+def _branched_sig_combine(bsig1, bsig2, dimension, max_nodes, n_jobs, planar):
+    return branched_sig_combine_ffi_call(bsig1, bsig2, dimension, max_nodes, n_jobs, planar)
 
 
-def _branched_sig_combine_fwd(bsig1, bsig2, dimension, max_nodes, n_jobs):
-    result = branched_sig_combine_ffi_call(bsig1, bsig2, dimension, max_nodes, n_jobs)
+def _branched_sig_combine_fwd(bsig1, bsig2, dimension, max_nodes, n_jobs, planar):
+    result = branched_sig_combine_ffi_call(bsig1, bsig2, dimension, max_nodes, n_jobs, planar)
     return result, (bsig1, bsig2)
 
 
-def _branched_sig_combine_bwd(dimension, max_nodes, n_jobs, residual, cotangent):
+def _branched_sig_combine_bwd(dimension, max_nodes, n_jobs, planar, residual, cotangent):
     bsig1, bsig2 = residual
     grad1, grad2 = branched_sig_combine_backprop_ffi_call(
-        cotangent, bsig1, bsig2, dimension, max_nodes, n_jobs
+        cotangent, bsig1, bsig2, dimension, max_nodes, n_jobs, planar
     )
     return (grad1, grad2)
 
@@ -1062,7 +1083,9 @@ def branched_sig_combine(
     bsig2,
     dimension: int,
     degree: int,
+    tree_order: str = "recursive",
     n_jobs: int = 1,
+    planar: bool = False,
 ):
     ensure_registered()
 
@@ -1071,13 +1094,23 @@ def branched_sig_combine(
     _validate_sig_shape(bsig1, "bsig1")
     _validate_sig_shape(bsig2, "bsig2")
 
+    if tree_order not in ("recursive", "canonical"):
+        raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
     check_type(dimension, "dimension", int)
     check_non_neg(dimension, "dimension")
     check_type(degree, "degree", int)
     check_non_neg(degree, "degree")
+    check_type(planar, "planar", bool)
     check_n_jobs(n_jobs)
 
-    return _branched_sig_combine(bsig1, bsig2, dimension, degree, n_jobs)
+    if tree_order != "recursive" and not planar:
+        bsig1 = _inv_permute_bsig_jax(bsig1, dimension, degree)
+        bsig2 = _inv_permute_bsig_jax(bsig2, dimension, degree)
+
+    result = _branched_sig_combine(bsig1, bsig2, dimension, degree, n_jobs, planar)
+    if tree_order != "recursive" and not planar:
+        result = _permute_bsig_jax(result, dimension, degree)
+    return result
 
 
 branched_sig_combine.__doc__ = branched_sig_combine_forward.__doc__

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -1035,6 +1035,8 @@ def branched_sig(
 
     if tree_order not in ("recursive", "canonical"):
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
+    if tree_order != "recursive" and planar:
+        raise ValueError("tree_order has no effect for planar branched signatures")
     check_type(degree, "degree", int)
     check_non_neg(degree, "degree")
     check_type(time_aug, "time_aug", bool)
@@ -1096,6 +1098,8 @@ def branched_sig_combine(
 
     if tree_order not in ("recursive", "canonical"):
         raise ValueError(f"tree_order must be 'recursive' or 'canonical', got {tree_order!r}")
+    if tree_order != "recursive" and planar:
+        raise ValueError("tree_order has no effect for planar branched signatures")
     check_type(dimension, "dimension", int)
     check_non_neg(dimension, "dimension")
     check_type(degree, "degree", int)

--- a/pysiglib/load_siglib.py
+++ b/pysiglib/load_siglib.py
@@ -487,62 +487,62 @@ if BUILT_WITH_CUDA:
 # branched_sig
 ######################################################
 
-CPSIG.prepare_branched_sig.argtypes = (c_uint64, c_uint64, c_bool)
+CPSIG.prepare_branched_sig.argtypes = (c_uint64, c_uint64, c_bool, c_bool)
 CPSIG.prepare_branched_sig.restype = c_int
 
-CPSIG.branched_sig_length.argtypes = (c_uint64, c_uint64)
+CPSIG.branched_sig_length.argtypes = (c_uint64, c_uint64, c_bool)
 CPSIG.branched_sig_length.restype = c_uint64
 
 
-CPSIG.branched_sig_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float)
+CPSIG.branched_sig_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float, c_bool)
 CPSIG.branched_sig_f.restype = c_int
 
-CPSIG.branched_sig_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double)
+CPSIG.branched_sig_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double, c_bool)
 CPSIG.branched_sig_d.restype = c_int
 
 
-CPSIG.branched_sig_combine_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_sig_combine_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool)
 CPSIG.branched_sig_combine_f.restype = c_int
 
-CPSIG.branched_sig_combine_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_sig_combine_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool)
 CPSIG.branched_sig_combine_d.restype = c_int
 
 
-CPSIG.branched_sig_combine_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_sig_combine_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool)
 CPSIG.branched_sig_combine_backprop_f.restype = c_int
 
-CPSIG.branched_sig_combine_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_sig_combine_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool)
 CPSIG.branched_sig_combine_backprop_d.restype = c_int
 
 
-CPSIG.branched_sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float)
+CPSIG.branched_sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float, c_bool)
 CPSIG.branched_sig_backprop_f.restype = c_int
 
-CPSIG.branched_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double)
+CPSIG.branched_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double, c_bool)
 CPSIG.branched_sig_backprop_d.restype = c_int
 
 if BUILT_WITH_CUDA:
 
-    CUSIG.branched_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float)
+    CUSIG.branched_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool)
     CUSIG.branched_sig_cuda_f.restype = c_int
 
-    CUSIG.branched_sig_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double)
+    CUSIG.branched_sig_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool)
     CUSIG.branched_sig_cuda_d.restype = c_int
 
-    CUSIG.branched_sig_combine_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_sig_combine_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_bool)
     CUSIG.branched_sig_combine_cuda_f.restype = c_int
-    CUSIG.branched_sig_combine_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_sig_combine_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_bool)
     CUSIG.branched_sig_combine_cuda_d.restype = c_int
 
-    CUSIG.branched_sig_combine_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_sig_combine_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_bool)
     CUSIG.branched_sig_combine_backprop_cuda_f.restype = c_int
-    CUSIG.branched_sig_combine_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_sig_combine_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_bool)
     CUSIG.branched_sig_combine_backprop_cuda_d.restype = c_int
 
-    CUSIG.branched_sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float)
+    CUSIG.branched_sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool)
     CUSIG.branched_sig_backprop_cuda_f.restype = c_int
 
-    CUSIG.branched_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double)
+    CUSIG.branched_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool)
     CUSIG.branched_sig_backprop_cuda_d.restype = c_int
 
     ######################################################

--- a/pysiglib/torch_api/torch_api.py
+++ b/pysiglib/torch_api/torch_api.py
@@ -563,9 +563,9 @@ from ..branched_sig_backprop import branched_sig_backprop, branched_sig_combine_
 
 class BranchedSig(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, path, degree, time_aug, lead_lag, end_time, tree_order, scalar_term, n_jobs):
+    def forward(ctx, path, degree, time_aug, lead_lag, end_time, tree_order, scalar_term, n_jobs, planar):
         bsig = branched_sig_forward(path, degree, scalar_term=True, tree_order=tree_order, n_jobs=n_jobs,
-                                     time_aug=time_aug, lead_lag=lead_lag, end_time=end_time)
+                                     time_aug=time_aug, lead_lag=lead_lag, end_time=end_time, planar=planar)
 
         ctx.save_for_backward(path, bsig)
         ctx.degree = degree
@@ -575,6 +575,7 @@ class BranchedSig(torch.autograd.Function):
         ctx.lead_lag = lead_lag
         ctx.end_time = end_time
         ctx.n_jobs = n_jobs
+        ctx.planar = planar
 
         if not scalar_term:
             return bsig[..., 1:]
@@ -587,8 +588,8 @@ class BranchedSig(torch.autograd.Function):
             grad_output = prepend_scalar(grad_output, 0)
         grad = branched_sig_backprop(path, bsig, grad_output, ctx.degree,
                                      scalar_term=True, time_aug=ctx.time_aug, lead_lag=ctx.lead_lag, end_time=ctx.end_time,
-                                     tree_order=ctx.tree_order, n_jobs=ctx.n_jobs)
-        return grad, None, None, None, None, None, None, None
+                                     tree_order=ctx.tree_order, n_jobs=ctx.n_jobs, planar=ctx.planar)
+        return grad, None, None, None, None, None, None, None, None
 
 def branched_sig(
         path: Union[np.ndarray, torch.Tensor],
@@ -599,24 +600,26 @@ def branched_sig(
         tree_order: str = "recursive",
         scalar_term = None,
         n_jobs: int = 1,
+        planar: bool = False,
 ) -> Union[np.ndarray, torch.Tensor]:
     scalar_term = resolve_scalar_term(scalar_term)
-    return BranchedSig.apply(path, degree, time_aug, lead_lag, end_time, tree_order, scalar_term, n_jobs)
+    return BranchedSig.apply(path, degree, time_aug, lead_lag, end_time, tree_order, scalar_term, n_jobs, planar)
 
 branched_sig.__doc__ = branched_sig_forward.__doc__
 
 
 class BranchedSigCombine(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, bsig1, bsig2, dimension, degree, tree_order, scalar_term, n_jobs):
+    def forward(ctx, bsig1, bsig2, dimension, degree, tree_order, scalar_term, n_jobs, planar):
         combined = branched_sig_combine_forward(bsig1, bsig2, dimension, degree,
-                                                 scalar_term=True, tree_order=tree_order, n_jobs=n_jobs)
+                                                 scalar_term=True, tree_order=tree_order, n_jobs=n_jobs, planar=planar)
         ctx.save_for_backward(bsig1, bsig2)
         ctx.dimension = dimension
         ctx.degree = degree
         ctx.scalar_term = scalar_term
         ctx.tree_order = tree_order
         ctx.n_jobs = n_jobs
+        ctx.planar = planar
 
         if not scalar_term:
             return combined[..., 1:]
@@ -629,8 +632,8 @@ class BranchedSigCombine(torch.autograd.Function):
             grad_output = prepend_scalar(grad_output, 0)
         d1, d2 = branched_sig_combine_backprop(
             grad_output, bsig1, bsig2, ctx.dimension, ctx.degree,
-            scalar_term=True, tree_order=ctx.tree_order, n_jobs=ctx.n_jobs)
-        return d1, d2, None, None, None, None, None
+            scalar_term=True, tree_order=ctx.tree_order, n_jobs=ctx.n_jobs, planar=ctx.planar)
+        return d1, d2, None, None, None, None, None, None
 
 def branched_sig_combine(
         bsig1: Union[np.ndarray, torch.Tensor],
@@ -640,9 +643,10 @@ def branched_sig_combine(
         tree_order: str = "recursive",
         scalar_term = None,
         n_jobs: int = 1,
+        planar: bool = False,
 ) -> Union[np.ndarray, torch.Tensor]:
     scalar_term = resolve_scalar_term(scalar_term)
-    return BranchedSigCombine.apply(bsig1, bsig2, dimension, degree, tree_order, scalar_term, n_jobs)
+    return BranchedSigCombine.apply(bsig1, bsig2, dimension, degree, tree_order, scalar_term, n_jobs, planar)
 
 branched_sig_combine.__doc__ = branched_sig_combine_forward.__doc__
 

--- a/siglib/cpsig/cp_branched_cache.cpp
+++ b/siglib/cpsig/cp_branched_cache.cpp
@@ -20,11 +20,24 @@
 #include "macros.h"
 
 namespace {
+using BranchedCacheKey = std::tuple<uint64_t, uint64_t, bool>;
+
+struct BranchedCacheKeyHash {
+	std::size_t operator()(const BranchedCacheKey& k) const noexcept {
+		std::size_t h1 = std::hash<uint64_t>{}(std::get<0>(k));
+		std::size_t h2 = std::hash<uint64_t>{}(std::get<1>(k));
+		std::size_t h3 = std::hash<bool>{}(std::get<2>(k));
+		h1 ^= (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+		h1 ^= (h3 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+		return h1;
+	}
+};
+
 struct BranchedSigCacheRegistry {
 	std::unordered_map<
-		std::pair<uint64_t, uint64_t>,
+		BranchedCacheKey,
 		std::unique_ptr<BranchedSigCache>,
-		PairHash
+		BranchedCacheKeyHash
 	> map;
 	std::shared_mutex mu;
 };
@@ -42,9 +55,10 @@ BranchedSigCacheRegistry& branched_sig_cache_registry() {
 
 static constexpr const char* branched_cache_version = "v1";
 
-static std::filesystem::path branched_cache_file_path(uint64_t dimension, uint64_t max_nodes) {
+static std::filesystem::path branched_cache_file_path(uint64_t dimension, uint64_t max_nodes, bool planar) {
+	const char* prefix = planar ? "planar_branched_" : "branched_";
 	return get_cache_dir() / cache_folder_name /
-		("branched_" + std::to_string(dimension) + "_" + std::to_string(max_nodes) + "_" + branched_cache_version + ".bin");
+		(prefix + std::to_string(dimension) + "_" + std::to_string(max_nodes) + "_" + branched_cache_version + ".bin");
 }
 
 static void write_branched_cache(const BranchedSigCache& c) {
@@ -52,7 +66,7 @@ static void write_branched_cache(const BranchedSigCache& c) {
 	if (!std::filesystem::exists(dir))
 		std::filesystem::create_directory(dir);
 
-	std::ofstream out(branched_cache_file_path(c.dimension, c.max_nodes), std::ios::binary);
+	std::ofstream out(branched_cache_file_path(c.dimension, c.max_nodes, c.planar), std::ios::binary);
 	if (!out) return;
 
 	out.write(reinterpret_cast<const char*>(&cache_magic_number), sizeof(cache_magic_number));
@@ -74,8 +88,8 @@ static void write_branched_cache(const BranchedSigCache& c) {
 	serialize_vector(out, c.coproduct_offsets);
 }
 
-static bool read_branched_cache(uint64_t dimension, uint64_t max_nodes, BranchedSigCache& c) {
-	auto path = branched_cache_file_path(dimension, max_nodes);
+static bool read_branched_cache(uint64_t dimension, uint64_t max_nodes, bool planar, BranchedSigCache& c) {
+	auto path = branched_cache_file_path(dimension, max_nodes, planar);
 	if (!std::filesystem::exists(path)) return false;
 
 	std::ifstream in(path, std::ios::binary);
@@ -130,8 +144,8 @@ static bool read_branched_cache(uint64_t dimension, uint64_t max_nodes, Branched
 // Cache construction
 // ---------------------------------------------------------------------------
 
-void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use_disk) {
-	std::pair<uint64_t, uint64_t> key(dimension, max_nodes);
+void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use_disk, bool planar) {
+	BranchedCacheKey key(dimension, max_nodes, planar);
 	auto& reg = branched_sig_cache_registry();
 
 	{
@@ -143,7 +157,8 @@ void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use
 	// Try loading from disk
 	if (use_disk) {
 		auto cache = std::make_unique<BranchedSigCache>();
-		if (read_branched_cache(dimension, max_nodes, *cache)) {
+		if (read_branched_cache(dimension, max_nodes, planar, *cache)) {
+			cache->planar = planar;
 			std::unique_lock wlock(reg.mu);
 			reg.map.insert_or_assign(key, std::move(cache));
 			return;
@@ -151,7 +166,7 @@ void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use
 	}
 
 	// Compute from scratch using shared builder
-	auto cache = std::make_unique<BranchedSigCache>(build_branched_sig_cache(dimension, max_nodes));
+	auto cache = std::make_unique<BranchedSigCache>(build_branched_sig_cache(dimension, max_nodes, planar));
 
 	if (use_disk) {
 		write_branched_cache(*cache);
@@ -161,8 +176,8 @@ void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use
 	reg.map.insert_or_assign(key, std::move(cache));
 }
 
-const BranchedSigCache& get_branched_sig_cache(uint64_t dimension, uint64_t max_nodes) {
-	std::pair<uint64_t, uint64_t> key(dimension, max_nodes);
+const BranchedSigCache& get_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool planar) {
+	BranchedCacheKey key(dimension, max_nodes, planar);
 	auto& reg = branched_sig_cache_registry();
 	std::shared_lock rlock(reg.mu);
 	auto it = reg.map.find(key);
@@ -177,4 +192,3 @@ void clear_branched_sig_cache() {
 	std::unique_lock wlock(reg.mu);
 	reg.map.clear();
 }
-

--- a/siglib/cpsig/cp_branched_cache.h
+++ b/siglib/cpsig/cp_branched_cache.h
@@ -18,6 +18,6 @@
 #include "../shared/branched_cache.h"
 #include "words.h"  // for PairHash
 
-void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use_disk = false);
-const BranchedSigCache& get_branched_sig_cache(uint64_t dimension, uint64_t max_nodes);
+void prepare_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool use_disk = false, bool planar = false);
+const BranchedSigCache& get_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool planar = false);
 void clear_branched_sig_cache();

--- a/siglib/cpsig/cp_branched_signature.cpp
+++ b/siglib/cpsig/cp_branched_signature.cpp
@@ -16,44 +16,97 @@
 #include "cppch.h"
 #include "cpsig.h"
 #include "cp_branched_signature.h"
+#include "cp_branched_cache.h"
 #include "macros.h"
 
 extern "C" {
 
-	CPSIG_API int prepare_branched_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk) noexcept {
-		SAFE_CALL(prepare_branched_sig_cache(dimension, max_nodes, use_disk));
+	CPSIG_API int prepare_branched_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk, bool planar) noexcept {
+		SAFE_CALL(prepare_branched_sig_cache(dimension, max_nodes, use_disk, planar));
 	}
 
-	CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time) noexcept {
-		SAFE_CALL(branched_signature_<float>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time));
+	CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time, bool planar) noexcept {
+		SAFE_CALL(branched_signature_<float>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar));
 	}
 
-	CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time) noexcept {
-		SAFE_CALL(branched_signature_<double>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time));
+	CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time, bool planar) noexcept {
+		SAFE_CALL(branched_signature_<double>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar));
 	}
 
-	CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
-		SAFE_CALL(branched_sig_combine_<float>(bsig1, bsig2, out, batch_size, dimension, max_nodes, n_jobs));
+	CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar) noexcept {
+		SAFE_CALL(branched_sig_combine_<float>(bsig1, bsig2, out, batch_size, dimension, max_nodes, n_jobs, planar));
 	}
 
-	CPSIG_API int branched_sig_combine_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
-		SAFE_CALL(branched_sig_combine_<double>(bsig1, bsig2, out, batch_size, dimension, max_nodes, n_jobs));
+	CPSIG_API int branched_sig_combine_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar) noexcept {
+		SAFE_CALL(branched_sig_combine_<double>(bsig1, bsig2, out, batch_size, dimension, max_nodes, n_jobs, planar));
 	}
 
-	CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
-		SAFE_CALL(branched_sig_combine_backprop_<float>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, n_jobs));
+	CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar) noexcept {
+		SAFE_CALL(branched_sig_combine_backprop_<float>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, n_jobs, planar));
 	}
 
-	CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
-		SAFE_CALL(branched_sig_combine_backprop_<double>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, n_jobs));
+	CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar) noexcept {
+		SAFE_CALL(branched_sig_combine_backprop_<double>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, n_jobs, planar));
 	}
 
-	CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time) noexcept {
-		SAFE_CALL(branched_sig_backprop_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time));
+	CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time, bool planar) noexcept {
+		SAFE_CALL(branched_sig_backprop_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar));
 	}
 
-	CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time) noexcept {
-		SAFE_CALL(branched_sig_backprop_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time));
+	CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time, bool planar) noexcept {
+		SAFE_CALL(branched_sig_backprop_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar));
+	}
+
+	// Returns the cache arrays' sizes so callers can allocate before calling
+	// get_branched_cache_data. Returns 0 on success, 1 on error.
+	CPSIG_API int get_branched_cache_sizes(
+		uint64_t dimension, uint64_t max_nodes, bool planar,
+		uint64_t* total_length,
+		uint64_t* num_trees,
+		int* out_max_nodes,
+		uint64_t* order_index_len,
+		uint64_t* labels_data_len,
+		uint64_t* labels_offsets_len,
+		uint64_t* coprod_data_len,
+		uint64_t* coprod_offsets_len
+	) noexcept {
+		try {
+			const auto& c = get_branched_sig_cache(dimension, max_nodes, planar);
+			*total_length = c.total_length;
+			*num_trees = c.total_length - 1;
+			*out_max_nodes = static_cast<int>(c.max_nodes);
+			*order_index_len = c.order_index.size();
+			*labels_data_len = c.node_labels_data.size();
+			*labels_offsets_len = c.node_labels_offsets.size();
+			*coprod_data_len = c.coproduct_data.size();
+			*coprod_offsets_len = c.coproduct_offsets.size();
+			return 0;
+		}
+		catch (...) { return 1; }
+	}
+
+	// Copies cache arrays into caller-provided buffers.
+	// Caller must allocate buffers of the sizes returned by get_branched_cache_sizes.
+	CPSIG_API int get_branched_cache_data(
+		uint64_t dimension, uint64_t max_nodes, bool planar,
+		double* inv_tree_factorial,
+		uint8_t* node_labels_data,
+		uint64_t* node_labels_offsets,
+		uint64_t* coproduct_data,
+		uint64_t* coproduct_offsets,
+		uint64_t* order_index
+	) noexcept {
+		try {
+			const auto& c = get_branched_sig_cache(dimension, max_nodes, planar);
+			memcpy(inv_tree_factorial, c.inv_tree_factorial.data(), c.inv_tree_factorial.size() * sizeof(double));
+			memcpy(node_labels_data, c.node_labels_data.data(), c.node_labels_data.size() * sizeof(uint8_t));
+			memcpy(node_labels_offsets, c.node_labels_offsets.data(), c.node_labels_offsets.size() * sizeof(uint64_t));
+			memcpy(coproduct_data, c.coproduct_data.data(), c.coproduct_data.size() * sizeof(uint64_t));
+			memcpy(coproduct_offsets, c.coproduct_offsets.data(), c.coproduct_offsets.size() * sizeof(uint64_t));
+			memcpy(order_index, c.order_index.data(), c.order_index.size() * sizeof(uint64_t));
+			return 0;
+		}
+		catch (...) { return 1; }
 	}
 
 }

--- a/siglib/cpsig/cp_branched_signature.h
+++ b/siglib/cpsig/cp_branched_signature.h
@@ -132,10 +132,11 @@ void branched_signature_(
 	int n_jobs,
 	bool time_aug = false,
 	bool lead_lag = false,
-	T end_time = static_cast<T>(1.)
+	T end_time = static_cast<T>(1.),
+	bool planar = false
 ) {
 	uint64_t aug_dim = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
-	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes);
+	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
 	uint64_t flat_path_length = length * dimension;
 
@@ -187,9 +188,10 @@ void branched_sig_combine_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
-	int n_jobs
+	int n_jobs,
+	bool planar = false
 ) {
-	const auto& cache = get_branched_sig_cache(dimension, max_nodes);
+	const auto& cache = get_branched_sig_cache(dimension, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
 
 	auto thread_func = [&](const T* sig1_ptr, const T* sig2_ptr, T* out_ptr) {
@@ -220,9 +222,10 @@ void branched_sig_combine_backprop_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
-	int n_jobs
+	int n_jobs,
+	bool planar = false
 ) {
-	const auto& cache = get_branched_sig_cache(dimension, max_nodes);
+	const auto& cache = get_branched_sig_cache(dimension, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
 
 	auto work = [&](uint64_t b) {
@@ -493,10 +496,11 @@ void branched_sig_backprop_(
 	int n_jobs,
 	bool time_aug = false,
 	bool lead_lag = false,
-	T end_time = static_cast<T>(1.)
+	T end_time = static_cast<T>(1.),
+	bool planar = false
 ) {
 	uint64_t aug_dim = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
-	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes);
+	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
 	uint64_t flat_path_length = length * dimension;
 

--- a/siglib/cpsig/cp_utils.cpp
+++ b/siglib/cpsig/cp_utils.cpp
@@ -136,14 +136,16 @@ extern "C" CPSIG_API uint64_t log_sig_length(uint64_t dimension, uint64_t degree
     return result;
 }
 
-uint64_t branched_sig_length_(uint64_t dimension, uint64_t max_nodes) {
+uint64_t branched_sig_length_(uint64_t dimension, uint64_t max_nodes, bool planar) {
+    if (planar)
+        return compute_planar_branched_sig_length(dimension, max_nodes);
     return compute_branched_sig_length(dimension, max_nodes);
 }
 
 extern "C" {
-    CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes) noexcept {
+    CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
         try {
-            return branched_sig_length_(dimension, max_nodes);
+            return branched_sig_length_(dimension, max_nodes, planar);
         }
         catch (...) {
             return 0;

--- a/siglib/cpsig/cp_utils.h
+++ b/siglib/cpsig/cp_utils.h
@@ -24,4 +24,4 @@ uint64_t power(uint64_t base, uint64_t exp) noexcept;
 void populate_level_index(uint64_t* level_index, uint64_t dimension, uint64_t degree);
 
 // Length of a branched signature vector (1 + number of trees up to max_nodes).
-uint64_t branched_sig_length_(uint64_t dimension, uint64_t max_nodes);
+uint64_t branched_sig_length_(uint64_t dimension, uint64_t max_nodes, bool planar = false);

--- a/siglib/cpsig/cpsig.h
+++ b/siglib/cpsig/cpsig.h
@@ -493,20 +493,23 @@ extern "C" {
 	* @{
 	*/
 
-	[[nodiscard]] CPSIG_API int prepare_branched_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk = false) noexcept;
-	CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes) noexcept;
+	[[nodiscard]] CPSIG_API int prepare_branched_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk = false, bool planar = false) noexcept;
+	CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
 
-	[[nodiscard]] CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f) noexcept;
-	[[nodiscard]] CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1.) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false) noexcept;
 
-	[[nodiscard]] CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
-	[[nodiscard]] CPSIG_API int branched_sig_combine_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_combine_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false) noexcept;
 
-	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
-	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
+	[[nodiscard]] CPSIG_API int get_branched_cache_sizes(uint64_t dimension, uint64_t max_nodes, bool planar, uint64_t* total_length, uint64_t* num_trees, int* out_max_nodes, uint64_t* order_index_len, uint64_t* labels_data_len, uint64_t* labels_offsets_len, uint64_t* coprod_data_len, uint64_t* coprod_offsets_len) noexcept;
+	[[nodiscard]] CPSIG_API int get_branched_cache_data(uint64_t dimension, uint64_t max_nodes, bool planar, double* inv_tree_factorial, uint8_t* node_labels_data, uint64_t* node_labels_offsets, uint64_t* coproduct_data, uint64_t* coproduct_offsets, uint64_t* order_index) noexcept;
 
-	[[nodiscard]] CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f) noexcept;
-	[[nodiscard]] CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1.) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false) noexcept;
+
+	[[nodiscard]] CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false) noexcept;
 	/** @} */
 }
 

--- a/siglib/cusig/cu_branched_signature.cu
+++ b/siglib/cusig/cu_branched_signature.cu
@@ -62,10 +62,23 @@ struct BranchedSigCacheGPU {
 // Reuse the hash from cu_log_sig_cache.h
 #include "cu_log_sig_cache.h"
 
+using CuBranchedCacheKey = std::tuple<uint64_t, uint64_t, bool>;
+
+struct CuBranchedCacheKeyHash {
+	std::size_t operator()(const CuBranchedCacheKey& k) const noexcept {
+		std::size_t h1 = std::hash<uint64_t>{}(std::get<0>(k));
+		std::size_t h2 = std::hash<uint64_t>{}(std::get<1>(k));
+		std::size_t h3 = std::hash<bool>{}(std::get<2>(k));
+		h1 ^= (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+		h1 ^= (h3 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+		return h1;
+	}
+};
+
 static std::unordered_map<
-	std::pair<uint64_t, uint64_t>,
+	CuBranchedCacheKey,
 	std::unique_ptr<BranchedSigCacheGPU>,
-	CuPairHash
+	CuBranchedCacheKeyHash
 > s_gpu_cache_map;
 static std::mutex s_gpu_cache_map_mu;
 
@@ -80,8 +93,8 @@ static void upload(T*& d_ptr, const T* h_data, size_t count) {
 	CUDA_CHECK(cudaMemcpy(d_ptr, h_data, count * sizeof(T), cudaMemcpyHostToDevice));
 }
 
-static const BranchedSigCacheGPU& get_or_upload_gpu_cache(uint64_t dimension, uint64_t max_nodes) {
-	auto key = std::make_pair(dimension, max_nodes);
+static const BranchedSigCacheGPU& get_or_upload_gpu_cache(uint64_t dimension, uint64_t max_nodes, bool planar = false) {
+	CuBranchedCacheKey key(dimension, max_nodes, planar);
 	{
 		std::lock_guard<std::mutex> lock(s_gpu_cache_map_mu);
 		auto it = s_gpu_cache_map.find(key);
@@ -90,7 +103,7 @@ static const BranchedSigCacheGPU& get_or_upload_gpu_cache(uint64_t dimension, ui
 	}
 
 	// Build cache on CPU using shared header (no cpsig.dll dependency)
-	BranchedSigCache c = build_branched_sig_cache(dimension, max_nodes);
+	BranchedSigCache c = build_branched_sig_cache(dimension, max_nodes, planar);
 
 	uint64_t num_trees = c.total_length - 1;
 
@@ -586,9 +599,10 @@ void branched_sig_combine_backprop_ker(
 template<typename T>
 void branched_sig_combine_cuda_(
 	const T* bsig1, const T* bsig2, T* out,
-	uint64_t batch_size, uint64_t dimension, uint64_t max_nodes
+	uint64_t batch_size, uint64_t dimension, uint64_t max_nodes,
+	bool planar = false
 ) {
-	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes);
+	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 	unsigned int block = static_cast<unsigned int>((gc.num_trees + 31u) & ~31u);
 	if (block < 32) block = 32;
 	if (block > 1024) throw std::invalid_argument("CUDA branched sig combine: num_trees > 1024 not supported");
@@ -609,9 +623,10 @@ void branched_sig_combine_cuda_(
 template<typename T>
 void branched_sig_combine_backprop_cuda_(
 	const T* bsig1, const T* bsig2, const T* derivs, T* out1, T* out2,
-	uint64_t batch_size, uint64_t dimension, uint64_t max_nodes
+	uint64_t batch_size, uint64_t dimension, uint64_t max_nodes,
+	bool planar = false
 ) {
-	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes);
+	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 	unsigned int block = static_cast<unsigned int>((gc.num_trees + 31u) & ~31u);
 	if (block < 32) block = 32;
 	if (block > 1024) throw std::invalid_argument("CUDA branched sig combine backprop: num_trees > 1024 not supported");
@@ -640,9 +655,10 @@ void branched_sig_cuda_core_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t length,
-	uint64_t max_nodes
+	uint64_t max_nodes,
+	bool planar = false
 ) {
-	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes);
+	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 
 	// Single-point paths have no increments => identity branched sig
 	if (length <= 1) {
@@ -721,7 +737,8 @@ void branched_sig_cuda_(
 	uint64_t max_nodes,
 	bool time_aug,
 	bool lead_lag,
-	T end_time
+	T end_time,
+	bool planar = false
 ) {
 	const uint64_t t_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t t_length = lead_lag ? 2 * length - 1 : length;
@@ -733,10 +750,10 @@ void branched_sig_cuda_(
 		transform_path_<T>(path, d_transformed.get(), batch_size, dimension, length, time_aug, lead_lag, end_time);
 		cudaDeviceSynchronize();
 
-		branched_sig_cuda_core_<T>(d_transformed.get(), out, batch_size, t_dimension, t_length, max_nodes);
+		branched_sig_cuda_core_<T>(d_transformed.get(), out, batch_size, t_dimension, t_length, max_nodes, planar);
 	}
 	else {
-		branched_sig_cuda_core_<T>(path, out, batch_size, dimension, length, max_nodes);
+		branched_sig_cuda_core_<T>(path, out, batch_size, dimension, length, max_nodes, planar);
 	}
 }
 
@@ -753,9 +770,10 @@ void branched_sig_backprop_cuda_core_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t length,
-	uint64_t max_nodes
+	uint64_t max_nodes,
+	bool planar = false
 ) {
-	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes);
+	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 
 	// Single-point paths have no increments => zero path gradients
 	if (length <= 1) {
@@ -825,7 +843,8 @@ void branched_sig_backprop_cuda_(
 	uint64_t max_nodes,
 	bool time_aug,
 	bool lead_lag,
-	T end_time
+	T end_time,
+	bool planar = false
 ) {
 	const uint64_t t_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t t_length = lead_lag ? 2 * length - 1 : length;
@@ -841,7 +860,7 @@ void branched_sig_backprop_cuda_(
 
 			cudaMalloc(&d_transformed_derivs, t_path_size * sizeof(T));
 			branched_sig_backprop_cuda_core_<T>(d_transformed, d_transformed_derivs, bsig_derivs, bsig,
-				batch_size, t_dimension, t_length, max_nodes);
+				batch_size, t_dimension, t_length, max_nodes, planar);
 
 			cudaFree(d_transformed);
 			d_transformed = nullptr;
@@ -856,7 +875,7 @@ void branched_sig_backprop_cuda_(
 	}
 	else {
 		branched_sig_backprop_cuda_core_<T>(path, out, bsig_derivs, bsig,
-			batch_size, dimension, length, max_nodes);
+			batch_size, dimension, length, max_nodes, planar);
 	}
 }
 
@@ -867,35 +886,35 @@ void branched_sig_backprop_cuda_(
 extern "C" {
 
 
-	CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_cuda_<float>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time));
+	CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_cuda_<float>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar));
 	}
 
-	CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_cuda_<double>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time));
+	CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_cuda_<double>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar));
 	}
 
-	CUSIG_API int branched_sig_combine_cuda_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_combine_cuda_<float>(bsig1, bsig2, out, batch_size, dimension, max_nodes));
+	CUSIG_API int branched_sig_combine_cuda_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_combine_cuda_<float>(bsig1, bsig2, out, batch_size, dimension, max_nodes, planar));
 	}
-	CUSIG_API int branched_sig_combine_cuda_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_combine_cuda_<double>(bsig1, bsig2, out, batch_size, dimension, max_nodes));
-	}
-
-	CUSIG_API int branched_sig_combine_backprop_cuda_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_combine_backprop_cuda_<float>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes));
-	}
-	CUSIG_API int branched_sig_combine_backprop_cuda_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_combine_backprop_cuda_<double>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes));
+	CUSIG_API int branched_sig_combine_cuda_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_combine_cuda_<double>(bsig1, bsig2, out, batch_size, dimension, max_nodes, planar));
 	}
 
-
-	CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time));
+	CUSIG_API int branched_sig_combine_backprop_cuda_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_combine_backprop_cuda_<float>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, planar));
+	}
+	CUSIG_API int branched_sig_combine_backprop_cuda_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_combine_backprop_cuda_<double>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, planar));
 	}
 
-	CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time));
+
+	CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar));
+	}
+
+	CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time, bool planar) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar));
 	}
 
 }

--- a/siglib/cusig/cusig.h
+++ b/siglib/cusig/cusig.h
@@ -420,17 +420,17 @@ extern "C" {
 	* @{
 	*/
 
-	[[nodiscard]] CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1.) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false) noexcept;
 
-	[[nodiscard]] CUSIG_API int branched_sig_combine_cuda_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_combine_cuda_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_combine_cuda_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_combine_cuda_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
 
-	[[nodiscard]] CUSIG_API int branched_sig_combine_backprop_cuda_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_combine_backprop_cuda_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_combine_backprop_cuda_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_combine_backprop_cuda_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
 
-	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1.) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false) noexcept;
 	/** @} */
 
 	// linear_sig CUDA

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -1828,7 +1828,7 @@ namespace {
 
 template <typename T>
 ffi::Error BranchedSigCpuImpl(
-    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs,
+    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer& path, ffi::Result<ffi::AnyBuffer>& out
 ) {
     PathSpec spec;
@@ -1842,7 +1842,7 @@ ffi::Error BranchedSigCpuImpl(
         spec.is_batch ? spec.batch_size : 1,
         spec.dimension, spec.length,
         static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs),
-        time_aug, lead_lag, static_cast<T>(end_time)
+        time_aug, lead_lag, static_cast<T>(end_time), planar
     );
     if (err_code != 0) return NativeCallError("branched_sig", err_code);
     return ffi::Error::Success();
@@ -1850,7 +1850,7 @@ ffi::Error BranchedSigCpuImpl(
 
 template <typename T>
 ffi::Error BranchedSigBackpropCpuImpl(
-    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs,
+    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer& path, ffi::AnyBuffer& bsig, ffi::AnyBuffer& cotangent,
     ffi::Result<ffi::AnyBuffer>& out
 ) {
@@ -1867,37 +1867,37 @@ ffi::Error BranchedSigBackpropCpuImpl(
         spec.is_batch ? spec.batch_size : 1,
         spec.dimension, spec.length,
         static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs),
-        time_aug, lead_lag, static_cast<T>(end_time)
+        time_aug, lead_lag, static_cast<T>(end_time), planar
     );
     if (err_code != 0) return NativeCallError("branched_sig_backprop", err_code);
     return ffi::Error::Success();
 }
 
 ffi::Error BranchedSigCpu(
-    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs,
+    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer path, ffi::Result<ffi::AnyBuffer> out
 ) {
     if (auto msg = ValidateFloatBuffer("path", path); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
-        return BranchedSigCpuImpl<T>(max_nodes, time_aug, lead_lag, end_time, n_jobs, path, out);
+        return BranchedSigCpuImpl<T>(max_nodes, time_aug, lead_lag, end_time, n_jobs, planar, path, out);
     });
 }
 
 ffi::Error BranchedSigBackpropCpu(
-    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs,
+    std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer path, ffi::AnyBuffer bsig, ffi::AnyBuffer cotangent,
     ffi::Result<ffi::AnyBuffer> out
 ) {
     if (auto msg = ValidateFloatBuffer("path", path); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
-        return BranchedSigBackpropCpuImpl<T>(max_nodes, time_aug, lead_lag, end_time, n_jobs, path, bsig, cotangent, out);
+        return BranchedSigBackpropCpuImpl<T>(max_nodes, time_aug, lead_lag, end_time, n_jobs, planar, path, bsig, cotangent, out);
     });
 }
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 template <typename T>
 ffi::Error BranchedSigCudaImpl(
-    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time,
+    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t /*n_jobs*/, bool planar,
     ffi::AnyBuffer& path, ffi::Result<ffi::AnyBuffer>& out
 ) {
     PathSpec spec;
@@ -1908,14 +1908,14 @@ ffi::Error BranchedSigCudaImpl(
     int err_code = CudaFns<T>::bsig(BufferData<T>(path), BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
         spec.dimension, spec.length,
-        static_cast<std::uint64_t>(max_nodes), time_aug, lead_lag, static_cast<T>(end_time));
+        static_cast<std::uint64_t>(max_nodes), time_aug, lead_lag, static_cast<T>(end_time), planar);
     if (err_code != 0) return NativeCallError("branched_sig_cuda", err_code);
     return ffi::Error::Success();
 }
 
 template <typename T>
 ffi::Error BranchedSigBackpropCudaImpl(
-    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time,
+    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t /*n_jobs*/, bool planar,
     ffi::AnyBuffer& path, ffi::AnyBuffer& bsig, ffi::AnyBuffer& cotangent,
     ffi::Result<ffi::AnyBuffer>& out
 ) {
@@ -1927,29 +1927,29 @@ ffi::Error BranchedSigBackpropCudaImpl(
     int err_code = CudaFns<T>::bsig_backprop(BufferData<T>(path), BufferData<T>(out), BufferData<T>(cotangent), BufferData<T>(bsig),
         spec.is_batch ? spec.batch_size : 1,
         spec.dimension, spec.length,
-        static_cast<std::uint64_t>(max_nodes), time_aug, lead_lag, static_cast<T>(end_time));
+        static_cast<std::uint64_t>(max_nodes), time_aug, lead_lag, static_cast<T>(end_time), planar);
     if (err_code != 0) return NativeCallError("branched_sig_backprop_cuda", err_code);
     return ffi::Error::Success();
 }
 
 ffi::Error BranchedSigCuda(
-    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time,
+    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer path, ffi::Result<ffi::AnyBuffer> out
 ) {
     if (auto msg = ValidateFloatBuffer("path", path); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
-        return BranchedSigCudaImpl<T>(stream, max_nodes, time_aug, lead_lag, end_time, path, out);
+        return BranchedSigCudaImpl<T>(stream, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar, path, out);
     });
 }
 
 ffi::Error BranchedSigBackpropCuda(
-    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time,
+    cudaStream_t stream, std::int64_t max_nodes, bool time_aug, bool lead_lag, double end_time, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer path, ffi::AnyBuffer bsig, ffi::AnyBuffer cotangent,
     ffi::Result<ffi::AnyBuffer> out
 ) {
     if (auto msg = ValidateFloatBuffer("path", path); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
-        return BranchedSigBackpropCudaImpl<T>(stream, max_nodes, time_aug, lead_lag, end_time, path, bsig, cotangent, out);
+        return BranchedSigBackpropCudaImpl<T>(stream, max_nodes, time_aug, lead_lag, end_time, n_jobs, planar, path, bsig, cotangent, out);
     });
 }
 #endif
@@ -1960,7 +1960,7 @@ ffi::Error BranchedSigBackpropCuda(
 
 template <typename T>
 ffi::Error BranchedSigCombineCpuImpl(
-    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer& bsig1, ffi::AnyBuffer& bsig2, ffi::Result<ffi::AnyBuffer>& out
 ) {
     SigSpec spec;
@@ -1968,14 +1968,14 @@ ffi::Error BranchedSigCombineCpuImpl(
 
     int err_code = CpuFns<T>::bsig_combine(BufferData<T>(bsig1), BufferData<T>(bsig2), BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
-        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs));
+        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs), planar);
     if (err_code != 0) return NativeCallError("branched_sig_combine", err_code);
     return ffi::Error::Success();
 }
 
 template <typename T>
 ffi::Error BranchedSigCombineBackpropCpuImpl(
-    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer& cotangent, ffi::AnyBuffer& bsig1, ffi::AnyBuffer& bsig2,
     ffi::Result<ffi::AnyBuffer>& grad1, ffi::Result<ffi::AnyBuffer>& grad2
 ) {
@@ -1985,31 +1985,31 @@ ffi::Error BranchedSigCombineBackpropCpuImpl(
     int err_code = CpuFns<T>::bsig_combine_backprop(BufferData<T>(bsig1), BufferData<T>(bsig2), BufferData<T>(cotangent),
         BufferData<T>(grad1), BufferData<T>(grad2),
         spec.is_batch ? spec.batch_size : 1,
-        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs));
+        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs), planar);
     if (err_code != 0) return NativeCallError("branched_sig_combine_backprop", err_code);
     return ffi::Error::Success();
 }
 
-ffi::Error BranchedSigCombineCpu(std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+ffi::Error BranchedSigCombineCpu(std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig1, ffi::AnyBuffer bsig2, ffi::Result<ffi::AnyBuffer> out) {
     if (auto msg = ValidateSameFloatDtype("bsig1", bsig1, "bsig2", bsig2); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig1), [&]<typename T>() -> ffi::Error {
-        return BranchedSigCombineCpuImpl<T>(dimension, max_nodes, n_jobs, bsig1, bsig2, out);
+        return BranchedSigCombineCpuImpl<T>(dimension, max_nodes, n_jobs, planar, bsig1, bsig2, out);
     });
 }
 
-ffi::Error BranchedSigCombineBackpropCpu(std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+ffi::Error BranchedSigCombineBackpropCpu(std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer cotangent, ffi::AnyBuffer bsig1, ffi::AnyBuffer bsig2,
     ffi::Result<ffi::AnyBuffer> grad1, ffi::Result<ffi::AnyBuffer> grad2) {
     if (auto msg = ValidateSameFloatDtype("bsig1", bsig1, "bsig2", bsig2); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig1), [&]<typename T>() -> ffi::Error {
-        return BranchedSigCombineBackpropCpuImpl<T>(dimension, max_nodes, n_jobs, cotangent, bsig1, bsig2, grad1, grad2);
+        return BranchedSigCombineBackpropCpuImpl<T>(dimension, max_nodes, n_jobs, planar, cotangent, bsig1, bsig2, grad1, grad2);
     });
 }
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 template <typename T>
-ffi::Error BranchedSigCombineCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+ffi::Error BranchedSigCombineCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t /*n_jobs*/, bool planar,
     ffi::AnyBuffer& bsig1, ffi::AnyBuffer& bsig2, ffi::Result<ffi::AnyBuffer>& out) {
     SigSpec spec;
     if (auto msg = GetSigSpec(bsig1, spec); !msg.empty()) return InvalidArgument(msg);
@@ -2017,13 +2017,13 @@ ffi::Error BranchedSigCombineCudaImpl(cudaStream_t stream, std::int64_t dimensio
     if (sync != cudaSuccess) return InternalError(cudaGetErrorString(sync));
     int err_code = CudaFns<T>::bsig_combine(BufferData<T>(bsig1), BufferData<T>(bsig2), BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
-        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes));
+        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), planar);
     if (err_code != 0) return NativeCallError("branched_sig_combine_cuda", err_code);
     return ffi::Error::Success();
 }
 
 template <typename T>
-ffi::Error BranchedSigCombineBackpropCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+ffi::Error BranchedSigCombineBackpropCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t /*n_jobs*/, bool planar,
     ffi::AnyBuffer& cotangent, ffi::AnyBuffer& bsig1, ffi::AnyBuffer& bsig2,
     ffi::Result<ffi::AnyBuffer>& grad1, ffi::Result<ffi::AnyBuffer>& grad2) {
     SigSpec spec;
@@ -2033,25 +2033,25 @@ ffi::Error BranchedSigCombineBackpropCudaImpl(cudaStream_t stream, std::int64_t 
     int err_code = CudaFns<T>::bsig_combine_backprop(BufferData<T>(bsig1), BufferData<T>(bsig2), BufferData<T>(cotangent),
         BufferData<T>(grad1), BufferData<T>(grad2),
         spec.is_batch ? spec.batch_size : 1,
-        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes));
+        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), planar);
     if (err_code != 0) return NativeCallError("branched_sig_combine_backprop_cuda", err_code);
     return ffi::Error::Success();
 }
 
-ffi::Error BranchedSigCombineCuda(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+ffi::Error BranchedSigCombineCuda(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig1, ffi::AnyBuffer bsig2, ffi::Result<ffi::AnyBuffer> out) {
     if (auto msg = ValidateSameFloatDtype("bsig1", bsig1, "bsig2", bsig2); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig1), [&]<typename T>() -> ffi::Error {
-        return BranchedSigCombineCudaImpl<T>(stream, dimension, max_nodes, bsig1, bsig2, out);
+        return BranchedSigCombineCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, bsig1, bsig2, out);
     });
 }
 
-ffi::Error BranchedSigCombineBackpropCuda(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+ffi::Error BranchedSigCombineBackpropCuda(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer cotangent, ffi::AnyBuffer bsig1, ffi::AnyBuffer bsig2,
     ffi::Result<ffi::AnyBuffer> grad1, ffi::Result<ffi::AnyBuffer> grad2) {
     if (auto msg = ValidateSameFloatDtype("bsig1", bsig1, "bsig2", bsig2); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig1), [&]<typename T>() -> ffi::Error {
-        return BranchedSigCombineBackpropCudaImpl<T>(stream, dimension, max_nodes, cotangent, bsig1, bsig2, grad1, grad2);
+        return BranchedSigCombineBackpropCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, cotangent, bsig1, bsig2, grad1, grad2);
     });
 }
 #endif
@@ -2186,46 +2186,48 @@ ffi::Error LogSigFromPathBackpropCuda(cudaStream_t stream, std::int64_t dimensio
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCpu, BranchedSigCpu,
     ffi::Ffi::Bind().Attr<std::int64_t>("max_nodes")
-        .Attr<bool>("time_aug").Attr<bool>("lead_lag").Attr<double>("end_time").Attr<std::int64_t>("n_jobs")
+        .Attr<bool>("time_aug").Attr<bool>("lead_lag").Attr<double>("end_time").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigBackpropCpu, BranchedSigBackpropCpu,
     ffi::Ffi::Bind().Attr<std::int64_t>("max_nodes")
-        .Attr<bool>("time_aug").Attr<bool>("lead_lag").Attr<double>("end_time").Attr<std::int64_t>("n_jobs")
+        .Attr<bool>("time_aug").Attr<bool>("lead_lag").Attr<double>("end_time").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCuda, BranchedSigCuda,
     ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<std::int64_t>("max_nodes").Attr<bool>("time_aug").Attr<bool>("lead_lag").Attr<double>("end_time")
+        .Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigBackpropCuda, BranchedSigBackpropCuda,
     ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<std::int64_t>("max_nodes").Attr<bool>("time_aug").Attr<bool>("lead_lag").Attr<double>("end_time")
+        .Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 #endif
 
 // branched_sig_combine
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCombineCpu, BranchedSigCombineCpu,
-    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs")
+    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCombineBackpropCpu, BranchedSigCombineBackpropCpu,
-    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs")
+    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>()
         .Ret<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCombineCuda, BranchedSigCombineCuda,
     ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
-        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCombineBackpropCuda, BranchedSigCombineBackpropCuda,
     ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
-        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>()
         .Ret<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 #endif

--- a/siglib/shared/branched_cache.h
+++ b/siglib/shared/branched_cache.h
@@ -23,6 +23,7 @@
 struct BranchedSigCache {
 	uint64_t dimension = 0;
 	uint64_t max_nodes = 0;
+	bool planar = false;
 	uint64_t total_length = 0;  // 1 + num_trees (includes empty tree at index 0)
 
 	// order_index[n] = index in the trees vector where order-n trees start.
@@ -150,14 +151,115 @@ inline void enumerate_admissible_cuts(
 	}
 }
 
+// Enumerate admissible cuts for a planar tree. Same as the non-planar version
+// except the trunk's child ordering is preserved (no sort) to respect planarity.
+inline void enumerate_planar_admissible_cuts(
+	uint64_t tree_idx,
+	const std::vector<DecoratedTreeInfo>& trees,
+	const std::vector<uint64_t>& order_index,
+	const TreeIndexMap& tree_map,
+	const std::vector<std::vector<CutResult>>& memo,
+	std::vector<CutResult>& results
+) {
+	const auto& tree = trees[tree_idx];
+	const auto& children = tree.canonical.child_ids;
+
+	if (children.empty()) return;
+
+	struct ChildOption {
+		const std::vector<uint64_t>* forest_ptr;
+		uint64_t single_forest;
+		int64_t trunk_child;
+		bool is_cut;
+	};
+
+	std::vector<std::vector<ChildOption>> all_child_options;
+	all_child_options.reserve(children.size());
+
+	for (uint64_t child_idx : children) {
+		std::vector<ChildOption> options;
+		options.reserve(2 + memo[child_idx].size());
+		options.push_back({ nullptr, child_idx, -1, true });
+		options.push_back({ nullptr, 0, static_cast<int64_t>(child_idx), false });
+		for (const auto& sub_cut : memo[child_idx]) {
+			options.push_back({ &sub_cut.forest, 0, static_cast<int64_t>(sub_cut.trunk), false });
+		}
+		all_child_options.push_back(std::move(options));
+	}
+
+	uint64_t num_children = children.size();
+	std::vector<uint64_t> indices(num_children, 0);
+
+	std::vector<uint64_t> forest;
+	CanonicalTree trunk_canonical;
+	forest.reserve(num_children);
+	trunk_canonical.child_ids.reserve(num_children);
+
+	while (true) {
+		forest.clear();
+		trunk_canonical.child_ids.clear();
+		bool all_kept_empty = true;
+
+		for (uint64_t c = 0; c < num_children; ++c) {
+			const auto& opt = all_child_options[c][indices[c]];
+			if (opt.is_cut) {
+				forest.push_back(opt.single_forest);
+			} else {
+				if (opt.forest_ptr) {
+					for (uint64_t f : *opt.forest_ptr)
+						forest.push_back(f);
+				}
+				if (opt.trunk_child >= 0)
+					trunk_canonical.child_ids.push_back(static_cast<uint64_t>(opt.trunk_child));
+			}
+			if (indices[c] != 1)
+				all_kept_empty = false;
+		}
+
+		if (!all_kept_empty) {
+			// Planar: do NOT sort trunk_canonical.child_ids (preserve order)
+			trunk_canonical.root_label = tree.canonical.root_label;
+			trunk_canonical.num_nodes = 1;
+			for (uint64_t tc : trunk_canonical.child_ids)
+				trunk_canonical.num_nodes += trees[tc].canonical.num_nodes;
+
+			uint64_t trunk_idx;
+			if (trunk_canonical.num_nodes == 1) {
+				trunk_idx = order_index[1] + trunk_canonical.root_label;
+			}
+			else {
+				auto it = tree_map.find(trunk_canonical);
+				if (it == tree_map.end())
+					throw std::runtime_error("Planar tree not found in enumeration");
+				trunk_idx = it->second;
+			}
+
+			results.push_back(CutResult{ {forest.begin(), forest.end()}, trunk_idx });
+		}
+
+		int64_t pos = static_cast<int64_t>(num_children) - 1;
+		while (pos >= 0) {
+			indices[pos]++;
+			if (indices[pos] < all_child_options[pos].size()) break;
+			indices[pos] = 0;
+			--pos;
+		}
+		if (pos < 0) break;
+	}
+}
+
 // Build a BranchedSigCache from scratch (pure computation, no disk cache or threading).
-inline BranchedSigCache build_branched_sig_cache(uint64_t dimension, uint64_t max_nodes) {
+inline BranchedSigCache build_branched_sig_cache(uint64_t dimension, uint64_t max_nodes, bool planar = false) {
 	BranchedSigCache cache;
 	cache.dimension = dimension;
 	cache.max_nodes = max_nodes;
+	cache.planar = planar;
 
 	std::vector<DecoratedTreeInfo> trees;
-	enumerate_all_decorated_trees(dimension, max_nodes, trees, cache.order_index);
+	if (planar)
+		enumerate_all_planar_decorated_trees(dimension, max_nodes, trees, cache.order_index);
+	else
+		enumerate_all_decorated_trees(dimension, max_nodes, trees, cache.order_index);
 
 	uint64_t num_trees = trees.size();
 	cache.total_length = 1 + num_trees;
@@ -188,7 +290,10 @@ inline BranchedSigCache build_branched_sig_cache(uint64_t dimension, uint64_t ma
 		uint64_t ostart = cache.order_index[order];
 		uint64_t oend = cache.order_index[order + 1];
 		for (uint64_t i = ostart; i < oend; i += dimension) {
-			enumerate_admissible_cuts(i, trees, cache.order_index, tree_map, all_cuts, all_cuts[i]);
+			if (planar)
+				enumerate_planar_admissible_cuts(i, trees, cache.order_index, tree_map, all_cuts, all_cuts[i]);
+			else
+				enumerate_admissible_cuts(i, trees, cache.order_index, tree_map, all_cuts, all_cuts[i]);
 			for (uint64_t L = 1; L < dimension && i + L < oend; ++L) {
 				auto& dest = all_cuts[i + L];
 				dest.resize(all_cuts[i].size());

--- a/siglib/shared/branched_trees.h
+++ b/siglib/shared/branched_trees.h
@@ -168,3 +168,101 @@ inline uint64_t compute_branched_sig_length(uint64_t dimension, uint64_t max_nod
 	enumerate_all_decorated_trees(dimension, max_nodes, trees, order_index);
 	return 1 + trees.size();
 }
+
+
+// =========================================================================
+// Planar (ordered) tree enumeration
+// =========================================================================
+
+// Enumerate ordered sequences of tree indices whose total node count equals target_nodes.
+// Unlike enumerate_child_multisets, children can appear in any order (no min_idx constraint).
+// Trees are ordered by num_nodes (non-decreasing) so `continue`/`break` logic is safe.
+inline void enumerate_child_sequences(
+	uint64_t target_nodes,
+	const std::vector<DecoratedTreeInfo>& all_trees,
+	uint64_t total_count,
+	std::vector<uint64_t>& current,
+	std::vector<std::vector<uint64_t>>& results
+) {
+	if (target_nodes == 0) {
+		results.push_back(current);
+		return;
+	}
+
+	for (uint64_t idx = 0; idx < total_count; ++idx) {
+		uint64_t n = all_trees[idx].canonical.num_nodes;
+		if (n > target_nodes) break;
+		current.push_back(idx);
+		enumerate_child_sequences(target_nodes - n, all_trees, total_count, current, results);
+		current.pop_back();
+	}
+}
+
+inline void enumerate_all_planar_decorated_trees(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	std::vector<DecoratedTreeInfo>& trees,
+	std::vector<uint64_t>& order_index
+) {
+	if (dimension > 255)
+		throw std::invalid_argument("branched signature dimension must be <= 255");
+
+	trees.clear();
+	order_index.clear();
+	order_index.resize(max_nodes + 2, 0);
+
+	for (uint64_t order = 1; order <= max_nodes; ++order) {
+		order_index[order] = trees.size();
+
+		if (order == 1) {
+			for (uint8_t label = 0; label < static_cast<uint8_t>(dimension); ++label) {
+				DecoratedTreeInfo info;
+				info.canonical.num_nodes = 1;
+				info.canonical.root_label = label;
+				info.tree_factorial = 1.0;
+				info.node_labels.push_back(label);
+				trees.push_back(std::move(info));
+			}
+		}
+		else {
+			uint64_t current_count = trees.size();
+
+			std::vector<std::vector<uint64_t>> child_sequences;
+			std::vector<uint64_t> current_seq;
+			enumerate_child_sequences(order - 1, trees, current_count,
+				current_seq, child_sequences);
+
+			for (const auto& children : child_sequences) {
+				if (children.empty()) continue;
+
+				// Fully construct label=0, derive label=1..d-1 by copy+patch
+				uint64_t base_idx = trees.size();
+				for (uint8_t label = 0; label < static_cast<uint8_t>(dimension); ++label) {
+					DecoratedTreeInfo info;
+					if (label == 0) {
+						info.canonical.num_nodes = order;
+						info.canonical.root_label = 0;
+						info.canonical.child_ids = children;  // ordered, NOT sorted
+						info.tree_factorial = compute_tree_factorial(info.canonical, trees);
+						collect_labels(info.canonical, trees, info.node_labels);
+					} else {
+						info = trees[base_idx];  // copy from label=0
+						info.canonical.root_label = label;
+						info.node_labels[0] = label;
+					}
+
+					trees.push_back(std::move(info));
+				}
+			}
+		}
+	}
+
+	order_index[max_nodes + 1] = trees.size();
+}
+
+inline uint64_t compute_planar_branched_sig_length(uint64_t dimension, uint64_t max_nodes) {
+	std::vector<DecoratedTreeInfo> trees;
+	std::vector<uint64_t> order_index;
+	enumerate_all_planar_decorated_trees(dimension, max_nodes, trees, order_index);
+	return 1 + trees.size();
+}

--- a/siglib/test_app/dll_funcs.h
+++ b/siglib/test_app/dll_funcs.h
@@ -152,9 +152,9 @@ extern log_sig_combine_cuda_d_fn log_sig_combine_cuda_d;
 extern log_sig_combine_backprop_d_fn log_sig_combine_backprop_d;
 extern log_sig_combine_backprop_cuda_d_fn log_sig_combine_backprop_cuda_d;
 
-using prepare_branched_sig_fn = int(CDECL_*)(uint64_t, uint64_t, bool);
-using branched_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t);
-using branched_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int, bool, bool, double);
+using prepare_branched_sig_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
+using branched_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t, bool);
+using branched_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int, bool, bool, double, bool);
 
 extern prepare_branched_sig_fn prepare_branched_sig;
 extern branched_sig_length_fn branched_sig_length;

--- a/siglib/test_app/tests.cpp
+++ b/siglib/test_app/tests.cpp
@@ -815,13 +815,13 @@ void example_batch_branched_sig_d(
 ) {
     print_header("Batch Branched Signature Double");
 
-    prepare_branched_sig(dimension, max_nodes, false);
-    uint64_t out_size = branched_sig_length(dimension, max_nodes) * batch_size;
+    prepare_branched_sig(dimension, max_nodes, false, false);
+    uint64_t out_size = branched_sig_length(dimension, max_nodes, false) * batch_size;
 
     std::vector<double> path = test_data<double>(batch_size * dimension * length);
     std::vector<double> out(out_size, 0.);
 
-    time_function(num_runs, branched_sig_d, path.data(), out.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1.);
+    time_function(num_runs, branched_sig_d, path.data(), out.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1., false);
 
     std::cout << "done\n";
 }

--- a/tests/test_branched_sig.py
+++ b/tests/test_branched_sig.py
@@ -21,7 +21,6 @@ import itertools
 import kauri
 import kauri.bck
 import kauri.mkw
-import kauri.mkw
 
 import pysiglib
 from conftest import DEVICES, check_close, skip_no_cuda
@@ -242,27 +241,6 @@ def test_branched_sig_vs_kauri(d, N):
     np.testing.assert_allclose(bsig[1:], ref_reordered, atol=1e-10)
 
 
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_branched_sig_concatenation(d, N):
-    """Chen's identity: bsig(X*Y) == branched_sig_combine(bsig(X), bsig(Y))."""
-    pysiglib.prepare_branched_sig(d, N)
-    np.random.seed(99)
-    L1, L2 = 5, 6
-    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
-    # path2 must start where path1 ends
-    path2_increments = np.random.randn(L2 - 1, d) * 0.1
-    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_increments, axis=0)])
-
-    bsig1 = pysiglib.branched_sig(path1, N)
-    bsig2 = pysiglib.branched_sig(path2, N)
-    combined = pysiglib.branched_sig_combine(bsig1, bsig2, d, N)
-
-    full_path = np.vstack([path1, path2[1:]])
-    bsig_full = pysiglib.branched_sig(full_path, N)
-
-    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
-
-
 @pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
 def test_branched_sig_batch(d, N):
     pysiglib.prepare_branched_sig(d, N)
@@ -380,27 +358,6 @@ def test_branched_sig_time_aug_batch(d, N):
     for i in range(B):
         single = pysiglib.branched_sig(paths[i], N, time_aug=True)
         np.testing.assert_allclose(batch_result[i], single, atol=1e-12)
-
-
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_branched_sig_lead_lag_concatenation(d, N):
-    """Chen's identity should hold with lead_lag enabled."""
-    aug_dim = 2 * d
-    pysiglib.prepare_branched_sig(aug_dim, N)
-    np.random.seed(204)
-    L1, L2 = 5, 6
-    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
-    path2_inc = np.random.randn(L2 - 1, d) * 0.1
-    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_inc, axis=0)])
-
-    bsig1 = pysiglib.branched_sig(path1, N, lead_lag=True)
-    bsig2 = pysiglib.branched_sig(path2, N, lead_lag=True)
-    combined = pysiglib.branched_sig_combine(bsig1, bsig2, aug_dim, N)
-
-    full_path = np.vstack([path1, path2[1:]])
-    bsig_full = pysiglib.branched_sig(full_path, N, lead_lag=True)
-
-    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -571,6 +528,26 @@ def test_branched_sig_backprop_torch_api(d, N):
 
 
 @pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_backprop_torch_api(d, N):
+    """torch_api planar branched_sig backward produces correct gradients."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(4021)
+    path = torch.tensor(np.cumsum(np.random.randn(5, d) * 0.1, axis=0),
+                        dtype=torch.float64, requires_grad=True)
+
+    bsig = pysiglib.torch_api.branched_sig(path, N, planar=True)
+    loss = bsig.sum()
+    loss.backward()
+    grad_torch = path.grad.clone()
+
+    grad_manual = pysiglib.branched_sig_backprop(
+        path.detach(), bsig.detach(),
+        torch.ones_like(bsig), N, planar=True)
+
+    check_close(grad_torch, grad_manual, double_atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
 def test_branched_sig_backprop_batch(d, N):
     """Batched backprop matches single-path backprop."""
     pysiglib.prepare_branched_sig(d, N)
@@ -646,124 +623,6 @@ def test_branched_sig_backprop_cuda_torch_api(d=2, N=3):
     cpu_grad = path_cpu.grad
 
     check_close(cpu_grad, cuda_grad, double_atol=1e-10)
-
-
-@skip_no_cuda
-def test_branched_sig_combine_torch_api(d=2, N=3):
-    """torch_api branched_sig_combine backward works."""
-    pysiglib.prepare_branched_sig(d, N)
-    np.random.seed(503)
-    bsig1 = torch.tensor(np.random.randn(pysiglib.branched_sig_length(d, N)),
-                         dtype=torch.float64, requires_grad=True)
-    bsig2 = torch.tensor(np.random.randn(pysiglib.branched_sig_length(d, N)),
-                         dtype=torch.float64, requires_grad=True)
-
-    combined = pysiglib.torch_api.branched_sig_combine(bsig1, bsig2, d, N)
-    loss = combined.sum()
-    loss.backward()
-
-    assert bsig1.grad is not None
-    assert bsig2.grad is not None
-    assert bsig1.grad.shape == bsig1.shape
-    assert bsig2.grad.shape == bsig2.shape
-
-
-# ---------------------------------------------------------------------------
-# Combine backprop finite-difference tests
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
-def test_branched_sig_combine_backprop_finite_diff(d, N):
-    """Combine backprop matches finite differences."""
-    pysiglib.prepare_branched_sig(d, N)
-    np.random.seed(600)
-    bsig_len = pysiglib.branched_sig_length(d, N)
-    bsig1 = np.random.randn(bsig_len)
-    bsig2 = np.random.randn(bsig_len)
-    derivs = np.random.randn(bsig_len)
-
-    d1, d2 = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N)
-
-    eps = 1e-8
-    fd1 = np.zeros(bsig_len)
-    for i in range(bsig_len):
-        b1p = bsig1.copy()
-        b1p[i] += eps
-        cp = np.array(pysiglib.branched_sig_combine(b1p, bsig2, d, N))
-        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N))
-        fd1[i] = np.dot(derivs, (cp - cm)) / eps
-    np.testing.assert_allclose(d1, fd1, atol=1e-4)
-
-    fd2 = np.zeros(bsig_len)
-    for i in range(bsig_len):
-        b2p = bsig2.copy()
-        b2p[i] += eps
-        cp = np.array(pysiglib.branched_sig_combine(bsig1, b2p, d, N))
-        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N))
-        fd2[i] = np.dot(derivs, (cp - cm)) / eps
-    np.testing.assert_allclose(d2, fd2, atol=1e-4)
-
-
-# ---------------------------------------------------------------------------
-# CUDA combine tests
-# ---------------------------------------------------------------------------
-
-@skip_no_cuda
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_branched_sig_combine_cuda_matches_cpu(d, N):
-    """CUDA combine matches CPU."""
-    pysiglib.prepare_branched_sig(d, N)
-    np.random.seed(601)
-    bsig_len = pysiglib.branched_sig_length(d, N)
-    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-
-    cpu = pysiglib.branched_sig_combine(bsig1, bsig2, d, N)
-    cuda = pysiglib.branched_sig_combine(bsig1.cuda(), bsig2.cuda(), d, N)
-    check_close(cpu, cuda, double_atol=1e-12)
-
-
-@skip_no_cuda
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_branched_sig_combine_backprop_cuda_matches_cpu(d, N):
-    """CUDA combine backprop matches CPU."""
-    pysiglib.prepare_branched_sig(d, N)
-    np.random.seed(602)
-    bsig_len = pysiglib.branched_sig_length(d, N)
-    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-    derivs = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-
-    d1_cpu, d2_cpu = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N)
-    d1_cuda, d2_cuda = pysiglib.branched_sig_combine_backprop(
-        derivs.cuda(), bsig1.cuda(), bsig2.cuda(), d, N)
-    check_close(d1_cpu, d1_cuda, double_atol=1e-10)
-    check_close(d2_cpu, d2_cuda, double_atol=1e-10)
-
-
-@skip_no_cuda
-def test_branched_sig_combine_torch_api_cuda(d=2, N=3):
-    """torch_api branched_sig_combine backward on CUDA."""
-    pysiglib.prepare_branched_sig(d, N)
-    np.random.seed(603)
-    bsig_len = pysiglib.branched_sig_length(d, N)
-    bsig1 = torch.tensor(np.random.randn(bsig_len),
-                         dtype=torch.float64, device='cuda', requires_grad=True)
-    bsig2 = torch.tensor(np.random.randn(bsig_len),
-                         dtype=torch.float64, device='cuda', requires_grad=True)
-
-    combined = pysiglib.torch_api.branched_sig_combine(bsig1, bsig2, d, N)
-    combined.sum().backward()
-
-    assert bsig1.grad is not None
-    assert bsig2.grad is not None
-
-    # Compare against CPU
-    b1_cpu = bsig1.detach().cpu().requires_grad_(True)
-    b2_cpu = bsig2.detach().cpu().requires_grad_(True)
-    pysiglib.torch_api.branched_sig_combine(b1_cpu, b2_cpu, d, N).sum().backward()
-    check_close(b1_cpu.grad, bsig1.grad, double_atol=1e-10)
-    check_close(b2_cpu.grad, bsig2.grad, double_atol=1e-10)
 
 
 # ===========================================================================
@@ -960,26 +819,6 @@ def test_planar_branched_sig_vs_kauri(d, N):
     np.testing.assert_allclose(bsig[1:], ref_reordered, atol=1e-10)
 
 
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_planar_branched_sig_concatenation(d, N):
-    """Chen's identity: bsig(X*Y) == branched_sig_combine(bsig(X), bsig(Y))."""
-    pysiglib.prepare_branched_sig(d, N, planar=True)
-    np.random.seed(1002)
-    L1, L2 = 5, 6
-    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
-    path2_increments = np.random.randn(L2 - 1, d) * 0.1
-    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_increments, axis=0)])
-
-    bsig1 = pysiglib.branched_sig(path1, N, planar=True)
-    bsig2 = pysiglib.branched_sig(path2, N, planar=True)
-    combined = pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
-
-    full_path = np.vstack([path1, path2[1:]])
-    bsig_full = pysiglib.branched_sig(full_path, N, planar=True)
-
-    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
-
-
 @pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
 def test_planar_branched_sig_batch(d, N):
     pysiglib.prepare_branched_sig(d, N, planar=True)
@@ -1106,27 +945,6 @@ def test_planar_branched_sig_time_aug_batch(d, N):
     for i in range(B):
         single = pysiglib.branched_sig(paths[i], N, time_aug=True, planar=True)
         np.testing.assert_allclose(batch_result[i], single, atol=1e-12)
-
-
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_planar_branched_sig_lead_lag_concatenation(d, N):
-    """Chen's identity should hold with lead_lag enabled for planar sigs."""
-    aug_dim = 2 * d
-    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
-    np.random.seed(1104)
-    L1, L2 = 5, 6
-    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
-    path2_inc = np.random.randn(L2 - 1, d) * 0.1
-    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_inc, axis=0)])
-
-    bsig1 = pysiglib.branched_sig(path1, N, lead_lag=True, planar=True)
-    bsig2 = pysiglib.branched_sig(path2, N, lead_lag=True, planar=True)
-    combined = pysiglib.branched_sig_combine(bsig1, bsig2, aug_dim, N, planar=True)
-
-    full_path = np.vstack([path1, path2[1:]])
-    bsig_full = pysiglib.branched_sig(full_path, N, lead_lag=True, planar=True)
-
-    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -1319,69 +1137,3 @@ def test_planar_branched_sig_backprop_cuda_batch(d, N):
         single_grad = pysiglib.branched_sig_backprop(paths[i], bsigs[i], derivs[i], N, planar=True)
         check_close(batch_grad[i], single_grad, double_atol=1e-10)
 
-
-# ---------------------------------------------------------------------------
-# Planar combine backprop tests
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
-def test_planar_branched_sig_combine_backprop_finite_diff(d, N):
-    """Planar combine backprop matches finite differences."""
-    pysiglib.prepare_branched_sig(d, N, planar=True)
-    np.random.seed(1500)
-    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
-    bsig1 = np.random.randn(bsig_len)
-    bsig2 = np.random.randn(bsig_len)
-    derivs = np.random.randn(bsig_len)
-
-    d1, d2 = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N, planar=True)
-
-    eps = 1e-8
-    fd1 = np.zeros(bsig_len)
-    for i in range(bsig_len):
-        b1p = bsig1.copy()
-        b1p[i] += eps
-        cp = np.array(pysiglib.branched_sig_combine(b1p, bsig2, d, N, planar=True))
-        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True))
-        fd1[i] = np.dot(derivs, (cp - cm)) / eps
-    np.testing.assert_allclose(d1, fd1, atol=1e-4)
-
-    fd2 = np.zeros(bsig_len)
-    for i in range(bsig_len):
-        b2p = bsig2.copy()
-        b2p[i] += eps
-        cp = np.array(pysiglib.branched_sig_combine(bsig1, b2p, d, N, planar=True))
-        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True))
-        fd2[i] = np.dot(derivs, (cp - cm)) / eps
-    np.testing.assert_allclose(d2, fd2, atol=1e-4)
-
-
-@skip_no_cuda
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_planar_branched_sig_combine_cuda_matches_cpu(d, N):
-    pysiglib.prepare_branched_sig(d, N, planar=True)
-    np.random.seed(1501)
-    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
-    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-
-    cpu = pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
-    cuda = pysiglib.branched_sig_combine(bsig1.cuda(), bsig2.cuda(), d, N, planar=True)
-    check_close(cpu, cuda, double_atol=1e-12)
-
-
-@skip_no_cuda
-@pytest.mark.parametrize("d,N", [(2, 3)])
-def test_planar_branched_sig_combine_backprop_cuda_matches_cpu(d, N):
-    pysiglib.prepare_branched_sig(d, N, planar=True)
-    np.random.seed(1502)
-    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
-    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-    derivs = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
-
-    d1_cpu, d2_cpu = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N, planar=True)
-    d1_cuda, d2_cuda = pysiglib.branched_sig_combine_backprop(
-        derivs.cuda(), bsig1.cuda(), bsig2.cuda(), d, N, planar=True)
-    check_close(d1_cpu, d1_cuda, double_atol=1e-10)
-    check_close(d2_cpu, d2_cuda, double_atol=1e-10)

--- a/tests/test_branched_sig.py
+++ b/tests/test_branched_sig.py
@@ -20,6 +20,8 @@ import itertools
 
 import kauri
 import kauri.bck
+import kauri.mkw
+import kauri.mkw
 
 import pysiglib
 from conftest import DEVICES, check_close, skip_no_cuda
@@ -762,3 +764,624 @@ def test_branched_sig_combine_torch_api_cuda(d=2, N=3):
     pysiglib.torch_api.branched_sig_combine(b1_cpu, b2_cpu, d, N).sum().backward()
     check_close(b1_cpu.grad, bsig1.grad, double_atol=1e-10)
     check_close(b2_cpu.grad, bsig2.grad, double_atol=1e-10)
+
+
+# ===========================================================================
+# Planar branched signature tests
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Helpers: kauri MKW-based reference implementation for planar branched sigs
+# ---------------------------------------------------------------------------
+
+def enumerate_decorated_planar_trees(d, N):
+    """Enumerate all decorated planar trees up to order N with d labels."""
+    all_trees = []
+    for order in range(1, N + 1):
+        for t in kauri.colored_planar_trees_of_order(order, d):
+            all_trees.append(t)
+    return all_trees
+
+
+def linear_planar_branched_sig_ref(z, trees):
+    """Reference linear planar branched sig: X(tau) = prod z[dec(v)] / gamma(tau)."""
+    coeffs = {}
+    for t in trees:
+        # PlanarTree.sorted_list_repr() returns self.list_repr (ordered, not sorted)
+        # so _extract_decs works identically: slr[-1] is root color, slr[:-1] are children
+        decs = []
+        _extract_decs(t.sorted_list_repr(), decs)
+        gamma = t.factorial()
+        num = 1.0
+        for dec in decs:
+            num *= z[dec]
+        coeffs[t.sorted_list_repr()] = num / gamma
+    return coeffs
+
+
+def planar_branched_sig_reference(path, d, N):
+    """Compute planar branched sig using kauri.mkw.map_product as ground truth.
+
+    kauri.mkw.map_product uses the NCK coproduct on PlanarTree objects, which
+    computes the correct convolution product for scalar-valued MKW characters
+    (shuffle coefficients cancel with the 1/k! factors).
+    """
+    trees = enumerate_decorated_planar_trees(d, N)
+
+    X = kauri.Map(lambda t: 1.0 if t.nodes() == 0 else 0.0)
+
+    for n in range(len(path) - 1):
+        z = path[n + 1] - path[n]
+        coeffs = linear_planar_branched_sig_ref(z, trees)
+
+        def make_char(c):
+            def char_func(t):
+                if t.nodes() == 0:
+                    return 1.0
+                return c.get(t.sorted_list_repr(), 0.0)
+            return char_func
+
+        Y = kauri.Map(make_char(coeffs))
+        X = kauri.mkw.map_product(X, Y)
+
+    return np.array([X(t) for t in trees])
+
+
+def compute_kauri_to_pysiglib_planar_permutation(d, N):
+    """Find permutation mapping kauri planar tree order to pysiglib planar tree order.
+
+    Uses a multi-segment path with irrational increments to break all symmetries.
+    """
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    trees = enumerate_decorated_planar_trees(d, N)
+    num_trees = len(trees)
+
+    path = np.zeros((3, d))
+    for i in range(d):
+        path[1, i] = np.pi * (i + 1) + np.e * (i + 1)**2
+        path[2, i] = path[1, i] + np.sqrt(2) * (i + 1) + np.log(i + 2)
+
+    pysig_bsig = np.array(pysiglib.branched_sig(path, N, planar=True), dtype=np.float64)
+    pysig_coeffs = pysig_bsig[1:]
+    kauri_arr = planar_branched_sig_reference(path, d, N)
+
+    perm = np.zeros(num_trees, dtype=int)
+    used = set()
+    for ki in range(num_trees):
+        best_idx = -1
+        best_diff = float('inf')
+        for pi in range(num_trees):
+            if pi in used:
+                continue
+            diff = abs(kauri_arr[ki] - pysig_coeffs[pi])
+            if diff < best_diff:
+                best_diff = diff
+                best_idx = pi
+        assert best_diff < 1e-8, f"No match for planar kauri tree {ki}: best_diff={best_diff}"
+        perm[ki] = best_idx
+        used.add(best_idx)
+
+    return perm
+
+
+def reorder_kauri_to_pysiglib_planar(kauri_arr, perm):
+    """Reorder a kauri-ordered planar array to match pysiglib ordering."""
+    result = np.empty_like(kauri_arr)
+    for ki in range(len(perm)):
+        result[perm[ki]] = kauri_arr[ki]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Planar length tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("d,N,expected", [
+    (1, 1, 2),    # 1 + 1
+    (1, 2, 3),    # 2 + 1
+    (1, 3, 5),    # 3 + 2  (same as non-planar for d=1)
+    (2, 1, 3),    # 1 + 2
+    (2, 2, 7),    # 3 + 4  (same as non-planar: single child ⇒ no ordering difference)
+    (2, 3, 23),   # 7 + 16 (non-planar: 21; +2 from (•₀,•₁) vs (•₁,•₀) orderings)
+    (3, 1, 4),    # 1 + 3
+    (3, 2, 13),   # 4 + 9
+])
+def test_planar_branched_sig_length(d, N, expected):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    assert pysiglib.branched_sig_length(d, N, planar=True) == expected
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_length_vs_kauri(d, N):
+    # colored_planar_trees_up_to_order includes the empty tree (order 0),
+    # which corresponds to the scalar term — so the count equals pysiglib's length directly.
+    expected = len(list(kauri.colored_planar_trees_up_to_order(N, d)))
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    assert pysiglib.branched_sig_length(d, N, planar=True) == expected
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 3), (2, 4)])
+def test_planar_branched_sig_length_geq_nonplanar(d, N):
+    """Planar length is at least non-planar length (more trees due to ordering)."""
+    pysiglib.prepare_branched_sig(d, N)
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    assert pysiglib.branched_sig_length(d, N, planar=True) >= pysiglib.branched_sig_length(d, N)
+
+
+# ---------------------------------------------------------------------------
+# Planar correctness tests
+# ---------------------------------------------------------------------------
+
+def test_planar_branched_sig_trivial_path():
+    d, N = 2, 3
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    path = np.array([[1.0, 2.0], [1.0, 2.0]])
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    assert bsig[0] == pytest.approx(1.0)
+    assert np.allclose(bsig[1:], 0.0, atol=1e-14)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_single_segment(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    perm = compute_kauri_to_pysiglib_planar_permutation(d, N)
+
+    np.random.seed(1000)
+    z = np.random.randn(d)
+    path = np.zeros((2, d))
+    path[1] = z
+
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+
+    trees = enumerate_decorated_planar_trees(d, N)
+    ref_coeffs = linear_planar_branched_sig_ref(z, trees)
+    ref = np.array([ref_coeffs[t.sorted_list_repr()] for t in trees])
+    ref_reordered = reorder_kauri_to_pysiglib_planar(ref, perm)
+
+    assert bsig[0] == pytest.approx(1.0)
+    np.testing.assert_allclose(bsig[1:], ref_reordered, atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2), (2, 4)])
+def test_planar_branched_sig_vs_kauri(d, N):
+    """Primary correctness test: compare against kauri MKW map product."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    perm = compute_kauri_to_pysiglib_planar_permutation(d, N)
+
+    np.random.seed(1001)
+    L = 10
+    path = np.cumsum(np.random.randn(L, d) * 0.1, axis=0)
+
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    ref = planar_branched_sig_reference(path, d, N)
+    ref_reordered = reorder_kauri_to_pysiglib_planar(ref, perm)
+
+    assert bsig[0] == pytest.approx(1.0)
+    np.testing.assert_allclose(bsig[1:], ref_reordered, atol=1e-10)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_concatenation(d, N):
+    """Chen's identity: bsig(X*Y) == branched_sig_combine(bsig(X), bsig(Y))."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1002)
+    L1, L2 = 5, 6
+    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
+    path2_increments = np.random.randn(L2 - 1, d) * 0.1
+    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_increments, axis=0)])
+
+    bsig1 = pysiglib.branched_sig(path1, N, planar=True)
+    bsig2 = pysiglib.branched_sig(path2, N, planar=True)
+    combined = pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
+
+    full_path = np.vstack([path1, path2[1:]])
+    bsig_full = pysiglib.branched_sig(full_path, N, planar=True)
+
+    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_batch(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1003)
+    B, L = 5, 8
+    paths = np.random.randn(B, L, d)
+
+    batch_result = pysiglib.branched_sig(paths, N, planar=True)
+    for i in range(B):
+        single = pysiglib.branched_sig(paths[i], N, planar=True)
+        np.testing.assert_allclose(batch_result[i], single, atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_batch_parallel(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1004)
+    B, L = 10, 8
+    paths = np.random.randn(B, L, d)
+
+    serial = pysiglib.branched_sig(paths, N, n_jobs=1, planar=True)
+    parallel = pysiglib.branched_sig(paths, N, n_jobs=-1, planar=True)
+    np.testing.assert_allclose(serial, parallel, atol=1e-14)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_planar_branched_sig_dtypes(dtype):
+    d, N = 2, 2
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    path = np.random.randn(5, d).astype(dtype)
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    assert bsig[0] == pytest.approx(1.0, abs=1e-5)
+    assert len(bsig) == pysiglib.branched_sig_length(d, N, planar=True)
+
+
+def test_planar_branched_sig_degree_1_matches_standard():
+    """At degree 1, planar branched sig == standard sig level 1 (same as non-planar)."""
+    d = 3
+    pysiglib.prepare_branched_sig(d, 1, planar=True)
+    np.random.seed(1005)
+    path = np.cumsum(np.random.randn(20, d) * 0.1, axis=0)
+
+    bsig = pysiglib.branched_sig(path, 1, planar=True)
+    total_incr = path[-1] - path[0]
+    np.testing.assert_allclose(bsig[0], 1.0, atol=1e-14)
+    np.testing.assert_allclose(bsig[1:], total_incr, atol=1e-12)
+
+
+def test_planar_branched_sig_degree_1_matches_nonplanar():
+    """At degree 1, planar and non-planar branched sigs are identical."""
+    d, N = 3, 1
+    pysiglib.prepare_branched_sig(d, N)
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1006)
+    path = np.cumsum(np.random.randn(15, d) * 0.1, axis=0)
+
+    bsig_np = pysiglib.branched_sig(path, N)
+    bsig_pl = pysiglib.branched_sig(path, N, planar=True)
+    np.testing.assert_allclose(bsig_pl, bsig_np, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Planar time_aug and lead_lag tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_time_aug_matches_manual(d, N):
+    aug_dim = d + 1
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1100)
+    L = 10
+    path = np.cumsum(np.random.randn(L, d) * 0.1, axis=0)
+
+    bsig_flag = pysiglib.branched_sig(path, N, time_aug=True, planar=True)
+
+    t = np.linspace(0, 1, L)[:, np.newaxis]
+    path_aug = np.concatenate([path, t], axis=1)
+    bsig_manual = pysiglib.branched_sig(path_aug, N, planar=True)
+
+    np.testing.assert_allclose(bsig_flag, bsig_manual, atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_lead_lag_matches_manual(d, N):
+    aug_dim = 2 * d
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1101)
+    L = 8
+    path = np.cumsum(np.random.randn(L, d) * 0.1, axis=0)
+
+    bsig_flag = pysiglib.branched_sig(path, N, lead_lag=True, planar=True)
+
+    path_ll = np.array(pysiglib.transform_path(path, lead_lag=True))
+    bsig_manual = pysiglib.branched_sig(path_ll, N, planar=True)
+
+    np.testing.assert_allclose(bsig_flag, bsig_manual, atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_time_aug_lead_lag_matches_manual(d, N):
+    aug_dim = 2 * d + 1
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1102)
+    L = 8
+    path = np.cumsum(np.random.randn(L, d) * 0.1, axis=0)
+
+    bsig_flag = pysiglib.branched_sig(path, N, time_aug=True, lead_lag=True, planar=True)
+
+    path_t = np.array(pysiglib.transform_path(path, time_aug=True, lead_lag=True))
+    bsig_manual = pysiglib.branched_sig(path_t, N, planar=True)
+
+    np.testing.assert_allclose(bsig_flag, bsig_manual, atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_time_aug_batch(d, N):
+    aug_dim = d + 1
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1103)
+    B, L = 4, 10
+    paths = np.random.randn(B, L, d)
+
+    batch_result = pysiglib.branched_sig(paths, N, time_aug=True, planar=True)
+    for i in range(B):
+        single = pysiglib.branched_sig(paths[i], N, time_aug=True, planar=True)
+        np.testing.assert_allclose(batch_result[i], single, atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_lead_lag_concatenation(d, N):
+    """Chen's identity should hold with lead_lag enabled for planar sigs."""
+    aug_dim = 2 * d
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1104)
+    L1, L2 = 5, 6
+    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
+    path2_inc = np.random.randn(L2 - 1, d) * 0.1
+    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_inc, axis=0)])
+
+    bsig1 = pysiglib.branched_sig(path1, N, lead_lag=True, planar=True)
+    bsig2 = pysiglib.branched_sig(path2, N, lead_lag=True, planar=True)
+    combined = pysiglib.branched_sig_combine(bsig1, bsig2, aug_dim, N, planar=True)
+
+    full_path = np.vstack([path1, path2[1:]])
+    bsig_full = pysiglib.branched_sig(full_path, N, lead_lag=True, planar=True)
+
+    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Planar CUDA tests
+# ---------------------------------------------------------------------------
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2), (2, 4)])
+def test_planar_branched_sig_cuda_matches_cpu(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1200)
+    path = np.cumsum(np.random.randn(10, d) * 0.1, axis=0)
+    path_t = torch.tensor(path)
+
+    cpu = pysiglib.branched_sig(path_t, N, planar=True)
+    cuda = pysiglib.branched_sig(path_t.cuda(), N, planar=True)
+    check_close(cpu, cuda, double_atol=1e-12)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_cuda_batch(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1201)
+    B, L = 8, 12
+    paths = torch.tensor(np.random.randn(B, L, d)).cuda()
+
+    batch_result = pysiglib.branched_sig(paths, N, planar=True)
+    for i in range(B):
+        single = pysiglib.branched_sig(paths[i], N, planar=True)
+        check_close(batch_result[i], single, double_atol=1e-12)
+
+
+@skip_no_cuda
+def test_planar_branched_sig_cuda_trivial():
+    d, N = 2, 3
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    path = torch.tensor([[1.0, 2.0], [1.0, 2.0]], dtype=torch.float64).cuda()
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    assert float(bsig[0].cpu()) == pytest.approx(1.0)
+    assert torch.allclose(bsig[1:], torch.zeros(bsig.shape[0] - 1, device="cuda", dtype=torch.float64), atol=1e-14)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_cuda_time_aug(d, N):
+    aug_dim = d + 1
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1202)
+    path = torch.tensor(np.cumsum(np.random.randn(10, d) * 0.1, axis=0))
+
+    cpu = pysiglib.branched_sig(path, N, time_aug=True, planar=True)
+    cuda = pysiglib.branched_sig(path.cuda(), N, time_aug=True, planar=True)
+    check_close(cpu, cuda, double_atol=1e-12)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_cuda_lead_lag(d, N):
+    aug_dim = 2 * d
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1203)
+    path = torch.tensor(np.cumsum(np.random.randn(8, d) * 0.1, axis=0))
+
+    cpu = pysiglib.branched_sig(path, N, lead_lag=True, planar=True)
+    cuda = pysiglib.branched_sig(path.cuda(), N, lead_lag=True, planar=True)
+    check_close(cpu, cuda, double_atol=1e-12)
+
+
+@skip_no_cuda
+def test_planar_branched_sig_cuda_float32():
+    d, N = 2, 3
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1204)
+    path = torch.tensor(np.random.randn(8, d).astype(np.float32)).cuda()
+
+    cuda = pysiglib.branched_sig(path, N, planar=True)
+    cpu = pysiglib.branched_sig(path.cpu(), N, planar=True)
+    check_close(cpu, cuda, single_atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Planar backpropagation tests
+# ---------------------------------------------------------------------------
+
+def _finite_diff_planar_branched_sig(path_np, d, N, eps=1e-8):
+    """dF/dpath via finite differences where F = sum(planar_branched_sig)."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    grad = np.zeros_like(path_np)
+    f0 = np.array(pysiglib.branched_sig(path_np, N, planar=True)).sum()
+    for i in range(path_np.shape[0]):
+        for j in range(path_np.shape[1]):
+            path_p = path_np.copy()
+            path_p[i, j] += eps
+            f1 = np.array(pysiglib.branched_sig(path_p, N, planar=True)).sum()
+            grad[i, j] = (f1 - f0) / eps
+    return grad
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_backprop_finite_diff(d, N):
+    """Planar backprop matches finite differences with F = sum(bsig)."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1300)
+    L = 5
+    path = np.cumsum(np.random.randn(L, d) * 0.1, axis=0)
+
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    derivs = np.ones(len(bsig))
+
+    grad_bp = np.array(pysiglib.branched_sig_backprop(path, bsig, derivs, N, planar=True))
+    grad_fd = _finite_diff_planar_branched_sig(path, d, N)
+
+    np.testing.assert_allclose(grad_bp, grad_fd, atol=1e-4)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_backprop_random_derivs(d, N):
+    """Planar backprop with random upstream derivatives matches finite differences."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1301)
+    L = 5
+    path = np.cumsum(np.random.randn(L, d) * 0.1, axis=0)
+
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    derivs = np.random.randn(len(bsig))
+
+    grad_bp = np.array(pysiglib.branched_sig_backprop(path, bsig, derivs, N, planar=True))
+
+    eps = 1e-8
+    grad_fd = np.zeros_like(path)
+    for i in range(path.shape[0]):
+        for j in range(path.shape[1]):
+            path_p = path.copy()
+            path_p[i, j] += eps
+            bsig_p = np.array(pysiglib.branched_sig(path_p, N, planar=True))
+            grad_fd[i, j] = np.dot(derivs, bsig_p - np.array(bsig)) / eps
+
+    np.testing.assert_allclose(grad_bp, grad_fd, atol=1e-4)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_backprop_batch(d, N):
+    """Batched planar backprop matches single-path backprop."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1302)
+    B, L = 4, 6
+    paths = np.random.randn(B, L, d)
+
+    bsigs = pysiglib.branched_sig(paths, N, planar=True)
+    derivs = np.random.randn(B, bsigs.shape[1])
+
+    batch_grad = np.array(pysiglib.branched_sig_backprop(paths, bsigs, derivs, N, planar=True))
+    for i in range(B):
+        single_grad = np.array(pysiglib.branched_sig_backprop(
+            paths[i], bsigs[i], derivs[i], N, planar=True))
+        np.testing.assert_allclose(batch_grad[i], single_grad, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Planar CUDA backprop tests
+# ---------------------------------------------------------------------------
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_backprop_cuda_matches_cpu(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1400)
+    path = torch.tensor(np.cumsum(np.random.randn(8, d) * 0.1, axis=0), dtype=torch.float64)
+    bsig = pysiglib.branched_sig(path, N, planar=True)
+    derivs = torch.rand(bsig.shape, dtype=torch.float64)
+
+    cpu_grad = pysiglib.branched_sig_backprop(path, bsig, derivs, N, planar=True)
+    cuda_grad = pysiglib.branched_sig_backprop(path.cuda(), bsig.cuda(), derivs.cuda(), N, planar=True)
+    check_close(cpu_grad, cuda_grad, double_atol=1e-10)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_backprop_cuda_batch(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1401)
+    B, L = 4, 6
+    paths = torch.tensor(np.random.randn(B, L, d), dtype=torch.float64, device='cuda')
+    bsigs = pysiglib.branched_sig(paths, N, planar=True)
+    derivs = torch.rand(bsigs.shape, dtype=torch.float64, device='cuda')
+
+    batch_grad = pysiglib.branched_sig_backprop(paths, bsigs, derivs, N, planar=True)
+    for i in range(B):
+        single_grad = pysiglib.branched_sig_backprop(paths[i], bsigs[i], derivs[i], N, planar=True)
+        check_close(batch_grad[i], single_grad, double_atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Planar combine backprop tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_combine_backprop_finite_diff(d, N):
+    """Planar combine backprop matches finite differences."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1500)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = np.random.randn(bsig_len)
+    bsig2 = np.random.randn(bsig_len)
+    derivs = np.random.randn(bsig_len)
+
+    d1, d2 = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N, planar=True)
+
+    eps = 1e-8
+    fd1 = np.zeros(bsig_len)
+    for i in range(bsig_len):
+        b1p = bsig1.copy()
+        b1p[i] += eps
+        cp = np.array(pysiglib.branched_sig_combine(b1p, bsig2, d, N, planar=True))
+        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True))
+        fd1[i] = np.dot(derivs, (cp - cm)) / eps
+    np.testing.assert_allclose(d1, fd1, atol=1e-4)
+
+    fd2 = np.zeros(bsig_len)
+    for i in range(bsig_len):
+        b2p = bsig2.copy()
+        b2p[i] += eps
+        cp = np.array(pysiglib.branched_sig_combine(bsig1, b2p, d, N, planar=True))
+        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True))
+        fd2[i] = np.dot(derivs, (cp - cm)) / eps
+    np.testing.assert_allclose(d2, fd2, atol=1e-4)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_combine_cuda_matches_cpu(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1501)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+
+    cpu = pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
+    cuda = pysiglib.branched_sig_combine(bsig1.cuda(), bsig2.cuda(), d, N, planar=True)
+    check_close(cpu, cuda, double_atol=1e-12)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_combine_backprop_cuda_matches_cpu(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1502)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    derivs = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+
+    d1_cpu, d2_cpu = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N, planar=True)
+    d1_cuda, d2_cuda = pysiglib.branched_sig_combine_backprop(
+        derivs.cuda(), bsig1.cuda(), bsig2.cuda(), d, N, planar=True)
+    check_close(d1_cpu, d1_cuda, double_atol=1e-10)
+    check_close(d2_cpu, d2_cuda, double_atol=1e-10)

--- a/tests/test_branched_sig_combine.py
+++ b/tests/test_branched_sig_combine.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Daniil Shmelev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========================================================================
+
+import pytest
+import numpy as np
+import torch
+
+import pysiglib
+from conftest import check_close, skip_no_cuda
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_branched_sig_concatenation(d, N):
+    """Chen's identity: bsig(X*Y) == branched_sig_combine(bsig(X), bsig(Y))."""
+    pysiglib.prepare_branched_sig(d, N)
+    np.random.seed(99)
+    L1, L2 = 5, 6
+    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
+    path2_increments = np.random.randn(L2 - 1, d) * 0.1
+    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_increments, axis=0)])
+
+    bsig1 = pysiglib.branched_sig(path1, N)
+    bsig2 = pysiglib.branched_sig(path2, N)
+    combined = pysiglib.branched_sig_combine(bsig1, bsig2, d, N)
+
+    full_path = np.vstack([path1, path2[1:]])
+    bsig_full = pysiglib.branched_sig(full_path, N)
+
+    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_branched_sig_lead_lag_concatenation(d, N):
+    """Chen's identity should hold with lead_lag enabled."""
+    aug_dim = 2 * d
+    pysiglib.prepare_branched_sig(aug_dim, N)
+    np.random.seed(204)
+    L1, L2 = 5, 6
+    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
+    path2_inc = np.random.randn(L2 - 1, d) * 0.1
+    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_inc, axis=0)])
+
+    bsig1 = pysiglib.branched_sig(path1, N, lead_lag=True)
+    bsig2 = pysiglib.branched_sig(path2, N, lead_lag=True)
+    combined = pysiglib.branched_sig_combine(bsig1, bsig2, aug_dim, N)
+
+    full_path = np.vstack([path1, path2[1:]])
+    bsig_full = pysiglib.branched_sig(full_path, N, lead_lag=True)
+
+    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_branched_sig_combine_cuda_matches_cpu(d, N):
+    """CUDA combine matches CPU."""
+    pysiglib.prepare_branched_sig(d, N)
+    np.random.seed(601)
+    bsig_len = pysiglib.branched_sig_length(d, N)
+    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+
+    cpu = pysiglib.branched_sig_combine(bsig1, bsig2, d, N)
+    cuda = pysiglib.branched_sig_combine(bsig1.cuda(), bsig2.cuda(), d, N)
+    check_close(cpu, cuda, double_atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_concatenation(d, N):
+    """Chen's identity: bsig(X*Y) == branched_sig_combine(bsig(X), bsig(Y))."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1002)
+    L1, L2 = 5, 6
+    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
+    path2_increments = np.random.randn(L2 - 1, d) * 0.1
+    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_increments, axis=0)])
+
+    bsig1 = pysiglib.branched_sig(path1, N, planar=True)
+    bsig2 = pysiglib.branched_sig(path2, N, planar=True)
+    combined = pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
+
+    full_path = np.vstack([path1, path2[1:]])
+    bsig_full = pysiglib.branched_sig(full_path, N, planar=True)
+
+    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_lead_lag_concatenation(d, N):
+    """Chen's identity should hold with lead_lag enabled for planar sigs."""
+    aug_dim = 2 * d
+    pysiglib.prepare_branched_sig(aug_dim, N, planar=True)
+    np.random.seed(1104)
+    L1, L2 = 5, 6
+    path1 = np.cumsum(np.random.randn(L1, d) * 0.1, axis=0)
+    path2_inc = np.random.randn(L2 - 1, d) * 0.1
+    path2 = np.vstack([path1[-1:], path1[-1] + np.cumsum(path2_inc, axis=0)])
+
+    bsig1 = pysiglib.branched_sig(path1, N, lead_lag=True, planar=True)
+    bsig2 = pysiglib.branched_sig(path2, N, lead_lag=True, planar=True)
+    combined = pysiglib.branched_sig_combine(bsig1, bsig2, aug_dim, N, planar=True)
+
+    full_path = np.vstack([path1, path2[1:]])
+    bsig_full = pysiglib.branched_sig(full_path, N, lead_lag=True, planar=True)
+
+    np.testing.assert_allclose(combined, bsig_full, atol=1e-10)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_combine_cuda_matches_cpu(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1501)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+
+    cpu = pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
+    cuda = pysiglib.branched_sig_combine(bsig1.cuda(), bsig2.cuda(), d, N, planar=True)
+    check_close(cpu, cuda, double_atol=1e-12)

--- a/tests/test_branched_sig_combine_backprop.py
+++ b/tests/test_branched_sig_combine_backprop.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Daniil Shmelev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========================================================================
+
+import pytest
+import numpy as np
+import torch
+
+import pysiglib
+from conftest import check_close, skip_no_cuda
+
+
+@skip_no_cuda
+def test_branched_sig_combine_torch_api(d=2, N=3):
+    """torch_api branched_sig_combine backward works."""
+    pysiglib.prepare_branched_sig(d, N)
+    np.random.seed(503)
+    bsig1 = torch.tensor(np.random.randn(pysiglib.branched_sig_length(d, N)),
+                         dtype=torch.float64, requires_grad=True)
+    bsig2 = torch.tensor(np.random.randn(pysiglib.branched_sig_length(d, N)),
+                         dtype=torch.float64, requires_grad=True)
+
+    combined = pysiglib.torch_api.branched_sig_combine(bsig1, bsig2, d, N)
+    combined.sum().backward()
+
+    assert bsig1.grad is not None
+    assert bsig2.grad is not None
+    assert bsig1.grad.shape == bsig1.shape
+    assert bsig2.grad.shape == bsig2.shape
+
+
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_combine_torch_api(d, N):
+    """torch_api planar branched_sig_combine backward matches manual backprop."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(5031)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = torch.tensor(np.random.randn(bsig_len),
+                         dtype=torch.float64, requires_grad=True)
+    bsig2 = torch.tensor(np.random.randn(bsig_len),
+                         dtype=torch.float64, requires_grad=True)
+
+    combined = pysiglib.torch_api.branched_sig_combine(bsig1, bsig2, d, N, planar=True)
+    combined.sum().backward()
+
+    d1_manual, d2_manual = pysiglib.branched_sig_combine_backprop(
+        torch.ones_like(combined), bsig1.detach(), bsig2.detach(), d, N, planar=True)
+
+    check_close(bsig1.grad, d1_manual, double_atol=1e-12)
+    check_close(bsig2.grad, d2_manual, double_atol=1e-12)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_branched_sig_combine_backprop_finite_diff(d, N):
+    """Combine backprop matches finite differences."""
+    pysiglib.prepare_branched_sig(d, N)
+    np.random.seed(600)
+    bsig_len = pysiglib.branched_sig_length(d, N)
+    bsig1 = np.random.randn(bsig_len)
+    bsig2 = np.random.randn(bsig_len)
+    derivs = np.random.randn(bsig_len)
+
+    d1, d2 = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N)
+
+    eps = 1e-8
+    fd1 = np.zeros(bsig_len)
+    for i in range(bsig_len):
+        b1p = bsig1.copy()
+        b1p[i] += eps
+        cp = np.array(pysiglib.branched_sig_combine(b1p, bsig2, d, N))
+        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N))
+        fd1[i] = np.dot(derivs, cp - cm) / eps
+    np.testing.assert_allclose(d1, fd1, atol=1e-4)
+
+    fd2 = np.zeros(bsig_len)
+    for i in range(bsig_len):
+        b2p = bsig2.copy()
+        b2p[i] += eps
+        cp = np.array(pysiglib.branched_sig_combine(bsig1, b2p, d, N))
+        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N))
+        fd2[i] = np.dot(derivs, cp - cm) / eps
+    np.testing.assert_allclose(d2, fd2, atol=1e-4)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_branched_sig_combine_backprop_cuda_matches_cpu(d, N):
+    """CUDA combine backprop matches CPU."""
+    pysiglib.prepare_branched_sig(d, N)
+    np.random.seed(602)
+    bsig_len = pysiglib.branched_sig_length(d, N)
+    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    derivs = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+
+    d1_cpu, d2_cpu = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N)
+    d1_cuda, d2_cuda = pysiglib.branched_sig_combine_backprop(
+        derivs.cuda(), bsig1.cuda(), bsig2.cuda(), d, N)
+    check_close(d1_cpu, d1_cuda, double_atol=1e-10)
+    check_close(d2_cpu, d2_cuda, double_atol=1e-10)
+
+
+@skip_no_cuda
+def test_branched_sig_combine_torch_api_cuda(d=2, N=3):
+    """torch_api branched_sig_combine backward on CUDA."""
+    pysiglib.prepare_branched_sig(d, N)
+    np.random.seed(603)
+    bsig_len = pysiglib.branched_sig_length(d, N)
+    bsig1 = torch.tensor(np.random.randn(bsig_len),
+                         dtype=torch.float64, device="cuda", requires_grad=True)
+    bsig2 = torch.tensor(np.random.randn(bsig_len),
+                         dtype=torch.float64, device="cuda", requires_grad=True)
+
+    combined = pysiglib.torch_api.branched_sig_combine(bsig1, bsig2, d, N)
+    combined.sum().backward()
+
+    assert bsig1.grad is not None
+    assert bsig2.grad is not None
+
+    b1_cpu = bsig1.detach().cpu().requires_grad_(True)
+    b2_cpu = bsig2.detach().cpu().requires_grad_(True)
+    pysiglib.torch_api.branched_sig_combine(b1_cpu, b2_cpu, d, N).sum().backward()
+    check_close(b1_cpu.grad, bsig1.grad, double_atol=1e-10)
+    check_close(b2_cpu.grad, bsig2.grad, double_atol=1e-10)
+
+
+@pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
+def test_planar_branched_sig_combine_backprop_finite_diff(d, N):
+    """Planar combine backprop matches finite differences."""
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1500)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = np.random.randn(bsig_len)
+    bsig2 = np.random.randn(bsig_len)
+    derivs = np.random.randn(bsig_len)
+
+    d1, d2 = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N, planar=True)
+
+    eps = 1e-8
+    fd1 = np.zeros(bsig_len)
+    for i in range(bsig_len):
+        b1p = bsig1.copy()
+        b1p[i] += eps
+        cp = np.array(pysiglib.branched_sig_combine(b1p, bsig2, d, N, planar=True))
+        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True))
+        fd1[i] = np.dot(derivs, cp - cm) / eps
+    np.testing.assert_allclose(d1, fd1, atol=1e-4)
+
+    fd2 = np.zeros(bsig_len)
+    for i in range(bsig_len):
+        b2p = bsig2.copy()
+        b2p[i] += eps
+        cp = np.array(pysiglib.branched_sig_combine(bsig1, b2p, d, N, planar=True))
+        cm = np.array(pysiglib.branched_sig_combine(bsig1, bsig2, d, N, planar=True))
+        fd2[i] = np.dot(derivs, cp - cm) / eps
+    np.testing.assert_allclose(d2, fd2, atol=1e-4)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("d,N", [(2, 3)])
+def test_planar_branched_sig_combine_backprop_cuda_matches_cpu(d, N):
+    pysiglib.prepare_branched_sig(d, N, planar=True)
+    np.random.seed(1502)
+    bsig_len = pysiglib.branched_sig_length(d, N, planar=True)
+    bsig1 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    bsig2 = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+    derivs = torch.tensor(np.random.randn(bsig_len), dtype=torch.float64)
+
+    d1_cpu, d2_cpu = pysiglib.branched_sig_combine_backprop(derivs, bsig1, bsig2, d, N, planar=True)
+    d1_cuda, d2_cuda = pysiglib.branched_sig_combine_backprop(
+        derivs.cuda(), bsig1.cuda(), bsig2.cuda(), d, N, planar=True)
+    check_close(d1_cpu, d1_cuda, double_atol=1e-10)
+    check_close(d2_cpu, d2_cuda, double_atol=1e-10)

--- a/tests/test_branched_sig_combine_backprop.py
+++ b/tests/test_branched_sig_combine_backprop.py
@@ -21,7 +21,6 @@ import pysiglib
 from conftest import check_close, skip_no_cuda
 
 
-@skip_no_cuda
 def test_branched_sig_combine_torch_api(d=2, N=3):
     """torch_api branched_sig_combine backward works."""
     pysiglib.prepare_branched_sig(d, N)

--- a/tests/test_jax_api.py
+++ b/tests/test_jax_api.py
@@ -875,6 +875,68 @@ def test_jax_branched_sig_grad_matches_pysiglib(device, jitted, dtype, case):
     check_close(grad_ref, grad, double_atol=1e-8)
 
 
+@pytest.mark.parametrize("device", _jax_devices())
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_branched_sig_planar_matches_pysiglib(device, jitted):
+    rng = np.random.default_rng(4242)
+    x = rng.uniform(size=(8, 2)).astype(np.float64)
+    deg = 2
+
+    pysiglib.prepare_branched_sig(2, deg, planar=True)
+    expected = pysiglib.branched_sig(x, deg, planar=True)
+
+    x_jax = _as_jax_array(x, device, np.float64)
+
+    def fn(path):
+        return jax_api.branched_sig(path, deg, planar=True)
+
+    actual = jax.jit(fn)(x_jax) if jitted else fn(x_jax)
+    check_close(expected, actual, double_atol=1e-8)
+
+
+@pytest.mark.parametrize("device", _jax_devices())
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_branched_sig_canonical_matches_pysiglib(device, jitted):
+    rng = np.random.default_rng(4343)
+    x = rng.uniform(size=(7, 2)).astype(np.float64)
+    deg = 3
+
+    pysiglib.prepare_branched_sig(2, deg)
+    expected = pysiglib.branched_sig(x, deg, tree_order="canonical")
+
+    x_jax = _as_jax_array(x, device, np.float64)
+
+    def fn(path):
+        return jax_api.branched_sig(path, deg, tree_order="canonical")
+
+    actual = jax.jit(fn)(x_jax) if jitted else fn(x_jax)
+    check_close(expected, actual, double_atol=1e-8)
+
+
+@pytest.mark.parametrize("device", _jax_devices())
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_branched_sig_planar_grad_matches_pysiglib(device, jitted):
+    rng = np.random.default_rng(4344)
+    x = rng.uniform(size=(7, 2)).astype(np.float64)
+    deg = 2
+
+    pysiglib.prepare_branched_sig(2, deg, planar=True)
+    bsig_ref = pysiglib.branched_sig(x, deg, planar=True)
+    weights = rng.uniform(size=bsig_ref.shape).astype(np.float64)
+    grad_ref = pysiglib.branched_sig_backprop(x, bsig_ref, weights, deg, planar=True)
+
+    x_jax = _as_jax_array(x, device, np.float64)
+    weights_jax = _as_jax_array(weights, device, np.float64)
+
+    def loss_fn(path):
+        bsig = jax_api.branched_sig(path, deg, planar=True)
+        return jnp.sum(bsig * weights_jax)
+
+    grad_fn = jax.jit(jax.grad(loss_fn)) if jitted else jax.grad(loss_fn)
+    grad = grad_fn(x_jax)
+    check_close(grad_ref, grad, double_atol=1e-8)
+
+
 # =========================================================================
 # branched_sig_combine — forward
 # =========================================================================
@@ -978,6 +1040,91 @@ def test_jax_branched_sig_combine_grad_matches_pysiglib(device, jitted, dtype, c
 
     def loss_fn(s1, s2):
         comb = jax_api.branched_sig_combine(s1, s2, dim, deg)
+        return jnp.sum(comb * weights_jax)
+
+    grad_fn = jax.jit(jax.grad(loss_fn, argnums=(0, 1))) if jitted else jax.grad(loss_fn, argnums=(0, 1))
+    grad_bsig1, grad_bsig2 = grad_fn(bsig1_jax, bsig2_jax)
+
+    check_close(grad_bsig1_ref, grad_bsig1, double_atol=1e-8)
+    check_close(grad_bsig2_ref, grad_bsig2, double_atol=1e-8)
+
+
+@pytest.mark.parametrize("device", _jax_devices())
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_branched_sig_combine_planar_matches_pysiglib(device, jitted):
+    rng = np.random.default_rng(4444)
+    dim, deg = 2, 2
+
+    pysiglib.prepare_branched_sig(dim, deg, planar=True)
+
+    x1 = rng.uniform(size=(9, dim)).astype(np.float64)
+    x2 = rng.uniform(size=(6, dim)).astype(np.float64)
+
+    bsig1 = pysiglib.branched_sig(x1, deg, planar=True)
+    bsig2 = pysiglib.branched_sig(x2, deg, planar=True)
+    expected = pysiglib.branched_sig_combine(bsig1, bsig2, dim, deg, planar=True)
+
+    bsig1_jax = _as_jax_array(bsig1, device, np.float64)
+    bsig2_jax = _as_jax_array(bsig2, device, np.float64)
+
+    def fn(s1, s2):
+        return jax_api.branched_sig_combine(s1, s2, dim, deg, planar=True)
+
+    actual = jax.jit(fn)(bsig1_jax, bsig2_jax) if jitted else fn(bsig1_jax, bsig2_jax)
+    check_close(expected, actual, double_atol=1e-8)
+
+
+@pytest.mark.parametrize("device", _jax_devices())
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_branched_sig_combine_canonical_matches_pysiglib(device, jitted):
+    rng = np.random.default_rng(4545)
+    dim, deg = 2, 3
+
+    pysiglib.prepare_branched_sig(dim, deg)
+
+    x1 = rng.uniform(size=(8, dim)).astype(np.float64)
+    x2 = rng.uniform(size=(7, dim)).astype(np.float64)
+
+    bsig1 = pysiglib.branched_sig(x1, deg, tree_order="canonical")
+    bsig2 = pysiglib.branched_sig(x2, deg, tree_order="canonical")
+    expected = pysiglib.branched_sig_combine(
+        bsig1, bsig2, dim, deg, tree_order="canonical")
+
+    bsig1_jax = _as_jax_array(bsig1, device, np.float64)
+    bsig2_jax = _as_jax_array(bsig2, device, np.float64)
+
+    def fn(s1, s2):
+        return jax_api.branched_sig_combine(s1, s2, dim, deg, tree_order="canonical")
+
+    actual = jax.jit(fn)(bsig1_jax, bsig2_jax) if jitted else fn(bsig1_jax, bsig2_jax)
+    check_close(expected, actual, double_atol=1e-8)
+
+
+@pytest.mark.parametrize("device", _jax_devices())
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_branched_sig_combine_planar_grad_matches_pysiglib(device, jitted):
+    rng = np.random.default_rng(4546)
+    dim, deg = 2, 2
+
+    pysiglib.prepare_branched_sig(dim, deg, planar=True)
+
+    x1 = rng.uniform(size=(8, dim)).astype(np.float64)
+    x2 = rng.uniform(size=(7, dim)).astype(np.float64)
+
+    bsig1_np = pysiglib.branched_sig(x1, deg, planar=True)
+    bsig2_np = pysiglib.branched_sig(x2, deg, planar=True)
+    combined = pysiglib.branched_sig_combine(bsig1_np, bsig2_np, dim, deg, planar=True)
+
+    weights = rng.uniform(size=combined.shape).astype(np.float64)
+    grad_bsig1_ref, grad_bsig2_ref = pysiglib.branched_sig_combine_backprop(
+        weights, bsig1_np, bsig2_np, dim, deg, planar=True)
+
+    bsig1_jax = _as_jax_array(bsig1_np, device, np.float64)
+    bsig2_jax = _as_jax_array(bsig2_np, device, np.float64)
+    weights_jax = _as_jax_array(weights, device, np.float64)
+
+    def loss_fn(s1, s2):
+        comb = jax_api.branched_sig_combine(s1, s2, dim, deg, planar=True)
         return jnp.sum(comb * weights_jax)
 
     grad_fn = jax.jit(jax.grad(loss_fn, argnums=(0, 1))) if jitted else jax.grad(loss_fn, argnums=(0, 1))


### PR DESCRIPTION
Hi Daniil,

This PR adds planar (ordered) branched path signatures. A `planar=True` flag is added to `prepare_branched_sig`, `branched_sig`, `branched_sig_length`, `branched_sig_combine`, and their backprop counterparts, as well as the Torch and JAX APIs.

The implementation required surprisingly little new infrastructure. The key insight is that planarity can be encoded entirely in the cache structure passed to the existing signature computation. Concretely, `prepare_branched_sig` now builds a distinct cache depending on `planar`, and the downstream C++/CUDA kernels consume it unchanged. The non-planar code paths are unaffected. Nicely we also do not need a new product.

We also raise a `ValueError` if `tree_order != "recursive"` is passed alongside `planar=True`, since tree reordering is not defined for planar signatures (afaik).

Tests cover:
- Correctness against a `kauri.mkw`-based reference implementation
- Concatenation via `branched_sig_combine` for planar sigs, with and without `lead_lag`
- Backprop via finite differences and against manual backprop through the Torch API
- CUDA vs CPU agreement for both forward and backprop
- `branched_sig_length` values against known counts (including the `d=2, N=3` case where planar gives 23 vs non-planar 21, reflecting the two extra orderings from `(•₀, •₁)` vs `(•₁, •₀)`)

I hope this is not too annoying to merge, I tried to keep my fork up to date by working from your `working` branch.

I believe this should be helpful to compare against manifold log-ODE for our paper, if we can get around to that in time.

We may wish to consider LOT algebra multi-index rough paths in future, which give a signature provably minimal in memory requirements.

Thanks,
Luke