### PR TITLE
Fix JAX FFI empty correction under vmap

### DIFF
--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -169,7 +169,7 @@ def _validate_shape(path) -> None:
 
 def _prepare_correction_jax(correction, path, degree: int, lead_lag: bool):
     if correction is None:
-        return jnp.ravel(path)[:0]
+        return jnp.empty((0,), dtype=path.dtype)
 
     correction = jnp.asarray(correction)
     if correction.ndim != 1:

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -213,13 +213,21 @@ inline std::uint64_t AugmentedDimension(std::uint64_t dimension, bool time_aug, 
 template <typename BufferT>
 std::string GetCorrectionLen(BufferT& correction, std::uint64_t& len) {
     const auto dims = BufferDims(correction);
-    if (dims.size() != 1) {
+    if (dims.size() == 1) {
+        len = static_cast<std::uint64_t>(dims[0]);
+        return {};
+    }
+    for (const auto dim : dims) {
+        if (dim == 0) {
+            len = 0;
+            return {};
+        }
+    }
+    {
         std::ostringstream oss;
         oss << "correction must have rank 1, got rank " << dims.size();
         return oss.str();
     }
-    len = static_cast<std::uint64_t>(dims[0]);
-    return {};
 }
 
 template <typename T>


### PR DESCRIPTION
Fixes a JAX FFI shape issue where `correction=None` could be broadcast under vmap into an empty rank-2 buffer like (B, 0), causing native calls to fail with correction must have rank 1.

This treats any empty correction buffer as `correction_len=0` in the FFI, while still rejecting non-empty non-1D corrections. There may be a simpler way to do this, but some quick tests showed no change in any other outputs. 