### PR TITLE
Per-segment Signature Corrections

### DIFF
--- a/pysiglib/branched_log_sig.py
+++ b/pysiglib/branched_log_sig.py
@@ -179,12 +179,16 @@ def branched_log_sig(
 
         where :math:`e_w` is the chain (root-to-leaf path) tree with labels
         :math:`w` and :math:`\\exp_*` is the Hopf-algebra exponential under the
-        Butcher product. ``correction`` must have shape
-        ``path.shape[:-2] + (path.shape[-2] - 1, L)``, with one row per
-        path segment. ``L = d^2 + d^3 + ... + d^m``, where :math:`d` is the
-        underlying path dimension and :math:`2 \\leq m \\leq N` is the highest
-        correction level supplied (missing higher levels are zero). Levels are
-        concatenated in order, and within level :math:`k` the entry for chain
+        Butcher product. A non-empty ``correction`` may have shape ``(C,)``
+        for one constant correction shared by every segment and batch item,
+        ``(path.shape[-2] - 1, C)`` for one correction row per segment shared
+        by the batch, or ``path.shape[:-2] + (path.shape[-2] - 1, C)`` for
+        batch-specific segment corrections. Here ``C`` is the correction
+        width, with ``C = d^2 + d^3 + ... + d^m``, where :math:`d` is the
+        underlying path dimension and
+        :math:`2 \\leq m \\leq N` is the highest correction level supplied
+        (missing higher levels are zero). Levels are concatenated in order,
+        and within level :math:`k` the entry for chain
         :math:`(i_1, \\ldots, i_k)` lives at flat index
         :math:`i_1 d^{k-1} + i_2 d^{k-2} + \\cdots + i_k`. Passing ``None``
         (default) or an empty array is equivalent to all-zero correction. Indices

--- a/pysiglib/branched_log_sig.py
+++ b/pysiglib/branched_log_sig.py
@@ -166,11 +166,11 @@ def branched_log_sig(
     :type planar: bool
     :param scalar_term: If True, include the leading scalar coefficient, which is zero.
     :type scalar_term: bool
-    :param correction: Optional constant correction of level
-        :math:`\\geq 2` added to the path increment at every path
+    :param correction: Optional per-segment correction of level
+        :math:`\\geq 2` added to the path increment on each path
         segment, before the branched log signature is taken. The
         level-1 part of the local lift is the segment's path increment
-        :math:`\\Delta x`, the higher levels come from this constant,
+        :math:`\\Delta x`, the higher levels come from the matching correction row,
         and the local branched signature on each segment is
 
         .. math::
@@ -179,11 +179,12 @@ def branched_log_sig(
 
         where :math:`e_w` is the chain (root-to-leaf path) tree with labels
         :math:`w` and :math:`\\exp_*` is the Hopf-algebra exponential under the
-        Butcher product. ``correction`` is a flat 1D array of length
-        :math:`d^2 + d^3 + \\cdots + d^m`, where :math:`d` is the underlying
-        path dimension and :math:`2 \\leq m \\leq N` is the highest
-        correction level supplied (missing higher levels are zero). Levels are concatenated
-        in order, and within level :math:`k` the entry for chain
+        Butcher product. ``correction`` must have shape
+        ``path.shape[:-2] + (path.shape[-2] - 1, L)``, with one row per
+        path segment. ``L = d^2 + d^3 + ... + d^m``, where :math:`d` is the
+        underlying path dimension and :math:`2 \\leq m \\leq N` is the highest
+        correction level supplied (missing higher levels are zero). Levels are
+        concatenated in order, and within level :math:`k` the entry for chain
         :math:`(i_1, \\ldots, i_k)` lives at flat index
         :math:`i_1 d^{k-1} + i_2 d^{k-2} + \\cdots + i_k`. Passing ``None``
         (default) or an empty array is equivalent to all-zero correction. Indices
@@ -230,8 +231,9 @@ def branched_log_sig(
         path = np.zeros((n_steps + 1, d))
         path[1:] = np.cumsum(rng.normal(0, np.sqrt(dt), (n_steps, d)), axis=0)
 
-        # Ito level-2 correction: dt * Sigma flattened (Sigma = I here).
-        correction = (np.eye(d) * dt).flatten()
+        # Ito level-2 correction: one dt * Sigma row per path segment.
+        correction = np.broadcast_to(
+            (np.eye(d) * dt).reshape(1, -1), (n_steps, d * d)).copy()
 
         pysiglib.prepare_branched_sig(d, N)
         ito_blogsig = pysiglib.branched_log_sig(

--- a/pysiglib/branched_sig.py
+++ b/pysiglib/branched_sig.py
@@ -220,11 +220,11 @@ def branched_sig(
     :param scalar_term: If True, the output includes the leading constant 1 at index 0
         (the empty-word term). If False (default), this leading element is stripped from the output.
     :type scalar_term: bool
-    :param correction: Optional constant correction of level
-        :math:`\\geq 2` added to the path increment at every path
+    :param correction: Optional per-segment correction of level
+        :math:`\\geq 2` added to the path increment on each path
         segment. The level-1 part of the local lift is the segment's
         path increment :math:`\\Delta x`, the higher levels come from
-        this constant, and the local branched signature on each
+        the matching correction row, and the local branched signature on each
         segment is
 
         .. math::
@@ -233,11 +233,12 @@ def branched_sig(
 
         where :math:`e_w` is the chain (root-to-leaf path) tree with labels
         :math:`w` and :math:`\\exp_*` is the Hopf-algebra exponential under the
-        Butcher product. ``correction`` is a flat 1D array of length
-        :math:`d^2 + d^3 + \\cdots + d^m`, where :math:`d` is the underlying
-        path dimension and :math:`2 \\leq m \\leq N` is the highest
-        correction level supplied (missing higher levels are zero). Levels are concatenated
-        in order, and within level :math:`k` the entry for chain
+        Butcher product. ``correction`` must have shape
+        ``path.shape[:-2] + (path.shape[-2] - 1, L)``, with one row per
+        path segment. ``L = d^2 + d^3 + ... + d^m``, where :math:`d` is the
+        underlying path dimension and :math:`2 \\leq m \\leq N` is the highest
+        correction level supplied (missing higher levels are zero). Levels are
+        concatenated in order, and within level :math:`k` the entry for chain
         :math:`(i_1, \\ldots, i_k)` lives at flat index
         :math:`i_1 d^{k-1} + i_2 d^{k-2} + \\cdots + i_k`. Passing ``None``
         (default) or an empty array is equivalent to all-zero correction. Indices
@@ -271,9 +272,9 @@ def branched_sig(
         path = np.zeros((n_steps + 1, d))
         path[1:] = np.cumsum(rng.normal(0, np.sqrt(dt), (n_steps, d)), axis=0)
 
-        # Ito level-2 correction: dt * Sigma flattened. Here Sigma = I so the
-        # diagonal entries c^(2)_ii are dt and off-diagonals are zero.
-        correction = (np.eye(d) * dt).flatten()
+        # Ito level-2 correction: one dt * Sigma row per path segment.
+        correction = np.broadcast_to(
+            (np.eye(d) * dt).reshape(1, -1), (n_steps, d * d)).copy()
 
         pysiglib.prepare_branched_sig(d, N)
         ito_bsig = pysiglib.branched_sig(
@@ -305,14 +306,16 @@ def branched_sig(
             data.data_ptr, result.data_ptr, data.batch_size,
             dimension, data.data_length, degree, n_jobs,
             data.time_aug, data.lead_lag, data.end_time, planar, scalar_term,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     else:
         _check_cuda_num_trees(aug_dimension, degree, planar, "branched_sig")
         err_code = CUSIG_BRANCHED_SIG_CUDA[data.dtype](
             data.data_ptr, result.data_ptr, data.batch_size,
             dimension, data.data_length, degree,
             data.time_aug, data.lead_lag, data.end_time, planar, scalar_term,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig: " + err_msg(err_code))
     if tree_order != "recursive":

--- a/pysiglib/branched_sig.py
+++ b/pysiglib/branched_sig.py
@@ -233,12 +233,16 @@ def branched_sig(
 
         where :math:`e_w` is the chain (root-to-leaf path) tree with labels
         :math:`w` and :math:`\\exp_*` is the Hopf-algebra exponential under the
-        Butcher product. ``correction`` must have shape
-        ``path.shape[:-2] + (path.shape[-2] - 1, L)``, with one row per
-        path segment. ``L = d^2 + d^3 + ... + d^m``, where :math:`d` is the
-        underlying path dimension and :math:`2 \\leq m \\leq N` is the highest
-        correction level supplied (missing higher levels are zero). Levels are
-        concatenated in order, and within level :math:`k` the entry for chain
+        Butcher product. A non-empty ``correction`` may have shape ``(C,)``
+        for one constant correction shared by every segment and batch item,
+        ``(path.shape[-2] - 1, C)`` for one correction row per segment shared
+        by the batch, or ``path.shape[:-2] + (path.shape[-2] - 1, C)`` for
+        batch-specific segment corrections. Here ``C`` is the correction
+        width, with ``C = d^2 + d^3 + ... + d^m``, where :math:`d` is the
+        underlying path dimension and
+        :math:`2 \\leq m \\leq N` is the highest correction level supplied
+        (missing higher levels are zero). Levels are concatenated in order,
+        and within level :math:`k` the entry for chain
         :math:`(i_1, \\ldots, i_k)` lives at flat index
         :math:`i_1 d^{k-1} + i_2 d^{k-2} + \\cdots + i_k`. Passing ``None``
         (default) or an empty array is equivalent to all-zero correction. Indices

--- a/pysiglib/branched_sig_backprop.py
+++ b/pysiglib/branched_sig_backprop.py
@@ -70,8 +70,8 @@ def branched_sig_backprop(
     :type tree_order: str
     :param planar: If True, backpropagate through planar branched signature.
     :type planar: bool
-    :param correction: The same per-segment correction supplied to
-        the forward call (see :func:`branched_sig` for layout and semantics).
+    :param correction: The same correction supplied to the forward call
+        (see :func:`branched_sig` for layout and semantics).
         Treated as a constant: no derivatives are returned with respect to
         ``correction``. Cannot be combined with ``lead_lag=True``.
     :type correction: numpy.ndarray | torch.tensor | None

--- a/pysiglib/branched_sig_backprop.py
+++ b/pysiglib/branched_sig_backprop.py
@@ -70,7 +70,7 @@ def branched_sig_backprop(
     :type tree_order: str
     :param planar: If True, backpropagate through planar branched signature.
     :type planar: bool
-    :param correction: The same constant correction supplied to
+    :param correction: The same per-segment correction supplied to
         the forward call (see :func:`branched_sig` for layout and semantics).
         Treated as a constant: no derivatives are returned with respect to
         ``correction``. Cannot be combined with ``lead_lag=True``.
@@ -100,8 +100,9 @@ def branched_sig_backprop(
         path = np.zeros((n_steps + 1, d))
         path[1:] = np.cumsum(rng.normal(0, np.sqrt(dt), (n_steps, d)), axis=0)
 
-        # Ito level-2 correction: dt * Sigma flattened (Sigma = I here).
-        correction = (np.eye(d) * dt).flatten()
+        # Ito level-2 correction: one dt * Sigma row per path segment.
+        correction = np.broadcast_to(
+            (np.eye(d) * dt).reshape(1, -1), (n_steps, d * d)).copy()
 
         pysiglib.prepare_branched_sig(d, N)
         bsig = pysiglib.branched_sig(
@@ -144,7 +145,8 @@ def branched_sig_backprop(
             sig_data.sig_ptr[1], sig_data.sig_ptr[0],
             path_data.batch_size, dimension, path_data.data_length, degree, n_jobs,
             path_data.time_aug, path_data.lead_lag, path_data.end_time, planar, scalar_term,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     else:
         _check_cuda_num_trees(aug_dimension, degree, planar, "branched_sig_backprop")
         err_code = CUSIG_BRANCHED_SIG_BACKPROP_CUDA[path_data.dtype](
@@ -152,7 +154,8 @@ def branched_sig_backprop(
             sig_data.sig_ptr[1], sig_data.sig_ptr[0],
             path_data.batch_size, dimension, path_data.data_length, degree,
             path_data.time_aug, path_data.lead_lag, path_data.end_time, planar, scalar_term,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_backprop: " + err_msg(err_code))
     return result.data

--- a/pysiglib/data_handlers.py
+++ b/pysiglib/data_handlers.py
@@ -177,12 +177,14 @@ class PathInputHandler:
 
 class CorrectionInputHandler:
     """
-    Handle flat constant correction levels for signature APIs.
+    Handle per-segment correction levels for signature APIs.
     """
     def __init__(self, correction, path_data, degree):
         self.correction = None
         self.length = 0
         self.data_ptr = None
+        self.batch_stride = 0
+        self.segment_stride = 0
 
         if correction is None:
             return
@@ -193,9 +195,6 @@ class CorrectionInputHandler:
 
         self.correction = ensure_own_contiguous_storage(correction)
         check_dtype(self.correction, "correction")
-
-        if len(self.correction.shape) != 1:
-            raise ValueError("correction must be a 1D array")
 
         if isinstance(self.correction, np.ndarray):
             self.dtype = str(self.correction.dtype)
@@ -212,9 +211,26 @@ class CorrectionInputHandler:
         if self.device != path_data.device:
             raise ValueError("correction and path must be on the same device")
 
-        self.length = self.correction.shape[0]
-        if self.length != 0 and path_data.lead_lag:
+        if (self.correction.size if isinstance(self.correction, np.ndarray) else self.correction.numel()) == 0:
+            return
+
+        if path_data.lead_lag:
             raise ValueError("correction cannot be used with lead_lag=True")
+
+        if len(self.correction.shape) == 0:
+            raise ValueError(
+                "correction shape must be path.shape[:-2] + (path.shape[-2] - 1, L)"
+            )
+        expected_shape = (*path_data.batch_shape, max(path_data.data_length - 1, 0), self.correction.shape[-1])
+        if tuple(self.correction.shape) != expected_shape:
+            raise ValueError(
+                "correction shape must be " + str(expected_shape) +
+                " for path shape " + str(tuple(path_data.path.shape))
+            )
+        self.length = self.correction.shape[-1]
+        self.batch_stride = max(path_data.data_length - 1, 0) * self.length
+        self.segment_stride = self.length
+
         _infer_correction_degree(path_data.data_dimension, degree, self.length)
 
 def _infer_correction_degree(dimension, degree, length):

--- a/pysiglib/data_handlers.py
+++ b/pysiglib/data_handlers.py
@@ -177,7 +177,7 @@ class PathInputHandler:
 
 class CorrectionInputHandler:
     """
-    Handle per-segment correction levels for signature APIs.
+    Handle correction levels for signature APIs.
     """
     def __init__(self, correction, path_data, degree):
         self.correction = None
@@ -217,19 +217,32 @@ class CorrectionInputHandler:
         if path_data.lead_lag:
             raise ValueError("correction cannot be used with lead_lag=True")
 
-        if len(self.correction.shape) == 0:
+        corr_shape = tuple(self.correction.shape)
+        if len(corr_shape) == 0:
             raise ValueError(
-                "correction shape must be path.shape[:-2] + (path.shape[-2] - 1, L)"
+                "correction shape must be (C,), (path.shape[-2] - 1, C), or "
+                "path.shape[:-2] + (path.shape[-2] - 1, C)"
             )
-        expected_shape = (*path_data.batch_shape, max(path_data.data_length - 1, 0), self.correction.shape[-1])
-        if tuple(self.correction.shape) != expected_shape:
-            raise ValueError(
-                "correction shape must be " + str(expected_shape) +
-                " for path shape " + str(tuple(path_data.path.shape))
-            )
-        self.length = self.correction.shape[-1]
-        self.batch_stride = max(path_data.data_length - 1, 0) * self.length
-        self.segment_stride = self.length
+
+        segments = max(path_data.data_length - 1, 0)
+        if len(corr_shape) == 1:
+            self.length = corr_shape[0]
+            self.batch_stride = 0
+            self.segment_stride = 0
+        elif len(corr_shape) == 2 and corr_shape[0] == segments:
+            self.length = corr_shape[1]
+            self.batch_stride = 0
+            self.segment_stride = self.length
+        else:
+            expected_shape = (*path_data.batch_shape, segments, corr_shape[-1])
+            if corr_shape != expected_shape:
+                raise ValueError(
+                    "correction shape must be (C,), (path.shape[-2] - 1, C), or " +
+                    str(expected_shape) + " for path shape " + str(tuple(path_data.path.shape))
+                )
+            self.length = corr_shape[-1]
+            self.batch_stride = segments * self.length
+            self.segment_stride = self.length
 
         _infer_correction_degree(path_data.data_dimension, degree, self.length)
 

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -168,20 +168,36 @@ def _validate_shape(path) -> None:
 
 
 def _prepare_correction_jax(correction, path, degree: int, lead_lag: bool):
+    """Validate ``correction`` against ``path`` and return a jax array.
+
+    Non-empty correction must have shape
+    ``path.shape[:-2] + (path.shape[-2] - 1, L)``.
+    """
     if correction is None:
         return jnp.empty((0,), dtype=path.dtype)
 
     correction = jnp.asarray(correction)
-    if correction.ndim != 1:
-        raise ValueError("correction must be a 1D array")
     if correction.dtype != path.dtype:
         raise TypeError("correction and path must have the same dtype")
-    if correction.shape[0] != 0 and lead_lag:
+
+    if correction.size == 0:
+        return jnp.empty((0,), dtype=path.dtype)
+
+    if lead_lag:
         raise ValueError("correction cannot be used with lead_lag=True")
 
-    _infer_correction_degree(path.shape[-1], degree, correction.shape[0])
-    return correction
+    if correction.ndim == 0:
+        raise ValueError("correction shape must be path.shape[:-2] + (path.shape[-2] - 1, L)")
 
+    expected_shape = path.shape[:-2] + (max(path.shape[-2] - 1, 0), correction.shape[-1])
+    if correction.shape != expected_shape:
+        raise ValueError(
+            "correction shape must be " + str(expected_shape) +
+            " for path shape " + str(path.shape)
+        )
+
+    _infer_correction_degree(path.shape[-1], degree, correction.shape[-1])
+    return correction
 
 @partial(jax.custom_vjp, nondiff_argnums=(2, 3, 4, 5, 6, 7))
 def _sig(path, correction, degree, time_aug, lead_lag, end_time, horner, n_jobs):

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -170,8 +170,8 @@ def _validate_shape(path) -> None:
 def _prepare_correction_jax(correction, path, degree: int, lead_lag: bool):
     """Validate ``correction`` against ``path`` and return a jax array.
 
-    Non-empty correction must have shape
-    ``path.shape[:-2] + (path.shape[-2] - 1, L)``.
+    Non-empty correction must have shape ``(C,)``, ``(path.shape[-2] - 1, C)``,
+    or ``path.shape[:-2] + (path.shape[-2] - 1, C)``.
     """
     if correction is None:
         return jnp.empty((0,), dtype=path.dtype)
@@ -187,16 +187,26 @@ def _prepare_correction_jax(correction, path, degree: int, lead_lag: bool):
         raise ValueError("correction cannot be used with lead_lag=True")
 
     if correction.ndim == 0:
-        raise ValueError("correction shape must be path.shape[:-2] + (path.shape[-2] - 1, L)")
-
-    expected_shape = path.shape[:-2] + (max(path.shape[-2] - 1, 0), correction.shape[-1])
-    if correction.shape != expected_shape:
         raise ValueError(
-            "correction shape must be " + str(expected_shape) +
-            " for path shape " + str(path.shape)
+            "correction shape must be (C,), (path.shape[-2] - 1, C), or "
+            "path.shape[:-2] + (path.shape[-2] - 1, C)"
         )
 
-    _infer_correction_degree(path.shape[-1], degree, correction.shape[-1])
+    segments = max(path.shape[-2] - 1, 0)
+    if correction.ndim == 1:
+        length = correction.shape[0]
+    elif correction.ndim == 2 and correction.shape[0] == segments:
+        length = correction.shape[1]
+    else:
+        expected_shape = path.shape[:-2] + (segments, correction.shape[-1])
+        if correction.shape != expected_shape:
+            raise ValueError(
+                "correction shape must be (C,), (path.shape[-2] - 1, C), or " +
+                str(expected_shape) + " for path shape " + str(path.shape)
+            )
+        length = correction.shape[-1]
+
+    _infer_correction_degree(path.shape[-1], degree, length)
     return correction
 
 @partial(jax.custom_vjp, nondiff_argnums=(2, 3, 4, 5, 6, 7))

--- a/pysiglib/load_siglib.py
+++ b/pysiglib/load_siglib.py
@@ -391,10 +391,10 @@ CPSIG.sig_coef_backprop_d.restype = c_int
 # signature
 ######################################################
 
-CPSIG.signature_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, c_int, POINTER(c_float), c_uint64)
+CPSIG.signature_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, c_int, POINTER(c_float), c_uint64, c_uint64, c_uint64)
 CPSIG.signature_f.restype = c_int
 
-CPSIG.signature_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, c_int, POINTER(c_double), c_uint64)
+CPSIG.signature_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, c_int, POINTER(c_double), c_uint64, c_uint64, c_uint64)
 CPSIG.signature_d.restype = c_int
 
 if BUILT_WITH_CUDA:
@@ -402,20 +402,20 @@ if BUILT_WITH_CUDA:
     # signature_cuda
     ######################################################
 
-    CUSIG.signature_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64)
+    CUSIG.signature_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64, c_uint64, c_uint64)
     CUSIG.signature_cuda_f.restype = c_int
 
-    CUSIG.signature_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64)
+    CUSIG.signature_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
     CUSIG.signature_cuda_d.restype = c_int
 
 ######################################################
 # sig_backprop
 ######################################################
 
-CPSIG.sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_int, POINTER(c_float), c_uint64)
+CPSIG.sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_int, POINTER(c_float), c_uint64, c_uint64, c_uint64)
 CPSIG.sig_backprop_f.restype = c_int
 
-CPSIG.sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_int, POINTER(c_double), c_uint64)
+CPSIG.sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_int, POINTER(c_double), c_uint64, c_uint64, c_uint64)
 CPSIG.sig_backprop_d.restype = c_int
 
 if BUILT_WITH_CUDA:
@@ -423,10 +423,10 @@ if BUILT_WITH_CUDA:
     # sig_backprop_cuda
     ######################################################
 
-    CUSIG.sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, POINTER(c_float), c_uint64)
+    CUSIG.sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, POINTER(c_float), c_uint64, c_uint64, c_uint64)
     CUSIG.sig_backprop_cuda_f.restype = c_int
 
-    CUSIG.sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, POINTER(c_double), c_uint64)
+    CUSIG.sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
     CUSIG.sig_backprop_cuda_d.restype = c_int
 
 ######################################################
@@ -522,10 +522,10 @@ CPSIG.branched_sig_length.argtypes = (c_uint64, c_uint64, c_bool)
 CPSIG.branched_sig_length.restype = c_uint64
 
 
-CPSIG.branched_sig_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64)
+CPSIG.branched_sig_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64, c_uint64, c_uint64)
 CPSIG.branched_sig_f.restype = c_int
 
-CPSIG.branched_sig_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64)
+CPSIG.branched_sig_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
 CPSIG.branched_sig_d.restype = c_int
 
 
@@ -554,18 +554,18 @@ CPSIG.branched_sig_combine_backprop_d.argtypes = (POINTER(c_double), POINTER(c_d
 CPSIG.branched_sig_combine_backprop_d.restype = c_int
 
 
-CPSIG.branched_sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64)
+CPSIG.branched_sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64, c_uint64, c_uint64)
 CPSIG.branched_sig_backprop_f.restype = c_int
 
-CPSIG.branched_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64)
+CPSIG.branched_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
 CPSIG.branched_sig_backprop_d.restype = c_int
 
 if BUILT_WITH_CUDA:
 
-    CUSIG.branched_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64)
+    CUSIG.branched_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64, c_uint64, c_uint64)
     CUSIG.branched_sig_cuda_f.restype = c_int
 
-    CUSIG.branched_sig_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64)
+    CUSIG.branched_sig_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
     CUSIG.branched_sig_cuda_d.restype = c_int
 
     CUSIG.branched_sig_combine_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_bool, c_bool)
@@ -578,10 +578,10 @@ if BUILT_WITH_CUDA:
     CUSIG.branched_sig_combine_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_bool, c_bool)
     CUSIG.branched_sig_combine_backprop_cuda_d.restype = c_int
 
-    CUSIG.branched_sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64)
+    CUSIG.branched_sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_float, c_bool, c_bool, POINTER(c_float), c_uint64, c_uint64, c_uint64)
     CUSIG.branched_sig_backprop_cuda_f.restype = c_int
 
-    CUSIG.branched_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64)
+    CUSIG.branched_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
     CUSIG.branched_sig_backprop_cuda_d.restype = c_int
 
     CUSIG.branched_sig_to_log_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_bool, c_bool)

--- a/pysiglib/log_sig.py
+++ b/pysiglib/log_sig.py
@@ -355,7 +355,8 @@ def log_sig(
     :type scalar_term: bool
     :param correction: Optional per-segment correction of level
         :math:`\\geq 2` added locally before exponentiating each path segment.
-        See :func:`sig` for the row layout. For non-Lie correction such as
+        See :func:`sig` for the accepted constant, shared per-segment, and
+        batch-specific layouts. For non-Lie correction such as
         Ito level-2 diagonal terms, use ``method=0`` to retain the full tensor
         logarithm. Cannot be combined with ``lead_lag=True``.
     :type correction: numpy.ndarray | torch.tensor | None

--- a/pysiglib/log_sig.py
+++ b/pysiglib/log_sig.py
@@ -353,9 +353,9 @@ def log_sig(
         Only affects method ``0`` (expanded) output; methods ``1`` and ``2`` produce
         log-sig-shaped output with no scalar term.
     :type scalar_term: bool
-    :param correction: Optional constant correction of level
+    :param correction: Optional per-segment correction of level
         :math:`\\geq 2` added locally before exponentiating each path segment.
-        See :func:`sig` for the flat layout. For non-Lie correction such as
+        See :func:`sig` for the row layout. For non-Lie correction such as
         Ito level-2 diagonal terms, use ``method=0`` to retain the full tensor
         logarithm. Cannot be combined with ``lead_lag=True``.
     :type correction: numpy.ndarray | torch.tensor | None
@@ -401,8 +401,8 @@ def log_sig(
         path = np.zeros((n_steps + 1, d))
         path[1:] = np.cumsum(rng.normal(0, np.sqrt(dt), (n_steps, d)), axis=0)
 
-        # Ito level-2 correction: dt * Sigma flattened (Sigma = I here).
-        correction = (np.eye(d) * dt).flatten()
+        # Ito level-2 correction: one dt * Sigma row per path segment.
+        correction = np.broadcast_to((np.eye(d) * dt).reshape(1, -1), (n_steps, d * d))
 
         ito_log_sig = pysiglib.log_sig(
             path, N, correction=correction, end_time=T, method=0)

--- a/pysiglib/sig.py
+++ b/pysiglib/sig.py
@@ -177,11 +177,15 @@ def sig(
             \\exp \\left( \\sum_i \\Delta x_i\\, e_i + \\sum_{k=2}^{m} \\sum_{i_1, \\ldots, i_k} c^{(k)}_{i_1 \\ldots i_k}\\, e_{i_1} \\otimes \\cdots \\otimes e_{i_k} \\right),
 
         where :math:`(e_{i_1} \\otimes \\cdots \\otimes e_{i_k})` is the
-        tensor basis. ``correction`` must have shape
-        ``path.shape[:-2] + (path.shape[-2] - 1, L)``, where
-        :math:`L = d^2 + d^3 + \\cdots + d^m` and :math:`d` is the original
-        path dimension and :math:`2 \\leq m \\leq N` is the highest
-        correction level supplied (missing higher levels are zero). Levels are
+        tensor basis. A non-empty ``correction`` may have shape ``(C,)``
+        for one constant correction shared by every segment and batch item,
+        ``(path.shape[-2] - 1, C)`` for one correction row per segment shared
+        by the batch, or ``path.shape[:-2] + (path.shape[-2] - 1, C)`` for
+        batch-specific segment corrections. Here ``C`` is the correction
+        width, with :math:`C = d^2 + d^3 + \\cdots + d^m`, where
+        :math:`d` is the original
+        path dimension and :math:`2 \\leq m \\leq N` is the highest correction
+        level supplied (missing higher levels are zero). Levels are
         concatenated in each row, and within level :math:`k` the entry for
         index tuple :math:`(i_1, \\ldots, i_k)` lives at flat index
         :math:`i_1 d^{k-1} + i_2 d^{k-2} + \\cdots + i_k`. Passing ``None``

--- a/pysiglib/sig.py
+++ b/pysiglib/sig.py
@@ -165,11 +165,11 @@ def sig(
     :param scalar_term: If True, the output includes the leading constant 1 at index 0
         (the empty-word term). If False (default), this leading element is stripped from the output.
     :type scalar_term: bool
-    :param correction: Optional constant correction of level
-        :math:`\\geq 2` added to the path increment at every path
-        segment before exponentiation. The level-1 part of the local
+    :param correction: Optional per-segment correction of level
+        :math:`\\geq 2` added to each path increment before exponentiation.
+        The level-1 part of the local
         lift is the segment's path increment :math:`\\Delta x`, the
-        higher levels come from this constant, and the local signature
+        higher levels come from the corresponding correction row, and the local signature
         on each segment is
 
         .. math::
@@ -177,11 +177,12 @@ def sig(
             \\exp \\left( \\sum_i \\Delta x_i\\, e_i + \\sum_{k=2}^{m} \\sum_{i_1, \\ldots, i_k} c^{(k)}_{i_1 \\ldots i_k}\\, e_{i_1} \\otimes \\cdots \\otimes e_{i_k} \\right),
 
         where :math:`(e_{i_1} \\otimes \\cdots \\otimes e_{i_k})` is the
-        tensor basis. ``correction`` is a flat 1D array of length
-        :math:`d^2 + d^3 + \\cdots + d^m`, where :math:`d` is the original
+        tensor basis. ``correction`` must have shape
+        ``path.shape[:-2] + (path.shape[-2] - 1, L)``, where
+        :math:`L = d^2 + d^3 + \\cdots + d^m` and :math:`d` is the original
         path dimension and :math:`2 \\leq m \\leq N` is the highest
         correction level supplied (missing higher levels are zero). Levels are
-        concatenated in order, and within level :math:`k` the entry for
+        concatenated in each row, and within level :math:`k` the entry for
         index tuple :math:`(i_1, \\ldots, i_k)` lives at flat index
         :math:`i_1 d^{k-1} + i_2 d^{k-2} + \\cdots + i_k`. Passing ``None``
         or an empty array is equivalent to all-zero correction. With
@@ -248,9 +249,8 @@ def sig(
         path = np.zeros((n_steps + 1, d))
         path[1:] = np.cumsum(rng.normal(0, np.sqrt(dt), (n_steps, d)), axis=0)
 
-        # Ito level-2 correction: dt * Sigma flattened. Here Sigma = I so the
-        # diagonal entries c^(2)_ii are dt and off-diagonals are zero.
-        correction = (np.eye(d) * dt).flatten()
+        # Ito level-2 correction: one dt * Sigma row per path segment.
+        correction = np.broadcast_to((np.eye(d) * dt).reshape(1, -1), (n_steps, d * d))
 
         ito_sig = pysiglib.sig(path, N, correction=correction, end_time=T)
         print(ito_sig)
@@ -277,13 +277,15 @@ def sig(
             data.data_ptr, result.data_ptr, data.batch_size,
             data.data_dimension, data.data_length, degree,
             data.time_aug, data.lead_lag, data.end_time, horner, scalar_term, n_jobs,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     else:
         err_code = CUSIG_SIGNATURE_CUDA[data.dtype](
             data.data_ptr, result.data_ptr, data.batch_size,
             data.data_dimension, data.data_length, degree,
             data.time_aug, data.lead_lag, data.end_time, horner, scalar_term,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     if err_code:
         raise Exception("Error in pysiglib.sig: " + err_msg(err_code))
 
@@ -301,4 +303,3 @@ def sig(
         )
 
     return result.data
-

--- a/pysiglib/sig_backprop.py
+++ b/pysiglib/sig_backprop.py
@@ -160,8 +160,8 @@ def sig_backprop(
     :type lead_lag: bool
     :param end_time: End time for time-augmentation, :math:`t_L`.
     :type end_time: float
-    :param correction: The same per-segment correction supplied to
-        the forward ``sig`` call. Treated as a constant: no derivatives are
+    :param correction: The same correction supplied to the forward ``sig`` call.
+        Treated as a constant: no derivatives are
         returned with respect to ``correction``. Cannot be combined with
         ``lead_lag=True``.
     :type correction: numpy.ndarray | torch.tensor | None

--- a/pysiglib/sig_backprop.py
+++ b/pysiglib/sig_backprop.py
@@ -160,7 +160,7 @@ def sig_backprop(
     :type lead_lag: bool
     :param end_time: End time for time-augmentation, :math:`t_L`.
     :type end_time: float
-    :param correction: The same constant correction supplied to
+    :param correction: The same per-segment correction supplied to
         the forward ``sig`` call. Treated as a constant: no derivatives are
         returned with respect to ``correction``. Cannot be combined with
         ``lead_lag=True``.
@@ -237,14 +237,16 @@ def sig_backprop(
             sig_data.sig_ptr[1], sig_data.sig_ptr[0],
             path_data.batch_size, path_data.data_dimension, path_data.data_length,
             degree, path_data.time_aug, path_data.lead_lag, path_data.end_time, scalar_term, n_jobs,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     else:
         err_code = CUSIG_SIG_BACKPROP_CUDA[path_data.dtype](
             path_data.data_ptr, result.data_ptr,
             sig_data.sig_ptr[1], sig_data.sig_ptr[0],
             path_data.batch_size, path_data.data_dimension, path_data.data_length,
             degree, path_data.time_aug, path_data.lead_lag, path_data.end_time, scalar_term,
-            correction_data.data_ptr, correction_data.length)
+            correction_data.data_ptr, correction_data.length,
+            correction_data.batch_stride, correction_data.segment_stride)
     if err_code:
         raise Exception("Error in pysiglib.sig_backprop: " + err_msg(err_code))
     return result.data

--- a/siglib/cpsig/cp_branched_signature.cpp
+++ b/siglib/cpsig/cp_branched_signature.cpp
@@ -25,12 +25,12 @@ extern "C" {
 		SAFE_CALL(prepare_branched_sig_cache(dimension, max_nodes, use_disk, planar));
 	}
 
-	CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(branched_signature_<float>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(branched_signature_<float>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
-	CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(branched_signature_<double>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(branched_signature_<double>(path, out, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 	CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar, bool scalar_term) noexcept {
@@ -49,12 +49,12 @@ extern "C" {
 		SAFE_CALL(branched_sig_combine_backprop_<double>(bsig1, bsig2, derivs, out1, out2, batch_size, dimension, max_nodes, n_jobs, planar, scalar_term));
 	}
 
-	CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(branched_sig_backprop_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(branched_sig_backprop_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
-	CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(branched_sig_backprop_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(branched_sig_backprop_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, n_jobs, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 }

--- a/siglib/cpsig/cp_branched_signature.h
+++ b/siglib/cpsig/cp_branched_signature.h
@@ -178,10 +178,12 @@ template<std::floating_point T>
 void branched_correction_(
 	const T* increment,
 	T* out,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t data_dimension,
 	const BranchedSigCache& cache
 ) {
-	std::memcpy(out, local_log_base, cache.total_length * sizeof(T));
+	build_correction_base_(out, correction, correction_len, data_dimension, cache);
 
 	if (cache.max_nodes >= 1) {
 		for (uint64_t d = 0; d < cache.dimension; ++d) {
@@ -225,17 +227,20 @@ void local_correction_branched_sig_(
 	T* local_log,
 	T* power,
 	T* next_power,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t data_dimension,
 	const BranchedSigCache& cache
 ) {
 	if (cache.max_nodes <= 2) {
 		linear_branched_sig_(increment, out, cache);
+		build_correction_base_(local_log, correction, correction_len, data_dimension, cache);
 		for (uint64_t i = 1; i < cache.total_length; ++i)
-			out[i] += local_log_base[i];
+			out[i] += local_log[i];
 		return;
 	}
 
-	branched_correction_(increment, local_log, local_log_base, cache);
+	branched_correction_(increment, local_log, correction, correction_len, data_dimension, cache);
 	branched_hopf_exp_(local_log, out, power, next_power, cache);
 }
 
@@ -285,12 +290,15 @@ void branched_signature_with_buffers_(
 	T* local_log,
 	T* power,
 	T* next_power,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t correction_segment_stride,
 	bool has_correction,
 	const BranchedSigCache& cache
 ) {
 	uint64_t total_len = cache.total_length;
 	uint64_t dim = path.dimension();
+	uint64_t data_dim = path.data_dimension();
 	uint64_t len = path.length();
 
 	if (len <= 1) {
@@ -308,7 +316,7 @@ void branched_signature_with_buffers_(
 		linear_branched_sig_(increment, out, cache);
 	} else {
 		local_correction_branched_sig_(increment, out, local_log, power, next_power,
-			local_log_base, cache);
+			correction, correction_len, data_dim, cache);
 	}
 
 	for (uint64_t seg = 1; seg < len - 1; ++seg) {
@@ -322,8 +330,9 @@ void branched_signature_with_buffers_(
 		if (!has_correction) {
 			linear_branched_sig_(increment, temp, cache);
 		} else {
+			const T* seg_correction = correction + seg * correction_segment_stride;
 			local_correction_branched_sig_(increment, temp, local_log, power, next_power,
-				local_log_base, cache);
+				seg_correction, correction_len, data_dim, cache);
 		}
 		butcher_product_inplace_(out, temp, cache);
 	}
@@ -345,7 +354,9 @@ void branched_signature_(
 	bool planar = false,
 	bool scalar_term = true,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	validate_correction_len_(dimension, max_nodes, correction_len);
 	if (correction == nullptr && correction_len != 0)
@@ -353,29 +364,26 @@ void branched_signature_(
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
 	const bool has_correction = correction_len != 0;
+	if (has_correction && correction_segment_stride == 0)
+		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	uint64_t aug_dim = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
 	uint64_t flat_path_length = length * dimension;
 	uint64_t out_stride = scalar_term ? total_len : total_len - 1;
 
-	std::vector<T> local_log_base;
-	if (has_correction) {
-		local_log_base.resize(total_len);
-		build_correction_base_(local_log_base.data(), correction, correction_len,
-			dimension, cache);
-	}
-
 	auto compute_one = [&](const T* path_ptr, T* out_ptr, T* increment, T* temp,
-		T* local_log, T* power, T* next_power) {
+		T* local_log, T* power, T* next_power, const T* correction_ptr) {
 		Path<T> path_obj(path_ptr, dimension, length, time_aug, lead_lag, end_time);
 		if (scalar_term) {
 			branched_signature_with_buffers_(path_obj, out_ptr, increment, temp,
-				local_log, power, next_power, local_log_base.data(), has_correction, cache);
+				local_log, power, next_power, correction_ptr, correction_len,
+				correction_segment_stride, has_correction, cache);
 		} else {
 			std::vector<T> buf(total_len);
 			branched_signature_with_buffers_(path_obj, buf.data(), increment, temp,
-				local_log, power, next_power, local_log_base.data(), has_correction, cache);
+				local_log, power, next_power, correction_ptr, correction_len,
+				correction_segment_stride, has_correction, cache);
 			std::memcpy(out_ptr, buf.data() + 1, (total_len - 1) * sizeof(T));
 		}
 	};
@@ -394,8 +402,9 @@ void branched_signature_(
 		const T* path_ptr = path;
 		T* out_ptr = out;
 		for (uint64_t b = 0; b < batch_size; ++b) {
+			const T* correction_ptr = has_correction ? correction + b * correction_batch_stride : nullptr;
 			compute_one(path_ptr, out_ptr, increment.get(), temp.get(),
-				local_log.get(), power.get(), next_power.get());
+				local_log.get(), power.get(), next_power.get(), correction_ptr);
 			path_ptr += flat_path_length;
 			out_ptr += out_stride;
 		}
@@ -423,8 +432,10 @@ void branched_signature_(
 					next_power = std::make_unique<T[]>(total_len);
 				}
 				for (uint64_t b = t; b < batch_size; b += max_threads) {
+					const T* correction_ptr = has_correction ? correction + b * correction_batch_stride : nullptr;
 					compute_one(path + b * flat_path_length, out + b * out_stride,
-						increment.get(), temp.get(), local_log.get(), power.get(), next_power.get());
+						increment.get(), temp.get(), local_log.get(), power.get(), next_power.get(),
+						correction_ptr);
 				}
 			});
 		}
@@ -696,7 +707,9 @@ void local_log_bsig_deriv_to_increment_deriv_(
 	T* powers,
 	T* power_derivs,
 	T* d_correction,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t data_dimension,
 	const BranchedSigCache& cache
 ) {
 	if (cache.max_nodes <= 2) {
@@ -708,7 +721,7 @@ void local_log_bsig_deriv_to_increment_deriv_(
 	std::memset(power_derivs, 0, cache.max_nodes * total_len * sizeof(T));
 	std::memset(d_correction, 0, total_len * sizeof(T));
 
-	branched_correction_(increment, local_log, local_log_base, cache);
+	branched_correction_(increment, local_log, correction, correction_len, data_dimension, cache);
 	std::memcpy(powers, local_log, total_len * sizeof(T));
 	for (uint64_t k = 2; k <= cache.max_nodes; ++k) {
 		branched_hopf_convolution_(powers + (k - 2) * total_len, local_log,
@@ -758,7 +771,9 @@ void branched_sig_backprop_inplace_(
 	T* powers,
 	T* power_derivs,
 	T* d_correction,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t correction_segment_stride,
 	bool has_correction,
 	const BranchedSigCache& cache
 ) {
@@ -781,8 +796,9 @@ void branched_sig_backprop_inplace_(
 			if (!has_correction) {
 				linear_branched_sig_(increment, temp_Y, cache);
 			} else {
+				const T* seg_correction = correction + static_cast<uint64_t>(seg) * correction_segment_stride;
 				local_correction_branched_sig_(increment, temp_Y, local_log, power, next_power,
-					local_log_base, cache);
+					seg_correction, correction_len, data_dim, cache);
 			}
 
 			if (seg > 0)
@@ -796,8 +812,10 @@ void branched_sig_backprop_inplace_(
 			if (!has_correction) {
 				linear_bsig_deriv_to_increment_deriv_(local_derivs, increment, inc_derivs, dim, cache);
 			} else {
+				const T* seg_correction = correction + static_cast<uint64_t>(seg) * correction_segment_stride;
 				local_log_bsig_deriv_to_increment_deriv_(local_derivs, increment, inc_derivs,
-					local_log, powers, power_derivs, d_correction, local_log_base, cache);
+					local_log, powers, power_derivs, d_correction, seg_correction,
+					correction_len, data_dim, cache);
 			}
 
 			T* pos = out + (seg + 1) * data_dim;
@@ -823,8 +841,9 @@ void branched_sig_backprop_inplace_(
 			if (!has_correction) {
 				linear_branched_sig_(increment, temp_Y, cache);
 			} else {
+				const T* seg_correction = correction + static_cast<uint64_t>(seg) * correction_segment_stride;
 				local_correction_branched_sig_(increment, temp_Y, local_log, power, next_power,
-					local_log_base, cache);
+					seg_correction, correction_len, data_dim, cache);
 			}
 
 			if (seg > 0)
@@ -838,8 +857,10 @@ void branched_sig_backprop_inplace_(
 			if (!has_correction) {
 				linear_bsig_deriv_to_increment_deriv_(local_derivs, increment, inc_derivs, dim, cache);
 			} else {
+				const T* seg_correction = correction + static_cast<uint64_t>(seg) * correction_segment_stride;
 				local_log_bsig_deriv_to_increment_deriv_(local_derivs, increment, inc_derivs,
-					local_log, powers, power_derivs, d_correction, local_log_base, cache);
+					local_log, powers, power_derivs, d_correction, seg_correction,
+					correction_len, data_dim, cache);
 			}
 
 			T* s = parity ? inc_derivs + data_dim : inc_derivs;
@@ -874,7 +895,9 @@ void branched_sig_backprop_(
 	bool planar = false,
 	bool scalar_term = true,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	validate_correction_len_(dimension, max_nodes, correction_len);
 	if (correction == nullptr && correction_len != 0)
@@ -882,18 +905,13 @@ void branched_sig_backprop_(
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
 	const bool has_correction = correction_len != 0;
+	if (has_correction && correction_segment_stride == 0)
+		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	uint64_t aug_dim = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
 	uint64_t flat_path_length = length * dimension;
 	uint64_t in_stride = scalar_term ? total_len : total_len - 1;
-
-	std::vector<T> local_log_base;
-	if (has_correction) {
-		local_log_base.resize(total_len);
-		build_correction_base_(local_log_base.data(), correction, correction_len,
-			dimension, cache);
-	}
 
 	auto work = [&](uint64_t b, T* increment, T* temp_Y, T* local_derivs, T* inc_derivs,
 		T* local_log, T* power, T* next_power, T* powers, T* power_derivs, T* d_correction) {
@@ -919,7 +937,8 @@ void branched_sig_backprop_(
 			path_obj, out_ptr, derivs_copy.get(), bsig_copy.get(),
 			increment, temp_Y, local_derivs, inc_derivs,
 			local_log, power, next_power, powers, power_derivs, d_correction,
-			local_log_base.data(), has_correction, cache);
+			has_correction ? correction + b * correction_batch_stride : nullptr,
+			correction_len, correction_segment_stride, has_correction, cache);
 	};
 
 	if (n_jobs == 1 || batch_size == 1) {

--- a/siglib/cpsig/cp_branched_signature.h
+++ b/siglib/cpsig/cp_branched_signature.h
@@ -364,8 +364,6 @@ void branched_signature_(
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
 	const bool has_correction = correction_len != 0;
-	if (has_correction && correction_segment_stride == 0)
-		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	uint64_t aug_dim = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes, planar);
 	uint64_t total_len = cache.total_length;
@@ -905,8 +903,6 @@ void branched_sig_backprop_(
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
 	const bool has_correction = correction_len != 0;
-	if (has_correction && correction_segment_stride == 0)
-		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	uint64_t aug_dim = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const auto& cache = get_branched_sig_cache(aug_dim, max_nodes, planar);
 	uint64_t total_len = cache.total_length;

--- a/siglib/cpsig/cp_signature.cpp
+++ b/siglib/cpsig/cp_signature.cpp
@@ -21,21 +21,21 @@
 extern "C" {
 
 
-	CPSIG_API int signature_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, float end_time, bool horner, bool scalar_term, int n_jobs, const float* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(signature_<float>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, n_jobs, correction, correction_len));
+	CPSIG_API int signature_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, float end_time, bool horner, bool scalar_term, int n_jobs, const float* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(signature_<float>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, n_jobs, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
-	CPSIG_API int signature_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, double end_time, bool horner, bool scalar_term, int n_jobs, const double* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(signature_<double>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, n_jobs, correction, correction_len));
+	CPSIG_API int signature_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, double end_time, bool horner, bool scalar_term, int n_jobs, const double* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(signature_<double>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, n_jobs, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 
-	CPSIG_API int sig_backprop_f(const float* path, float* out, const float* sig_derivs, const float* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, float end_time, bool scalar_term, int n_jobs, const float* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(sig_backprop_<float>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, n_jobs, correction, correction_len));
+	CPSIG_API int sig_backprop_f(const float* path, float* out, const float* sig_derivs, const float* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, float end_time, bool scalar_term, int n_jobs, const float* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(sig_backprop_<float>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, n_jobs, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
-	CPSIG_API int sig_backprop_d(const double* path, double* out, const double* sig_derivs, const double* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, double end_time, bool scalar_term, int n_jobs, const double* correction, uint64_t correction_len) noexcept {
-		SAFE_CALL(sig_backprop_<double>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, n_jobs, correction, correction_len));
+	CPSIG_API int sig_backprop_d(const double* path, double* out, const double* sig_derivs, const double* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug, bool lead_lag, double end_time, bool scalar_term, int n_jobs, const double* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		SAFE_CALL(sig_backprop_<double>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, n_jobs, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 }

--- a/siglib/cpsig/cp_signature.h
+++ b/siglib/cpsig/cp_signature.h
@@ -55,19 +55,24 @@ inline void validate_signature_correction_args_(
 	throw std::invalid_argument("correction length must be a prefix of tensor levels 2..degree");
 }
 
+// Build local_log for one segment: zero levels 0..degree, then scatter the
+// per-segment correction values (in data-dimension layout) into the augmented
+// layout at levels 2..degree. Level 1 is left zero; the caller writes the
+// path displacement there. The same function serves the constant-correction
+// case (caller passes the same `correction_segment` pointer every step).
 template<std::floating_point T>
-void build_signature_correction_base_(
-	T* out,
-	const T* correction,
+FORCE_INLINE void apply_segment_correction_(
+	T* local_log,
+	const T* correction_segment,
 	uint64_t correction_len,
 	uint64_t data_dimension,
 	uint64_t dimension,
 	uint64_t degree,
 	const uint64_t* level_index
 ) {
-	const uint64_t sig_len = ::sig_length(dimension, degree);
-	std::fill(out, out + sig_len, static_cast<T>(0));
-	if (correction == nullptr || correction_len == 0)
+	const uint64_t sig_len = level_index[degree + 1];
+	std::fill(local_log, local_log + sig_len, static_cast<T>(0));
+	if (correction_segment == nullptr || correction_len == 0)
 		return;
 
 	uint64_t offset = 0;
@@ -78,7 +83,7 @@ void build_signature_correction_base_(
 			break;
 
 		for (uint64_t word_idx = 0; word_idx < level_size; ++word_idx) {
-			const T value = correction[offset + word_idx];
+			const T value = correction_segment[offset + word_idx];
 			if (value == static_cast<T>(0))
 				continue;
 
@@ -94,15 +99,12 @@ void build_signature_correction_base_(
 				aug_word_idx = aug_word_idx * dimension + label;
 			}
 
-			out[level_index[level] + aug_word_idx] += value;
+			local_log[level_index[level] + aug_word_idx] += value;
 		}
 		offset += level_size;
 	}
 }
 
-// local_log_base has level 0 and level 1 zeroed by build_signature_correction_base_,
-// and levels 2+ are constant across segments. Memcpy once at setup, then only the
-// level-1 displacement entries change per segment.
 template<std::floating_point T>
 FORCE_INLINE void write_segment_displacement_(
 	const Point<T>& prev_pt,
@@ -119,22 +121,25 @@ void signature_correction_inplace_(
 	const Path<T>& path,
 	T* out,
 	uint64_t degree,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t segment_stride,
 	uint64_t sig_len,
 	const uint64_t* level_index
 ) {
+	const uint64_t data_dimension = path.data_dimension();
 	const uint64_t dimension = path.dimension();
 
 	auto local_log_uptr = std::make_unique<T[]>(sig_len);
 	auto local_sig_uptr = std::make_unique<T[]>(sig_len);
 	T* local_log = local_log_uptr.get();
 	T* local_sig = local_sig_uptr.get();
-	std::memcpy(local_log, local_log_base, sig_len * sizeof(T));
 
 	Point<T> prev_pt(path.begin());
 	Point<T> next_pt(path.begin());
 	++next_pt;
 
+	apply_segment_correction_(local_log, correction, correction_len, data_dimension, dimension, degree, level_index);
 	write_segment_displacement_(prev_pt, next_pt, local_log, dimension);
 	tensor_exp_<T>(local_log, out, dimension, degree);
 
@@ -144,8 +149,11 @@ void signature_correction_inplace_(
 	++prev_pt;
 	++next_pt;
 	Point<T> last_pt(path.end());
+	uint64_t step = 1;
 
-	for (; next_pt != last_pt; ++prev_pt, ++next_pt) {
+	for (; next_pt != last_pt; ++prev_pt, ++next_pt, ++step) {
+		const T* seg_corr = correction == nullptr ? nullptr : correction + step * segment_stride;
+		apply_segment_correction_(local_log, seg_corr, correction_len, data_dimension, dimension, degree, level_index);
 		write_segment_displacement_(prev_pt, next_pt, local_log, dimension);
 		tensor_exp_<T>(local_log, local_sig, dimension, degree);
 		sig_combine_inplace_(out, local_sig, degree, level_index);
@@ -495,7 +503,9 @@ void signature_(
 	bool scalar_term = true,
 	int n_jobs = 1,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 )
 {
 	//Deal with trivial cases
@@ -535,30 +545,33 @@ void signature_(
 		uint64_t* level_index = level_index_uptr.get();
 		populate_level_index(level_index, aug_dim, degree + 2);
 
-		auto local_log_base_uptr = std::make_unique<T[]>(full_len);
-		T* local_log_base = local_log_base_uptr.get();
-		build_signature_correction_base_(
-			local_log_base, correction, correction_len, dimension, aug_dim, degree, level_index);
-
 		if (scalar_term) {
-			auto sig_func = [&](const T* path_ptr, T* out_ptr) {
+			auto sig_func = [&](const T* path_ptr, const T* corr_ptr, T* out_ptr) {
 				Path<T> path_obj(path_ptr, dimension, length, time_aug, lead_lag, end_time);
-				signature_correction_inplace_(path_obj, out_ptr, degree, local_log_base, full_len, level_index);
+				signature_correction_inplace_(
+					path_obj, out_ptr, degree, corr_ptr, correction_len,
+					correction_segment_stride, full_len, level_index);
 			};
 
 			multi_threaded_batch(sig_func, batch_size, n_jobs,
-				make_batch(path, flat_path_length), make_batch(out, full_len));
+				make_batch(path, flat_path_length),
+				make_batch(correction, correction_batch_stride),
+				make_batch(out, full_len));
 		}
 		else {
-			auto sig_func = [&](const T* path_ptr, T* out_ptr) {
+			auto sig_func = [&](const T* path_ptr, const T* corr_ptr, T* out_ptr) {
 				std::vector<T> buf(full_len);
 				Path<T> path_obj(path_ptr, dimension, length, time_aug, lead_lag, end_time);
-				signature_correction_inplace_(path_obj, buf.data(), degree, local_log_base, full_len, level_index);
+				signature_correction_inplace_(
+					path_obj, buf.data(), degree, corr_ptr, correction_len,
+					correction_segment_stride, full_len, level_index);
 				std::memcpy(out_ptr, buf.data() + 1, (full_len - 1) * sizeof(T));
 			};
 
 			multi_threaded_batch(sig_func, batch_size, n_jobs,
-				make_batch(path, flat_path_length), make_batch(out, stride));
+				make_batch(path, flat_path_length),
+				make_batch(correction, correction_batch_stride),
+				make_batch(out, stride));
 		}
 		return;
 	}
@@ -622,7 +635,9 @@ void sig_backprop_correction_inplace_(
 	T* sig,
 	uint64_t degree,
 	uint64_t sig_len,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t segment_stride,
 	const uint64_t* level_index
 );
 
@@ -642,7 +657,9 @@ void sig_backprop_(
 	bool scalar_term = true,
 	int n_jobs = 1,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 )
 {
 	std::fill(out, out + length * dimension * batch_size, static_cast<T>(0.));
@@ -684,33 +701,39 @@ void sig_backprop_(
 
 	const bool has_correction = correction_len != 0;
 	std::unique_ptr<uint64_t[]> level_index_uptr;
-	std::unique_ptr<T[]> local_log_base_uptr;
 	if (has_correction) {
 		level_index_uptr = std::make_unique<uint64_t[]>(degree + 2);
 		populate_level_index(level_index_uptr.get(), dummy_path_obj.dimension(), degree + 2);
-		local_log_base_uptr = std::make_unique<T[]>(sig_len_);
-		build_signature_correction_base_(
-			local_log_base_uptr.get(), correction, correction_len,
-			dimension, dummy_path_obj.dimension(), degree, level_index_uptr.get());
 	}
 
-	auto sig_backprop_func = [&](const T* path_ptr, T* sig_derivs_ptr, T* sig_ptr, T* out_ptr) {
-		Path<T> path_obj(path_ptr, dimension, length, time_aug, lead_lag, end_time);
-		if (has_correction) {
+	if (has_correction) {
+		auto sig_backprop_func = [&](const T* path_ptr, const T* corr_ptr, T* sig_derivs_ptr, T* sig_ptr, T* out_ptr) {
+			Path<T> path_obj(path_ptr, dimension, length, time_aug, lead_lag, end_time);
 			sig_backprop_correction_inplace_<T>(
 				path_obj, out_ptr, sig_derivs_ptr, sig_ptr, degree, sig_len_,
-				local_log_base_uptr.get(), level_index_uptr.get());
-		}
-		else {
-			sig_backprop_inplace_<T>(path_obj, out_ptr, sig_derivs_ptr, sig_ptr, degree, sig_len_);
-		}
-	};
+				corr_ptr, correction_len, correction_segment_stride,
+				level_index_uptr.get());
+		};
 
-	multi_threaded_batch(sig_backprop_func, batch_size, n_jobs,
-		make_batch(path, flat_path_length),
-		make_batch(sig_derivs_copy, sig_len_),
-		make_batch(sig_copy, sig_len_),
-		make_batch(out, flat_path_length));
+		multi_threaded_batch(sig_backprop_func, batch_size, n_jobs,
+			make_batch(path, flat_path_length),
+			make_batch(correction, correction_batch_stride),
+			make_batch(sig_derivs_copy, sig_len_),
+			make_batch(sig_copy, sig_len_),
+			make_batch(out, flat_path_length));
+	}
+	else {
+		auto sig_backprop_func = [&](const T* path_ptr, T* sig_derivs_ptr, T* sig_ptr, T* out_ptr) {
+			Path<T> path_obj(path_ptr, dimension, length, time_aug, lead_lag, end_time);
+			sig_backprop_inplace_<T>(path_obj, out_ptr, sig_derivs_ptr, sig_ptr, degree, sig_len_);
+		};
+
+		multi_threaded_batch(sig_backprop_func, batch_size, n_jobs,
+			make_batch(path, flat_path_length),
+			make_batch(sig_derivs_copy, sig_len_),
+			make_batch(sig_copy, sig_len_),
+			make_batch(out, flat_path_length));
+	}
 	return;
 }
 
@@ -722,12 +745,15 @@ void sig_backprop_correction_inplace_(
 	T* sig,
 	uint64_t degree,
 	uint64_t sig_len,
-	const T* local_log_base,
+	const T* correction,
+	uint64_t correction_len,
+	uint64_t segment_stride,
 	const uint64_t* level_index
 ) {
 	const uint64_t data_dimension = path.data_dimension();
 	const uint64_t dimension = path.dimension();
 	const uint64_t data_length = path.data_length();
+	const uint64_t length = path.length();
 
 	auto local_derivs_uptr = std::make_unique<T[]>(sig_len);
 	T* local_derivs = local_derivs_uptr.get();
@@ -746,7 +772,6 @@ void sig_backprop_correction_inplace_(
 
 	auto inverse_local_sig_uptr = std::make_unique<T[]>(sig_len);
 	T* inverse_local_sig = inverse_local_sig_uptr.get();
-	std::memcpy(local_log, local_log_base, sig_len * sizeof(T));
 
 	Point<T> prev_pt(path.end());
 	Point<T> next_pt(path.end());
@@ -756,8 +781,11 @@ void sig_backprop_correction_inplace_(
 
 	Point<T> first_pt(path.begin());
 	T* pos = out + (data_length - 1) * data_dimension;
+	uint64_t step = length - 2;
 
 	while (next_pt != first_pt) {
+		const T* seg_corr = correction == nullptr ? nullptr : correction + step * segment_stride;
+		apply_segment_correction_(local_log, seg_corr, correction_len, data_dimension, dimension, degree, level_index);
 		write_segment_displacement_(prev_pt, next_pt, local_log, dimension);
 		tensor_exp_<T>(local_log, local_sig, dimension, degree);
 
@@ -781,6 +809,7 @@ void sig_backprop_correction_inplace_(
 		if (next_pt != first_pt) {
 			--prev_pt;
 			pos -= data_dimension;
+			--step;
 		}
 	}
 }

--- a/siglib/cpsig/cpsig.h
+++ b/siglib/cpsig/cpsig.h
@@ -254,9 +254,9 @@ extern "C" {
 	*				if n_jobs = -2, all threads but one are used (default = 1).
 	* @return Status code (0 = success).
 	*/
-	[[nodiscard]] CPSIG_API int signature_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1., bool horner = true, bool scalar_term = true, int n_jobs = 1, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CPSIG_API int signature_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1., bool horner = true, bool scalar_term = true, int n_jobs = 1, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @brief */
-	[[nodiscard]] CPSIG_API int signature_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool horner = true, bool scalar_term = true, int n_jobs = 1, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CPSIG_API int signature_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool horner = true, bool scalar_term = true, int n_jobs = 1, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @} */
 
 	/** @defgroup sig_backprop_functions Signature backprop functions
@@ -282,9 +282,9 @@ extern "C" {
 	*				if n_jobs = -2, all threads but one are used (default = 1).
 	* @return Status code (0 = success).
 	*/
-	[[nodiscard]] CPSIG_API int sig_backprop_f(const float* path, float* out, const float* sig_derivs, const float* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1., bool scalar_term = true, int n_jobs = 1, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CPSIG_API int sig_backprop_f(const float* path, float* out, const float* sig_derivs, const float* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1., bool scalar_term = true, int n_jobs = 1, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @brief */
-	[[nodiscard]] CPSIG_API int sig_backprop_d(const double* path, double* out, const double* sig_derivs, const double* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool scalar_term = true, int n_jobs = 1, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CPSIG_API int sig_backprop_d(const double* path, double* out, const double* sig_derivs, const double* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool scalar_term = true, int n_jobs = 1, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @} */
 
 	/**
@@ -511,8 +511,8 @@ extern "C" {
 	[[nodiscard]] CPSIG_API int prepare_branched_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk = false, bool planar = false) noexcept;
 	CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
 
-	[[nodiscard]] CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
-	[[nodiscard]] CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 
 	[[nodiscard]] CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CPSIG_API int branched_sig_combine_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
@@ -540,8 +540,7 @@ extern "C" {
 	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 
-	[[nodiscard]] CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
-	[[nodiscard]] CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_backprop_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_backprop_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @} */
 }
-

--- a/siglib/cpsig_unit_testing/cp_test_helpers.h
+++ b/siglib/cpsig_unit_testing/cp_test_helpers.h
@@ -101,8 +101,12 @@ void check_result(FN f, std::vector<T>& path, std::vector<T>& true_, Args... arg
     if constexpr (std::is_invocable_v<FN, T*, T*, Args...>) {
         f(path.data(), out.data(), args...);
     }
-    else {
+    else if constexpr (std::is_invocable_v<FN, T*, T*, Args..., const T*, uint64_t>) {
         f(path.data(), out.data(), args..., static_cast<const T*>(nullptr), static_cast<uint64_t>(0));
+    }
+    else {
+        f(path.data(), out.data(), args..., static_cast<const T*>(nullptr),
+            static_cast<uint64_t>(0), static_cast<uint64_t>(0), static_cast<uint64_t>(0));
     }
 
     for (uint64_t i = 0; i < true_.size(); ++i)

--- a/siglib/cpsig_unit_testing/cp_test_signature.cpp
+++ b/siglib/cpsig_unit_testing/cp_test_signature.cpp
@@ -141,7 +141,7 @@ TEST(signatureDoubleTest, TrivialCases) {
     auto f = signature_d;
     std::vector<double> path;
     std::vector<double> true_sig;
-    EXPECT_EQ(2, f(path.data(), true_sig.data(), (uint64_t)1, 0, 0, 0, false, false, 1., true, true, 1, nullptr, 0));
+    EXPECT_EQ(2, f(path.data(), true_sig.data(), (uint64_t)1, 0, 0, 0, false, false, 1., true, true, 1, nullptr, 0, 0, 0));
 
     true_sig.push_back(1.);
     check_result(f, path, true_sig, (uint64_t)1, 1, 0, 0, false, false, 1., true, true, 1);
@@ -271,7 +271,7 @@ TEST(signatureDoubleTest, BigLeadLagTest) {
     path.resize(batch * length * dimension);
     std::vector<double> out;
     out.resize(batch * sig_length(dimension * 2, degree));
-    f(path.data(), out.data(), batch, dimension, length, degree, false, true, 1., true, true, 1, nullptr, 0);
+    f(path.data(), out.data(), batch, dimension, length, degree, false, true, 1., true, true, 1, nullptr, 0, 0, 0);
 }
 
 TEST(sigBackpropTest, LinearPathTest) {

--- a/siglib/cusig/cu_branched_signature.cu
+++ b/siglib/cusig/cu_branched_signature.cu
@@ -1156,8 +1156,6 @@ void branched_sig_cuda_core_(
 	if (correction == nullptr && correction_len != 0)
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	const bool has_correction = correction_len != 0;
-	if (has_correction && correction_segment_stride == 0)
-		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 
 	// Single-point paths have no increments => identity branched sig
@@ -1240,8 +1238,6 @@ void branched_sig_cuda_(
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
-	if (correction_len != 0 && correction_segment_stride == 0)
-		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const uint64_t t_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t t_length = lead_lag ? 2 * length - 1 : length;
 
@@ -1303,8 +1299,6 @@ void branched_sig_backprop_cuda_core_(
 	if (correction == nullptr && correction_len != 0)
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	const bool has_correction = correction_len != 0;
-	if (has_correction && correction_segment_stride == 0)
-		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 
 	// Single-point paths have no increments => zero path gradients
@@ -1379,8 +1373,6 @@ void branched_sig_backprop_cuda_(
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
-	if (correction_len != 0 && correction_segment_stride == 0)
-		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const uint64_t t_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t t_length = lead_lag ? 2 * length - 1 : length;
 

--- a/siglib/cusig/cu_branched_signature.cu
+++ b/siglib/cusig/cu_branched_signature.cu
@@ -364,7 +364,9 @@ void branched_sig_ker(
 	int max_nodes,
 	uint32_t coprod_data_len,
 	const T* __restrict__ correction,
-	uint64_t correction_len
+	uint64_t correction_len,
+	uint64_t correction_batch_stride,
+	uint64_t correction_segment_stride
 ) {
 	const uint32_t batch_idx = blockIdx.y;
 	const uint32_t tid = threadIdx.x;
@@ -392,6 +394,9 @@ void branched_sig_ker(
 
 	const T* bp = path + static_cast<uint64_t>(batch_idx) * path_stride;
 	T* X = out + static_cast<uint64_t>(batch_idx) * total_len;
+	const T* batch_correction = has_correction
+		? correction + static_cast<uint64_t>(batch_idx) * correction_batch_stride
+		: nullptr;
 
 	for (int seg = 0; seg < steps; ++seg) {
 		// --- Cooperative increment load ---
@@ -400,8 +405,11 @@ void branched_sig_ker(
 		__syncthreads();
 
 		T* tgt = (seg == 0) ? X : temp;
+		const T* seg_correction = has_correction
+			? batch_correction + static_cast<uint64_t>(seg) * correction_segment_stride
+			: nullptr;
 		local_branched_sig_block_(inc, tgt, local_log, power, next_power,
-			dim, data_dim, correction, correction_len, total_len,
+			dim, data_dim, seg_correction, correction_len, total_len,
 			labels_data, labels_offsets, inv_factorial,
 			s_coprod_data, s_coprod_off, s_order_idx,
 			chain_index_offsets, chain_indices, max_nodes, tid);
@@ -634,7 +642,9 @@ void branched_sig_backprop_ker(
 	int max_nodes,
 	uint32_t coprod_data_len,
 	const T* __restrict__ correction,
-	uint64_t correction_len
+	uint64_t correction_len,
+	uint64_t correction_batch_stride,
+	uint64_t correction_segment_stride
 ) {
 	const uint32_t batch_idx = blockIdx.y;
 	const uint32_t tid = threadIdx.x;
@@ -673,6 +683,9 @@ void branched_sig_backprop_ker(
 	// Initialize path_derivs to zero
 	const T* bp = path + static_cast<uint64_t>(batch_idx) * path_stride;
 	T* pd = path_derivs + static_cast<uint64_t>(batch_idx) * path_stride;
+	const T* batch_correction = has_correction
+		? correction + static_cast<uint64_t>(batch_idx) * correction_batch_stride
+		: nullptr;
 	for (uint32_t i = tid; i < static_cast<uint32_t>(path_stride); i += blockDim.x)
 		pd[i] = T(0);
 	__syncthreads();
@@ -683,8 +696,11 @@ void branched_sig_backprop_ker(
 			inc[d] = bp[(seg + 1) * dim + d] - bp[seg * dim + d];
 		__syncthreads();
 
+		const T* seg_correction = has_correction
+			? batch_correction + static_cast<uint64_t>(seg) * correction_segment_stride
+			: nullptr;
 		local_branched_sig_block_(inc, temp_Y, local_log, powers, power_derivs,
-			dim, data_dim, correction, correction_len, total_len,
+			dim, data_dim, seg_correction, correction_len, total_len,
 			labels_data, labels_offsets, inv_factorial,
 			s_coprod_data, s_coprod_off, s_order_idx,
 			chain_index_offsets, chain_indices, max_nodes, tid);
@@ -768,7 +784,7 @@ void branched_sig_backprop_ker(
 		} else {
 			local_log_bsig_deriv_to_inc_block_(local_derivs, inc, inc_derivs,
 				local_log, powers, power_derivs, d_correction,
-				dim, data_dim, correction, correction_len, total_len,
+				dim, data_dim, seg_correction, correction_len, total_len,
 				labels_data, labels_offsets, inv_factorial,
 				s_coprod_data, s_coprod_off, s_order_idx,
 				chain_index_offsets, chain_indices, max_nodes, tid);
@@ -1131,13 +1147,17 @@ void branched_sig_cuda_core_(
 	bool planar = false,
 	uint64_t data_dimension = 0,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	if (data_dimension == 0) data_dimension = dimension;
 	validate_correction_len_(data_dimension, max_nodes, correction_len);
 	if (correction == nullptr && correction_len != 0)
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	const bool has_correction = correction_len != 0;
+	if (has_correction && correction_segment_stride == 0)
+		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 
 	// Single-point paths have no increments => identity branched sig
@@ -1186,7 +1206,8 @@ void branched_sig_cuda_core_(
 		d_inv_fact,
 		gc.d_coprod_data32, gc.d_coprod_offsets32,
 		gc.d_order_index32, gc.d_chain_index_offsets32, gc.d_chain_indices32, gc.max_nodes,
-		gc.coprod_data_len, correction, correction_len
+		gc.coprod_data_len, correction, correction_len,
+		correction_batch_stride, correction_segment_stride
 	);
 	cudaDeviceSynchronize();
 	check_cuda_error();
@@ -1210,13 +1231,17 @@ void branched_sig_cuda_(
 	bool planar = false,
 	bool scalar_term = true,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	validate_correction_len_(dimension, max_nodes, correction_len);
 	if (correction == nullptr && correction_len != 0)
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
+	if (correction_len != 0 && correction_segment_stride == 0)
+		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const uint64_t t_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t t_length = lead_lag ? 2 * length - 1 : length;
 
@@ -1238,11 +1263,13 @@ void branched_sig_cuda_(
 		cudaDeviceSynchronize();
 
 		branched_sig_cuda_core_<T>(d_transformed.get(), core_out, batch_size, t_dimension, t_length,
-			max_nodes, planar, dimension, correction, correction_len);
+			max_nodes, planar, dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 	}
 	else {
 		branched_sig_cuda_core_<T>(path, core_out, batch_size, dimension, length,
-			max_nodes, planar, dimension, correction, correction_len);
+			max_nodes, planar, dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 	}
 
 	if (!scalar_term) {
@@ -1267,13 +1294,17 @@ void branched_sig_backprop_cuda_core_(
 	bool planar = false,
 	uint64_t data_dimension = 0,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	if (data_dimension == 0) data_dimension = dimension;
 	validate_correction_len_(data_dimension, max_nodes, correction_len);
 	if (correction == nullptr && correction_len != 0)
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	const bool has_correction = correction_len != 0;
+	if (has_correction && correction_segment_stride == 0)
+		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const auto& gc = get_or_upload_gpu_cache(dimension, max_nodes, planar);
 
 	// Single-point paths have no increments => zero path gradients
@@ -1316,7 +1347,8 @@ void branched_sig_backprop_cuda_core_(
 		d_inv_fact,
 		gc.d_coprod_data32, gc.d_coprod_offsets32,
 		gc.d_order_index32, gc.d_chain_index_offsets32, gc.d_chain_indices32, gc.max_nodes,
-		gc.coprod_data_len, correction, correction_len
+		gc.coprod_data_len, correction, correction_len,
+		correction_batch_stride, correction_segment_stride
 	);
 	cudaDeviceSynchronize();
 	check_cuda_error();
@@ -1338,13 +1370,17 @@ void branched_sig_backprop_cuda_(
 	bool planar = false,
 	bool scalar_term = true,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	validate_correction_len_(dimension, max_nodes, correction_len);
 	if (correction == nullptr && correction_len != 0)
 		throw std::invalid_argument("correction pointer is null but correction_len is nonzero");
 	if (lead_lag && correction_len != 0)
 		throw std::invalid_argument("correction cannot be used with lead_lag=true");
+	if (correction_len != 0 && correction_segment_stride == 0)
+		throw std::invalid_argument("correction_segment_stride cannot be 0 when correction is non-empty");
 	const uint64_t t_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t t_length = lead_lag ? 2 * length - 1 : length;
 
@@ -1375,7 +1411,8 @@ void branched_sig_backprop_cuda_(
 
 			cudaMalloc(&d_transformed_derivs, t_path_size * sizeof(T));
 			branched_sig_backprop_cuda_core_<T>(d_transformed, d_transformed_derivs, core_derivs, core_bsig,
-				batch_size, t_dimension, t_length, max_nodes, planar, dimension, correction, correction_len);
+				batch_size, t_dimension, t_length, max_nodes, planar, dimension, correction, correction_len,
+				correction_batch_stride, correction_segment_stride);
 
 			cudaFree(d_transformed);
 			d_transformed = nullptr;
@@ -1390,7 +1427,8 @@ void branched_sig_backprop_cuda_(
 	}
 	else {
 		branched_sig_backprop_cuda_core_<T>(path, out, core_derivs, core_bsig,
-			batch_size, dimension, length, max_nodes, planar, dimension, correction, correction_len);
+			batch_size, dimension, length, max_nodes, planar, dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 	}
 }
 
@@ -1401,12 +1439,12 @@ void branched_sig_backprop_cuda_(
 extern "C" {
 
 
-	CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_cuda_<float>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_cuda_<float>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
-	CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_cuda_<double>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_cuda_<double>(path, out, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 	CUSIG_API int branched_sig_combine_cuda_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar, bool scalar_term) noexcept {
@@ -1424,12 +1462,12 @@ extern "C" {
 	}
 
 
-	CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, float end_time, bool planar, bool scalar_term, const float* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<float>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
-	CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len));
+	CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug, bool lead_lag, double end_time, bool planar, bool scalar_term, const double* correction, uint64_t correction_len, uint64_t correction_batch_stride, uint64_t correction_segment_stride) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_backprop_cuda_<double>(path, out, bsig_derivs, bsig, batch_size, dimension, length, max_nodes, time_aug, lead_lag, end_time, planar, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 }

--- a/siglib/cusig/cu_signature.cu
+++ b/siglib/cusig/cu_signature.cu
@@ -868,7 +868,7 @@ __device__ void build_correction_block_(
 	const T* path,
 	uint64_t step,
 	T* local_log,
-	const T* correction,
+	const T* correction_segment,
 	uint64_t correction_len,
 	uint64_t data_dimension,
 	uint64_t dimension,
@@ -888,6 +888,11 @@ __device__ void build_correction_block_(
 	for (uint64_t d = tid; d < dimension; d += nthreads)
 		local_log[level_index[1] + d] = next[d] - prev[d];
 
+	if (correction_segment == nullptr || correction_len == 0) {
+		__syncthreads();
+		return;
+	}
+
 	uint64_t offset = 0;
 	uint64_t level_size = data_dimension;
 	for (uint64_t level = 2; level <= degree; ++level) {
@@ -896,7 +901,7 @@ __device__ void build_correction_block_(
 			break;
 
 		for (uint64_t word_idx = tid; word_idx < level_size; word_idx += nthreads) {
-			const T value = correction[offset + word_idx];
+			const T value = correction_segment[offset + word_idx];
 			if (value == T(0))
 				continue;
 
@@ -1175,6 +1180,8 @@ __global__ void signature_correction_ker(
 	T* __restrict__ out,
 	const T* __restrict__ correction,
 	uint64_t correction_len,
+	uint64_t correction_batch_stride,
+	uint64_t correction_segment_stride,
 	const uint64_t* __restrict__ level_index,
 	uint64_t data_dimension,
 	uint64_t dimension,
@@ -1191,6 +1198,7 @@ __global__ void signature_correction_ker(
 	const int nthreads = blockDim.x;
 
 	const T* my_path = path + batch_idx * path_flat_len;
+	const T* my_correction = correction + batch_idx * correction_batch_stride;
 	T* my_out = out + batch_idx * sig_stride;
 	T* acc = workspace + batch_idx * 5 * full_sig_len;
 	T* local = acc + full_sig_len;
@@ -1199,13 +1207,14 @@ __global__ void signature_correction_ker(
 	T* power_curr = power_prev + full_sig_len;
 
 	build_correction_block_(
-		my_path, 0, local_log, correction, correction_len,
+		my_path, 0, local_log, my_correction, correction_len,
 		data_dimension, dimension, degree, level_index);
 	tensor_exp_block_(local_log, acc, power_prev, power_curr, dimension, degree, level_index);
 
 	for (uint64_t step = 1; step + 1 < length; ++step) {
+		const T* seg_corr = my_correction + step * correction_segment_stride;
 		build_correction_block_(
-			my_path, step, local_log, correction, correction_len,
+			my_path, step, local_log, seg_corr, correction_len,
 			data_dimension, dimension, degree, level_index);
 		tensor_exp_block_(local_log, local, power_prev, power_curr, dimension, degree, level_index);
 		sig_combine_block_(acc, local, degree, level_index);
@@ -1233,7 +1242,9 @@ void signature_cuda_core_(
 	bool scalar_term,
 	uint64_t data_dimension,
 	const T* correction,
-	uint64_t correction_len
+	uint64_t correction_len,
+	uint64_t correction_batch_stride,
+	uint64_t correction_segment_stride
 ) {
 	const uint64_t full_sig_len = host_sig_length(dimension, degree);
 	const uint64_t sig_stride = scalar_term ? full_sig_len : full_sig_len - 1;
@@ -1272,7 +1283,9 @@ void signature_cuda_core_(
 		CudaBuf<T> d_workspace(batch_size * 5 * full_sig_len * sizeof(T));
 		const unsigned int threads_per_block = host_choose_threads_per_block(full_sig_len);
 		signature_correction_ker<T><<<static_cast<unsigned int>(batch_size), threads_per_block>>>(
-			path, out, correction, correction_len, d_level_index.get(),
+			path, out, correction, correction_len,
+			correction_batch_stride, correction_segment_stride,
+			d_level_index.get(),
 			data_dimension, dimension, length, degree, full_sig_len, sig_stride,
 			path_flat_len, d_workspace.get(), scalar_term);
 		check_cuda_kernel_launch();
@@ -1328,7 +1341,9 @@ void signature_cuda_(
 	bool horner,
 	bool scalar_term = true,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	if (dimension == 0) throw std::invalid_argument("signature_cuda received path of dimension 0");
 	validate_signature_correction_args_cuda_(correction, correction_len, dimension, degree, lead_lag);
@@ -1347,12 +1362,14 @@ void signature_cuda_(
 
 		signature_cuda_core_<T>(
 			d_transformed.get(), out, batch_size, t_dimension, t_length, degree,
-			horner, scalar_term, dimension, correction, correction_len);
+			horner, scalar_term, dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 	}
 	else {
 		signature_cuda_core_<T>(
 			path, out, batch_size, dimension, length, degree,
-			horner, scalar_term, dimension, correction, correction_len);
+			horner, scalar_term, dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 	}
 }
 
@@ -1364,6 +1381,8 @@ __global__ void sig_backprop_correction_ker(
 	const T* __restrict__ sig,
 	const T* __restrict__ correction,
 	uint64_t correction_len,
+	uint64_t correction_batch_stride,
+	uint64_t correction_segment_stride,
 	const uint64_t* __restrict__ level_index,
 	uint64_t data_dimension,
 	uint64_t dimension,
@@ -1380,6 +1399,7 @@ __global__ void sig_backprop_correction_ker(
 	const int nthreads = blockDim.x;
 
 	const T* my_path = path + batch_idx * path_flat_len;
+	const T* my_correction = correction + batch_idx * correction_batch_stride;
 	T* my_out = out + batch_idx * path_flat_len;
 	const T* my_sig = sig + batch_idx * sig_stride;
 	const T* my_derivs = sig_derivs + batch_idx * sig_stride;
@@ -1423,8 +1443,9 @@ __global__ void sig_backprop_correction_ker(
 	__syncthreads();
 
 	for (int64_t seg = static_cast<int64_t>(length) - 2; seg >= 0; --seg) {
+		const T* seg_corr = my_correction + static_cast<uint64_t>(seg) * correction_segment_stride;
 		build_correction_block_(
-			my_path, static_cast<uint64_t>(seg), local_log, correction, correction_len,
+			my_path, static_cast<uint64_t>(seg), local_log, seg_corr, correction_len,
 			data_dimension, dimension, degree, level_index);
 		tensor_exp_block_(local_log, local_sig, power_prev, power_curr, dimension, degree, level_index);
 
@@ -1466,7 +1487,9 @@ void sig_backprop_cuda_core_(
 	bool scalar_term,
 	uint64_t data_dimension,
 	const T* correction,
-	uint64_t correction_len
+	uint64_t correction_len,
+	uint64_t correction_batch_stride,
+	uint64_t correction_segment_stride
 ) {
 	const uint64_t full_sig_len = host_sig_length(dimension, degree);
 	const uint64_t sig_stride = scalar_term ? full_sig_len : full_sig_len - 1;
@@ -1486,7 +1509,9 @@ void sig_backprop_cuda_core_(
 		CudaBuf<T> d_workspace(batch_size * (degree + 12) * full_sig_len * sizeof(T));
 		const unsigned int threads_per_block = host_choose_threads_per_block(full_sig_len);
 		sig_backprop_correction_ker<T><<<static_cast<unsigned int>(batch_size), threads_per_block>>>(
-			path, out, sig_derivs, sig, correction, correction_len, d_level_index.get(),
+			path, out, sig_derivs, sig, correction, correction_len,
+			correction_batch_stride, correction_segment_stride,
+			d_level_index.get(),
 			data_dimension, dimension, length, degree, full_sig_len, sig_stride,
 			path_flat_len, d_workspace.get(), scalar_term);
 		check_cuda_kernel_launch();
@@ -1577,7 +1602,9 @@ void sig_backprop_cuda_(
 	T end_time,
 	bool scalar_term = true,
 	const T* correction = nullptr,
-	uint64_t correction_len = 0
+	uint64_t correction_len = 0,
+	uint64_t correction_batch_stride = 0,
+	uint64_t correction_segment_stride = 0
 ) {
 	if (dimension == 0) throw std::invalid_argument("sig_backprop_cuda received path of dimension 0");
 	validate_signature_correction_args_cuda_(correction, correction_len, dimension, degree, lead_lag);
@@ -1596,7 +1623,8 @@ void sig_backprop_cuda_(
 		sig_backprop_cuda_core_<T>(
 			d_transformed.get(), d_transformed_derivs.get(), sig_derivs, sig,
 			batch_size, t_dimension, t_length, degree, scalar_term,
-			dimension, correction, correction_len);
+			dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 
 		d_transformed.reset();
 
@@ -1605,7 +1633,8 @@ void sig_backprop_cuda_(
 	else {
 		sig_backprop_cuda_core_<T>(
 			path, out, sig_derivs, sig, batch_size, dimension, length, degree,
-			scalar_term, dimension, correction, correction_len);
+			scalar_term, dimension, correction, correction_len,
+			correction_batch_stride, correction_segment_stride);
 	}
 }
 
@@ -1621,9 +1650,10 @@ extern "C" {
 		uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree,
 		bool time_aug, bool lead_lag, float end_time,
 		bool horner, bool scalar_term,
-		const float* correction, uint64_t correction_len
+		const float* correction, uint64_t correction_len,
+		uint64_t correction_batch_stride, uint64_t correction_segment_stride
 	) noexcept {
-		CUSIG_SAFE_CALL(signature_cuda_<float>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, correction, correction_len));
+		CUSIG_SAFE_CALL(signature_cuda_<float>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 	CUSIG_API int signature_cuda_d(
@@ -1631,9 +1661,10 @@ extern "C" {
 		uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree,
 		bool time_aug, bool lead_lag, double end_time,
 		bool horner, bool scalar_term,
-		const double* correction, uint64_t correction_len
+		const double* correction, uint64_t correction_len,
+		uint64_t correction_batch_stride, uint64_t correction_segment_stride
 	) noexcept {
-		CUSIG_SAFE_CALL(signature_cuda_<double>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, correction, correction_len));
+		CUSIG_SAFE_CALL(signature_cuda_<double>(path, out, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, horner, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 	// =====================================================================
@@ -1646,9 +1677,10 @@ extern "C" {
 		const float* sig_derivs, const float* sig,
 		uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree,
 		bool time_aug, bool lead_lag, float end_time, bool scalar_term,
-		const float* correction, uint64_t correction_len
+		const float* correction, uint64_t correction_len,
+		uint64_t correction_batch_stride, uint64_t correction_segment_stride
 	) noexcept {
-		CUSIG_SAFE_CALL(sig_backprop_cuda_<float>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, correction, correction_len));
+		CUSIG_SAFE_CALL(sig_backprop_cuda_<float>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 	CUSIG_API int sig_backprop_cuda_d(
@@ -1656,9 +1688,10 @@ extern "C" {
 		const double* sig_derivs, const double* sig,
 		uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree,
 		bool time_aug, bool lead_lag, double end_time, bool scalar_term,
-		const double* correction, uint64_t correction_len
+		const double* correction, uint64_t correction_len,
+		uint64_t correction_batch_stride, uint64_t correction_segment_stride
 	) noexcept {
-		CUSIG_SAFE_CALL(sig_backprop_cuda_<double>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, correction, correction_len));
+		CUSIG_SAFE_CALL(sig_backprop_cuda_<double>(path, out, sig_derivs, sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, scalar_term, correction, correction_len, correction_batch_stride, correction_segment_stride));
 	}
 
 }

--- a/siglib/cusig/cusig.h
+++ b/siglib/cusig/cusig.h
@@ -153,9 +153,9 @@ extern "C" {
 	* @param horner Whether to use the Horner algorithm (default = true).
 	* @return Status code (0 = success).
 	*/
-	[[nodiscard]] CUSIG_API int signature_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool horner = true, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CUSIG_API int signature_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool horner = true, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @brief */
-	[[nodiscard]] CUSIG_API int signature_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool horner = true, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CUSIG_API int signature_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool horner = true, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @} */
 
 	/** @defgroup sig_backprop_cuda_functions Signature backpropagation CUDA functions
@@ -178,9 +178,9 @@ extern "C" {
 	* @param end_time End time for time augmentation (default = 1.0).
 	* @return Status code (0 = success).
 	*/
-	[[nodiscard]] CUSIG_API int sig_backprop_cuda_f(const float* path, float* out, const float* sig_derivs, const float* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CUSIG_API int sig_backprop_cuda_f(const float* path, float* out, const float* sig_derivs, const float* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @brief */
-	[[nodiscard]] CUSIG_API int sig_backprop_cuda_d(const double* path, double* out, const double* sig_derivs, const double* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CUSIG_API int sig_backprop_cuda_d(const double* path, double* out, const double* sig_derivs, const double* sig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t degree, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @} */
 
 	/** @defgroup sig_combine_cuda_functions Signature combine CUDA functions
@@ -420,8 +420,8 @@ extern "C" {
 	* @{
 	*/
 
-	[[nodiscard]] CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 
 	[[nodiscard]] CUSIG_API int branched_sig_combine_cuda_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CUSIG_API int branched_sig_combine_cuda_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
@@ -429,8 +429,8 @@ extern "C" {
 	[[nodiscard]] CUSIG_API int branched_sig_combine_backprop_cuda_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CUSIG_API int branched_sig_combine_backprop_cuda_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
 
-	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_f(const float* path, float* out, const float* bsig_derivs, const float* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_backprop_cuda_d(const double* path, double* out, const double* bsig_derivs, const double* bsig, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	/** @} */
 
 	/** @defgroup branched_log_sig_cuda_functions Branched log signature CUDA functions

--- a/siglib/cusig_unit_testing/cu_test_helpers.h
+++ b/siglib/cusig_unit_testing/cu_test_helpers.h
@@ -276,8 +276,10 @@ void check_result_typed(FN f, std::vector<T>& path, std::vector<T>& true_, Args.
     int err;
     if constexpr (std::is_invocable_v<FN, T*, T*, Args...>)
         err = f(d_path, d_out, args...);
-    else
+    else if constexpr (std::is_invocable_v<FN, T*, T*, Args..., const T*, uint64_t>)
         err = f(d_path, d_out, args..., nullptr, (uint64_t)0);
+    else
+        err = f(d_path, d_out, args..., nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
     cudaDeviceSynchronize();
 
     cudaMemcpy(out.data(), d_out, sizeof(T) * out.size(), cudaMemcpyDeviceToHost);
@@ -403,8 +405,10 @@ void check_backprop_result(
     int err;
     if constexpr (std::is_invocable_v<FN, T*, T*, T*, T*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, T, bool>)
         err = f(d_path, d_out, d_sig_derivs, d_sig, (uint64_t)1, dimension, length, degree, time_aug, lead_lag, end_time, true);
-    else
+    else if constexpr (std::is_invocable_v<FN, T*, T*, T*, T*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, T, bool, const T*, uint64_t>)
         err = f(d_path, d_out, d_sig_derivs, d_sig, (uint64_t)1, dimension, length, degree, time_aug, lead_lag, end_time, true, nullptr, (uint64_t)0);
+    else
+        err = f(d_path, d_out, d_sig_derivs, d_sig, (uint64_t)1, dimension, length, degree, time_aug, lead_lag, end_time, true, nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
     cudaDeviceSynchronize();
 
     cudaMemcpy(out.data(), d_out, sizeof(T) * out.size(), cudaMemcpyDeviceToHost);
@@ -461,8 +465,10 @@ void check_batch_backprop_result(
     int err;
     if constexpr (std::is_invocable_v<FN, T*, T*, T*, T*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, T, bool>)
         err = f(d_path, d_out, d_sig_derivs, d_sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, true);
-    else
+    else if constexpr (std::is_invocable_v<FN, T*, T*, T*, T*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, T, bool, const T*, uint64_t>)
         err = f(d_path, d_out, d_sig_derivs, d_sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, true, nullptr, (uint64_t)0);
+    else
+        err = f(d_path, d_out, d_sig_derivs, d_sig, batch_size, dimension, length, degree, time_aug, lead_lag, end_time, true, nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
     cudaDeviceSynchronize();
 
     cudaMemcpy(out.data(), d_out, sizeof(T) * out.size(), cudaMemcpyDeviceToHost);

--- a/siglib/cusig_unit_testing/cu_test_sig_backprop.cpp
+++ b/siglib/cusig_unit_testing/cu_test_sig_backprop.cpp
@@ -104,7 +104,7 @@ TEST(sigBackpropDoubleTest, CorrectionSingleSegment) {
     cudaMemcpy(d_correction, correction.data(), sizeof(double) * correction.size(), cudaMemcpyHostToDevice);
 
     int err = f(d_path, d_out, d_sig_derivs, d_sig, (uint64_t)1, dimension, length, degree,
-        false, false, 1., true, d_correction, correction.size());
+        false, false, 1., true, d_correction, correction.size(), 0, 0);
     cudaDeviceSynchronize();
     cudaMemcpy(out.data(), d_out, sizeof(double) * out.size(), cudaMemcpyDeviceToHost);
     cudaFree(d_path);
@@ -120,7 +120,7 @@ TEST(sigBackpropDoubleTest, CorrectionSingleSegment) {
 }
 
 TEST(sigBackpropDoubleTest, ErrorDimension0) {
-    int err = sig_backprop_cuda_d(nullptr, nullptr, nullptr, nullptr, (uint64_t)1, 0, 3, 2, false, false, 1., true, nullptr, 0);
+    int err = sig_backprop_cuda_d(nullptr, nullptr, nullptr, nullptr, (uint64_t)1, 0, 3, 2, false, false, 1., true, nullptr, 0, 0, 0);
     EXPECT_NE(0, err);
 }
 

--- a/siglib/cusig_unit_testing/cu_test_signature.cpp
+++ b/siglib/cusig_unit_testing/cu_test_signature.cpp
@@ -19,7 +19,7 @@ TEST(signatureDoubleTest, TrivialCases) {
     auto f = signature_cuda_d;
     std::vector<double> path;
     std::vector<double> true_sig;
-    EXPECT_EQ(2, f(nullptr, nullptr, (uint64_t)1, 0, 0, 0, false, false, 1., true, true, nullptr, 0));
+    EXPECT_EQ(2, f(nullptr, nullptr, (uint64_t)1, 0, 0, 0, false, false, 1., true, true, nullptr, 0, 0, 0));
 
     true_sig.push_back(1.);
     check_result_typed(f, path, true_sig, (uint64_t)1, 1, 0, 0, false, false, 1., true, true);
@@ -101,7 +101,7 @@ TEST(signatureDoubleTest, CorrectionSingleSegment) {
     cudaMemcpy(d_out, out.data(), sizeof(double) * out.size(), cudaMemcpyHostToDevice);
     cudaMemcpy(d_correction, correction.data(), sizeof(double) * correction.size(), cudaMemcpyHostToDevice);
 
-    int err = f(d_path, d_out, (uint64_t)1, dimension, length, degree, false, false, 1., true, true, d_correction, correction.size());
+    int err = f(d_path, d_out, (uint64_t)1, dimension, length, degree, false, false, 1., true, true, d_correction, correction.size(), 0, 0);
     cudaDeviceSynchronize();
     cudaMemcpy(out.data(), d_out, sizeof(double) * out.size(), cudaMemcpyDeviceToHost);
     cudaFree(d_path);
@@ -133,7 +133,7 @@ TEST(signatureDoubleTest, CorrectionTimeAug) {
     cudaMemcpy(d_out, out.data(), sizeof(double) * out.size(), cudaMemcpyHostToDevice);
     cudaMemcpy(d_correction, correction.data(), sizeof(double) * correction.size(), cudaMemcpyHostToDevice);
 
-    int err = f(d_path, d_out, (uint64_t)1, dimension, length, degree, true, false, 1., true, true, d_correction, correction.size());
+    int err = f(d_path, d_out, (uint64_t)1, dimension, length, degree, true, false, 1., true, true, d_correction, correction.size(), 0, 0);
     cudaDeviceSynchronize();
     cudaMemcpy(out.data(), d_out, sizeof(double) * out.size(), cudaMemcpyDeviceToHost);
     cudaFree(d_path);
@@ -279,7 +279,7 @@ TEST(batchSignatureTest, BigLeadLagTest) {
     cudaMalloc(&d_out, sizeof(double) * out.size());
     cudaMemcpy(d_path, path.data(), sizeof(double) * path.size(), cudaMemcpyHostToDevice);
 
-    int err = f(d_path, d_out, batch, dimension, length, degree, false, true, 1., true, true, nullptr, 0);
+    int err = f(d_path, d_out, batch, dimension, length, degree, false, true, 1., true, true, nullptr, 0, 0, 0);
 
     cudaMemcpy(out.data(), d_out, sizeof(double) * out.size(), cudaMemcpyDeviceToHost);
     cudaFree(d_path);

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -216,7 +216,7 @@ struct CorrectionSpec {
     std::uint64_t segment_stride = 0;
 };
 
-// Correction is either empty or exactly path.shape[:-2] + (path.shape[-2] - 1, L).
+// Correction is empty, constant, shared per-segment, or batch-specific per-segment.
 template <typename PathBufferT, typename CorrectionBufferT>
 std::string GetCorrectionSpec(
     PathBufferT& path,
@@ -233,18 +233,35 @@ std::string GetCorrectionSpec(
         }
     }
 
-    if (corr_dims.size() != path_dims.size()) {
-        std::ostringstream oss;
-        oss << "correction must have shape path.shape[:-2] + "
-               "(path.shape[-2] - 1, L), got rank " << corr_dims.size()
-            << " for path rank " << path_dims.size();
-        return oss.str();
-    }
-
     const std::uint64_t path_segments =
         path_dims[path_dims.size() - 2] > 0
             ? static_cast<std::uint64_t>(path_dims[path_dims.size() - 2] - 1)
             : 0;
+
+    if (corr_dims.size() == 1) {
+        spec.len = static_cast<std::uint64_t>(corr_dims[0]);
+        spec.batch_stride = 0;
+        spec.segment_stride = 0;
+        return {};
+    }
+
+    if (corr_dims.size() == 2 &&
+        static_cast<std::uint64_t>(corr_dims[0]) == path_segments) {
+        const auto correction_width = static_cast<std::uint64_t>(corr_dims[1]);
+        spec.len = correction_width;
+        spec.batch_stride = 0;
+        spec.segment_stride = correction_width;
+        return {};
+    }
+
+    if (corr_dims.size() != path_dims.size()) {
+        std::ostringstream oss;
+        oss << "correction must have shape (C,), (path.shape[-2] - 1, C), or "
+               "path.shape[:-2] + (path.shape[-2] - 1, C), got rank "
+            << corr_dims.size() << " for path rank " << path_dims.size();
+        return oss.str();
+    }
+
     if (static_cast<std::uint64_t>(corr_dims[corr_dims.size() - 2]) != path_segments) {
         std::ostringstream oss;
         oss << "correction segment dim " << corr_dims[corr_dims.size() - 2]
@@ -261,10 +278,11 @@ std::string GetCorrectionSpec(
         }
     }
 
-    const auto L = static_cast<std::uint64_t>(corr_dims[corr_dims.size() - 1]);
-    spec.len = L;
-    spec.batch_stride = path_segments * L;
-    spec.segment_stride = L;
+    const auto correction_width =
+        static_cast<std::uint64_t>(corr_dims[corr_dims.size() - 1]);
+    spec.len = correction_width;
+    spec.batch_stride = path_segments * correction_width;
+    spec.segment_stride = correction_width;
     return {};
 }
 

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -210,31 +210,69 @@ inline std::uint64_t AugmentedDimension(std::uint64_t dimension, bool time_aug, 
     return (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 }
 
-template <typename BufferT>
-std::string GetCorrectionLen(BufferT& correction, std::uint64_t& len) {
-    const auto dims = BufferDims(correction);
-    if (dims.size() == 1) {
-        len = static_cast<std::uint64_t>(dims[0]);
-        return {};
-    }
-    for (const auto dim : dims) {
+struct CorrectionSpec {
+    std::uint64_t len = 0;
+    std::uint64_t batch_stride = 0;
+    std::uint64_t segment_stride = 0;
+};
+
+// Correction is either empty or exactly path.shape[:-2] + (path.shape[-2] - 1, L).
+template <typename PathBufferT, typename CorrectionBufferT>
+std::string GetCorrectionSpec(
+    PathBufferT& path,
+    CorrectionBufferT& correction,
+    CorrectionSpec& spec
+) {
+    const auto path_dims = BufferDims(path);
+    const auto corr_dims = BufferDims(correction);
+
+    for (const auto dim : corr_dims) {
         if (dim == 0) {
-            len = 0;
+            spec = {};
             return {};
         }
     }
-    {
+
+    if (corr_dims.size() != path_dims.size()) {
         std::ostringstream oss;
-        oss << "correction must have rank 1, got rank " << dims.size();
+        oss << "correction must have shape path.shape[:-2] + "
+               "(path.shape[-2] - 1, L), got rank " << corr_dims.size()
+            << " for path rank " << path_dims.size();
         return oss.str();
     }
+
+    const std::uint64_t path_segments =
+        path_dims[path_dims.size() - 2] > 0
+            ? static_cast<std::uint64_t>(path_dims[path_dims.size() - 2] - 1)
+            : 0;
+    if (static_cast<std::uint64_t>(corr_dims[corr_dims.size() - 2]) != path_segments) {
+        std::ostringstream oss;
+        oss << "correction segment dim " << corr_dims[corr_dims.size() - 2]
+            << " does not match path segments " << path_segments;
+        return oss.str();
+    }
+
+    for (size_t i = 0; i < path_dims.size() - 2; ++i) {
+        if (corr_dims[i] != path_dims[i]) {
+            std::ostringstream oss;
+            oss << "correction batch dim " << i << " is " << corr_dims[i]
+                << " but path batch dim is " << path_dims[i];
+            return oss.str();
+        }
+    }
+
+    const auto L = static_cast<std::uint64_t>(corr_dims[corr_dims.size() - 1]);
+    spec.len = L;
+    spec.batch_stride = path_segments * L;
+    spec.segment_stride = L;
+    return {};
 }
 
 template <typename T>
-using CpuSigFn = int (*)(const T*, T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, bool, int, const T*, std::uint64_t) noexcept;
+using CpuSigFn = int (*)(const T*, T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, bool, int, const T*, std::uint64_t, std::uint64_t, std::uint64_t) noexcept;
 
 template <typename T>
-using CpuSigBackpropFn = int (*)(const T*, T*, const T*, const T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, int, const T*, std::uint64_t) noexcept;
+using CpuSigBackpropFn = int (*)(const T*, T*, const T*, const T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, int, const T*, std::uint64_t, std::uint64_t, std::uint64_t) noexcept;
 
 template <typename T>
 struct CpuFns;
@@ -317,10 +355,10 @@ struct CpuFns<double> {
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 template <typename T>
-using CudaSigFn = int (*)(const T*, T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, bool, const T*, std::uint64_t) noexcept;
+using CudaSigFn = int (*)(const T*, T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, bool, const T*, std::uint64_t, std::uint64_t, std::uint64_t) noexcept;
 
 template <typename T>
-using CudaSigBackpropFn = int (*)(const T*, T*, const T*, const T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, const T*, std::uint64_t) noexcept;
+using CudaSigBackpropFn = int (*)(const T*, T*, const T*, const T*, std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t, bool, bool, T, bool, const T*, std::uint64_t, std::uint64_t, std::uint64_t) noexcept;
 
 template <typename T>
 struct CudaFns;
@@ -431,8 +469,9 @@ ffi::Error SigCpuImpl(
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
     if (auto msg = ValidateArgs(degree, n_jobs, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty())
+        return InvalidArgument(msg);
 
     const auto sig_len = sig_length(
         AugmentedDimension(spec.dimension, time_aug, lead_lag),
@@ -461,7 +500,9 @@ ffi::Error SigCpuImpl(
         true,
         static_cast<int>(n_jobs),
         correction_ptr,
-        correction_len
+        corr_spec.len,
+        corr_spec.batch_stride,
+        corr_spec.segment_stride
     );
 
     if (err_code != 0) {
@@ -489,8 +530,9 @@ ffi::Error SigBackpropCpuImpl(
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
     if (auto msg = ValidateArgs(degree, n_jobs, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty())
+        return InvalidArgument(msg);
 
     const auto sig_len = sig_length(
         AugmentedDimension(spec.dimension, time_aug, lead_lag),
@@ -524,7 +566,9 @@ ffi::Error SigBackpropCpuImpl(
         true,
         static_cast<int>(n_jobs),
         correction_ptr,
-        correction_len
+        corr_spec.len,
+        corr_spec.batch_stride,
+        corr_spec.segment_stride
     );
 
     if (err_code != 0) {
@@ -553,8 +597,9 @@ ffi::Error SigCudaImpl(
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
     if (auto msg = ValidateArgs(degree, n_jobs, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty())
+        return InvalidArgument(msg);
 
     const auto sig_len = sig_length(
         AugmentedDimension(spec.dimension, time_aug, lead_lag),
@@ -587,7 +632,9 @@ ffi::Error SigCudaImpl(
         horner,
         true,
         correction_ptr,
-        correction_len
+        corr_spec.len,
+        corr_spec.batch_stride,
+        corr_spec.segment_stride
     );
 
     if (err_code != 0) {
@@ -616,8 +663,9 @@ ffi::Error SigBackpropCudaImpl(
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
     if (auto msg = ValidateArgs(degree, n_jobs, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty())
+        return InvalidArgument(msg);
 
     const auto sig_len = sig_length(
         AugmentedDimension(spec.dimension, time_aug, lead_lag),
@@ -655,7 +703,9 @@ ffi::Error SigBackpropCudaImpl(
         static_cast<T>(end_time),
         true,
         correction_ptr,
-        correction_len
+        corr_spec.len,
+        corr_spec.batch_stride,
+        corr_spec.segment_stride
     );
 
     if (err_code != 0) {
@@ -1933,8 +1983,8 @@ ffi::Error BranchedSigCpuImpl(
 ) {
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty()) return InvalidArgument(msg);
 
     const auto* path_ptr = BufferData<T>(path);
     const auto* correction_ptr = BufferData<T>(correction);
@@ -1946,7 +1996,7 @@ ffi::Error BranchedSigCpuImpl(
         spec.dimension, spec.length,
         static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs),
         time_aug, lead_lag, static_cast<T>(end_time), planar, true,
-        correction_ptr, correction_len
+        correction_ptr, corr_spec.len, corr_spec.batch_stride, corr_spec.segment_stride
     );
     if (err_code != 0) return NativeCallError("branched_sig", err_code);
     return ffi::Error::Success();
@@ -1960,8 +2010,8 @@ ffi::Error BranchedSigBackpropCpuImpl(
 ) {
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty()) return InvalidArgument(msg);
 
     const auto* path_ptr = BufferData<T>(path);
     const auto* bsig_ptr = BufferData<T>(bsig);
@@ -1975,7 +2025,7 @@ ffi::Error BranchedSigBackpropCpuImpl(
         spec.dimension, spec.length,
         static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs),
         time_aug, lead_lag, static_cast<T>(end_time), planar, true,
-        correction_ptr, correction_len
+        correction_ptr, corr_spec.len, corr_spec.batch_stride, corr_spec.segment_stride
     );
     if (err_code != 0) return NativeCallError("branched_sig_backprop", err_code);
     return ffi::Error::Success();
@@ -2014,8 +2064,8 @@ ffi::Error BranchedSigCudaImpl(
 ) {
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty()) return InvalidArgument(msg);
     auto sync = cudaStreamSynchronize(stream);
     if (sync != cudaSuccess) return InternalError(cudaGetErrorString(sync));
 
@@ -2023,7 +2073,7 @@ ffi::Error BranchedSigCudaImpl(
         spec.is_batch ? spec.batch_size : 1,
         spec.dimension, spec.length,
         static_cast<std::uint64_t>(max_nodes), time_aug, lead_lag, static_cast<T>(end_time), planar, true,
-        BufferData<T>(correction), correction_len);
+        BufferData<T>(correction), corr_spec.len, corr_spec.batch_stride, corr_spec.segment_stride);
     if (err_code != 0) return NativeCallError("branched_sig_cuda", err_code);
     return ffi::Error::Success();
 }
@@ -2036,8 +2086,8 @@ ffi::Error BranchedSigBackpropCudaImpl(
 ) {
     PathSpec spec;
     if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
-    std::uint64_t correction_len = 0;
-    if (auto msg = GetCorrectionLen(correction, correction_len); !msg.empty()) return InvalidArgument(msg);
+    CorrectionSpec corr_spec;
+    if (auto msg = GetCorrectionSpec(path, correction, corr_spec); !msg.empty()) return InvalidArgument(msg);
     auto sync = cudaStreamSynchronize(stream);
     if (sync != cudaSuccess) return InternalError(cudaGetErrorString(sync));
 
@@ -2045,7 +2095,7 @@ ffi::Error BranchedSigBackpropCudaImpl(
         spec.is_batch ? spec.batch_size : 1,
         spec.dimension, spec.length,
         static_cast<std::uint64_t>(max_nodes), time_aug, lead_lag, static_cast<T>(end_time), planar, true,
-        BufferData<T>(correction), correction_len);
+        BufferData<T>(correction), corr_spec.len, corr_spec.batch_stride, corr_spec.segment_stride);
     if (err_code != 0) return NativeCallError("branched_sig_backprop_cuda", err_code);
     return ffi::Error::Success();
 }

--- a/siglib/test_app/dll_funcs.h
+++ b/siglib/test_app/dll_funcs.h
@@ -46,9 +46,9 @@ void get_cusig_fn_ptrs();
 
 using sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t);
 using log_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t);
-using signature_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, bool, int, const double*, uint64_t);
+using signature_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, bool, int, const double*, uint64_t, uint64_t, uint64_t);
 
-using signature_f_fn = int(CDECL_*)(const float*, float*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, float, bool, bool, int, const float*, uint64_t);
+using signature_f_fn = int(CDECL_*)(const float*, float*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, float, bool, bool, int, const float*, uint64_t, uint64_t, uint64_t);
 
 using sig_kernel_f_fn = int(CDECL_*)(const float*, float*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, int);
 
@@ -56,8 +56,8 @@ using sig_kernel_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t,
 
 using sig_kernel_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool);
 
-using signature_cuda_f_fn = int(CDECL_*)(const float*, float*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, float, bool, bool, const float*, uint64_t);
-using signature_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, bool, const double*, uint64_t);
+using signature_cuda_f_fn = int(CDECL_*)(const float*, float*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, float, bool, bool, const float*, uint64_t, uint64_t, uint64_t);
+using signature_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, bool, const double*, uint64_t, uint64_t, uint64_t);
 
 using sig_coef_d_fn = int(CDECL_*)(const double*, double*, const uint64_t*, uint64_t, const uint64_t*, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, int);
 
@@ -71,9 +71,9 @@ using sig_combine_d_fn = int(CDECL_*)(const double*, const double*, double*, uin
 using sig_combine_cuda_d_fn = int(CDECL_*)(const double*, const double*, double*, uint64_t, uint64_t, uint64_t);
 using sig_combine_backprop_d_fn = int(CDECL_*)(const double*, double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t, int);
 using sig_combine_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t);
-using sig_backprop_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, int, const double*, uint64_t);
+using sig_backprop_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, int, const double*, uint64_t, uint64_t, uint64_t);
 
-using sig_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t);
+using sig_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t, uint64_t, uint64_t);
 
 using sig_kernel_backprop_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, int);
 
@@ -154,7 +154,7 @@ extern log_sig_combine_backprop_cuda_d_fn log_sig_combine_backprop_cuda_d;
 
 using prepare_branched_sig_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
 using branched_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t, bool);
-using branched_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int, bool, bool, double, bool, bool, const double*, uint64_t);
+using branched_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int, bool, bool, double, bool, bool, const double*, uint64_t, uint64_t, uint64_t);
 using branched_sig_to_log_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, int, bool, bool);
 using branched_sig_to_log_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, bool, bool);
 

--- a/siglib/test_app/tests.cpp
+++ b/siglib/test_app/tests.cpp
@@ -35,7 +35,7 @@ void example_batch_signature_d(
     uint64_t out_size = sig_length(dimension, degree) * batch_size;
     std::vector<double> out(out_size, 0.);
 
-    time_function(num_runs, signature_d, path.data(), out.data(), batch_size, dimension, length, degree, time_aug, lead_lag, 1., horner, true, n_jobs, nullptr, (uint64_t)0);
+    time_function(num_runs, signature_d, path.data(), out.data(), batch_size, dimension, length, degree, time_aug, lead_lag, 1., horner, true, n_jobs, nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
 
     std::cout << "done\n";
 }
@@ -65,7 +65,7 @@ void example_batch_signature_cuda_d(
 
     cudaMemcpy(d_path, path.data(), sizeof(double) * path_size, cudaMemcpyHostToDevice);
 
-    time_function(num_runs, signature_cuda_d, d_path, d_out, batch_size, dimension, length, degree, time_aug, lead_lag, 1., horner, true, nullptr, (uint64_t)0);
+    time_function(num_runs, signature_cuda_d, d_path, d_out, batch_size, dimension, length, degree, time_aug, lead_lag, 1., horner, true, nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
 
     cudaFree(d_path);
     cudaFree(d_out);
@@ -194,7 +194,7 @@ void example_batch_sig_backprop_d(
     uint64_t out_size = batch_size * dimension * length;
     std::vector<double> out(out_size, 0.);
 
-    time_function(num_runs, sig_backprop_d, path.data(), out.data(), sig_derivs.data(), sig.data(), batch_size, dimension, length, degree, time_aug, lead_lag, 1., true, n_jobs, nullptr, (uint64_t)0);
+    time_function(num_runs, sig_backprop_d, path.data(), out.data(), sig_derivs.data(), sig.data(), batch_size, dimension, length, degree, time_aug, lead_lag, 1., true, n_jobs, nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
 
     std::cout << "done\n";
 }
@@ -232,7 +232,7 @@ void example_batch_sig_backprop_cuda_d(
     cudaMemcpy(d_sig_derivs, sig_derivs.data(), sizeof(double) * batch_size * sig_len, cudaMemcpyHostToDevice);
     cudaMemcpy(d_sig, sig.data(), sizeof(double) * batch_size * sig_len, cudaMemcpyHostToDevice);
 
-    time_function(num_runs, sig_backprop_cuda_d, d_path, d_out, d_sig_derivs, d_sig, batch_size, dimension, length, degree, time_aug, lead_lag, 1., true, nullptr, (uint64_t)0);
+    time_function(num_runs, sig_backprop_cuda_d, d_path, d_out, d_sig_derivs, d_sig, batch_size, dimension, length, degree, time_aug, lead_lag, 1., true, nullptr, (uint64_t)0, (uint64_t)0, (uint64_t)0);
 
     cudaFree(d_path);
     cudaFree(d_out);
@@ -847,7 +847,7 @@ void example_batch_branched_log_sig_d(
     std::vector<double> cpu_out(total, 0.);
     std::vector<double> cuda_out(total, 0.);
 
-    branched_sig_d(path.data(), bsig.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1., planar, scalar_term, nullptr, 0);
+    branched_sig_d(path.data(), bsig.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1., planar, scalar_term, nullptr, 0, 0, 0);
     branched_sig_to_log_sig_d(bsig.data(), cpu_out.data(), batch_size, dimension, max_nodes, n_jobs, planar, scalar_term);
 
     double* d_bsig;

--- a/siglib/test_app/tests.cpp
+++ b/siglib/test_app/tests.cpp
@@ -821,7 +821,7 @@ void example_batch_branched_sig_d(
     std::vector<double> path = test_data<double>(batch_size * dimension * length);
     std::vector<double> out(out_size, 0.);
 
-    time_function(num_runs, branched_sig_d, path.data(), out.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1., false, true, nullptr, 0);
+    time_function(num_runs, branched_sig_d, path.data(), out.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1., false, true, nullptr, 0, 0, 0);
 
     std::cout << "done\n";
 }

--- a/tests/test_branched_sig.py
+++ b/tests/test_branched_sig.py
@@ -165,6 +165,12 @@ def ito_level2_correction(d, dt, dtype=np.float64):
     return correction
 
 
+def per_segment_correction(path, correction):
+    correction = np.asarray(correction)
+    shape = (*path.shape[:-2], max(path.shape[-2] - 1, 0), correction.shape[-1])
+    return np.broadcast_to(correction, shape).copy()
+
+
 def local_segment_dt(path, end_time=1.0):
     length = path.shape[-2]
     return end_time / (length - 1) if length > 1 else 0.0
@@ -174,7 +180,8 @@ def torch_ito_level2_correction(d, dt, path):
     correction = torch.zeros(d * d, dtype=path.dtype, device=path.device)
     for i in range(d):
         correction[i * d + i] = dt
-    return correction
+    shape = (*path.shape[:-2], max(path.shape[-2] - 1, 0), correction.shape[-1])
+    return correction.expand(*shape).clone()
 
 
 def compute_kauri_to_pysiglib_permutation(d, N):
@@ -279,19 +286,19 @@ def test_branched_sig_correction_validation_numpy():
     d, N = 2, 3
     path = np.zeros((3, d), dtype=np.float64)
 
-    with pytest.raises(ValueError, match="1D"):
-        pysiglib.branched_sig(path, N, correction=np.zeros((d, d), dtype=path.dtype))
+    with pytest.raises(ValueError, match="correction shape"):
+        pysiglib.branched_sig(path, N, correction=np.zeros(d * d, dtype=path.dtype))
     with pytest.raises(ValueError, match="prefix"):
-        pysiglib.branched_sig(path, N, correction=np.zeros(d * d + 1, dtype=path.dtype))
+        pysiglib.branched_sig(path, N, correction=np.zeros((path.shape[-2] - 1, d * d + 1), dtype=path.dtype))
     with pytest.raises(ValueError, match="same dtype"):
-        pysiglib.branched_sig(path, N, correction=np.zeros(d * d, dtype=np.float32))
+        pysiglib.branched_sig(path, N, correction=np.zeros((path.shape[-2] - 1, d * d), dtype=np.float32))
 
 
 def test_torch_branched_sig_correction_validation_dtype():
     d, N = 2, 3
     path = torch.zeros((3, d), dtype=torch.float64)
     with pytest.raises(ValueError, match="same dtype"):
-        pysiglib.torch_api.branched_sig(path, N, correction=torch.zeros(d * d, dtype=torch.float32))
+        pysiglib.torch_api.branched_sig(path, N, correction=torch.zeros((path.shape[-2] - 1, d * d), dtype=torch.float32))
 
 
 def test_torch_branched_sig_correction_rejects_lead_lag():
@@ -307,7 +314,7 @@ def test_torch_branched_sig_correction_validation_device():
     d, N = 2, 3
     path = torch.zeros((3, d), dtype=torch.float64, device="cuda")
     with pytest.raises(ValueError, match="same device"):
-        pysiglib.torch_api.branched_sig(path, N, correction=torch.zeros(d * d, dtype=torch.float64))
+        pysiglib.torch_api.branched_sig(path, N, correction=torch.zeros((path.shape[-2] - 1, d * d), dtype=torch.float64))
 
 
 def test_branched_sig_correction_degree2_single_segment():
@@ -317,7 +324,7 @@ def test_branched_sig_correction_degree2_single_segment():
     end_time = 2.0
     path = np.array([[0.0], [x]])
 
-    correction = ito_level2_correction(d, end_time)
+    correction = per_segment_correction(path, ito_level2_correction(d, end_time))
     bsig = pysiglib.branched_sig(path, N, correction=correction, end_time=end_time)
 
     expected = np.array([x, 0.5 * x * x + end_time])
@@ -330,7 +337,7 @@ def test_branched_sig_correction_zero_path_accumulates_constant():
     end_time = 3.5
     path = np.zeros((8, d))
 
-    correction = ito_level2_correction(d, local_segment_dt(path, end_time))
+    correction = per_segment_correction(path, ito_level2_correction(d, local_segment_dt(path, end_time)))
     bsig = pysiglib.branched_sig(path, N, correction=correction, end_time=end_time)
 
     np.testing.assert_allclose(bsig, np.array([0.0, end_time]), atol=1e-14)
@@ -343,7 +350,7 @@ def test_branched_sig_level2_correction_single_segment_hopf_exp_higher_degree():
     path = np.vstack([np.zeros(d), increment])
     end_time = 1.7
 
-    correction = ito_level2_correction(d, end_time)
+    correction = per_segment_correction(path, ito_level2_correction(d, end_time))
     bsig = pysiglib.branched_sig(path, N, correction=correction, end_time=end_time, scalar_term=True)
     expected = ito_local_log_reference(increment, d, N, end_time)
     expected = branched_hopf_exp_reference(expected, d, N)
@@ -358,7 +365,7 @@ def test_branched_sig_level3_correction_single_segment():
     c2 = 0.4
     c3 = -0.15
     path = np.array([[0.0], [x]])
-    correction = np.array([c2, c3], dtype=np.float64)
+    correction = per_segment_correction(path, np.array([c2, c3], dtype=np.float64))
 
     local_log = np.zeros(pysiglib.branched_sig_length(d, N, scalar_term=True))
     local_log[1] = x
@@ -377,7 +384,7 @@ def test_planar_branched_sig_level2_correction_single_segment_hopf_exp():
     path = np.vstack([np.zeros(d), increment])
     end_time = 1.7
 
-    correction = ito_level2_correction(d, end_time)
+    correction = per_segment_correction(path, ito_level2_correction(d, end_time))
     bsig = pysiglib.branched_sig(path, N, correction=correction, end_time=end_time, planar=True, scalar_term=True)
     expected = ito_local_log_reference(increment, d, N, end_time, planar=True)
     expected = branched_hopf_exp_reference(expected, d, N, planar=True)
@@ -392,7 +399,7 @@ def test_branched_sig_correction_time_aug_original_channels_only():
     increment = 0.8
     path = np.array([[0.0], [increment]])
 
-    correction = ito_level2_correction(data_dim, end_time)
+    correction = per_segment_correction(path, ito_level2_correction(data_dim, end_time))
     bsig = pysiglib.branched_sig(path, N, time_aug=True, correction=correction, end_time=end_time, scalar_term=True)
     expected = ito_local_log_reference(np.array([increment, end_time]), data_dim, N, end_time)
     expected = branched_hopf_exp_reference(expected, 2, N)
@@ -405,7 +412,7 @@ def test_branched_sig_correction_rejects_lead_lag():
     pysiglib.prepare_branched_sig(2 * d, N)
     x = 0.7
     path = np.array([[0.0], [x]])
-    correction = ito_level2_correction(d, 0.5)
+    correction = per_segment_correction(path, ito_level2_correction(d, 0.5))
 
     with pytest.raises(ValueError, match="lead_lag"):
         pysiglib.branched_sig(path, N, correction=correction, lead_lag=True)
@@ -419,7 +426,7 @@ def test_branched_sig_correction_rejects_lead_lag_in_related_apis():
     d, N = 1, 2
     pysiglib.prepare_branched_sig(2 * d, N)
     path = np.array([[0.0], [0.7]])
-    correction = ito_level2_correction(d, 0.5)
+    correction = per_segment_correction(path, ito_level2_correction(d, 0.5))
     bsig = pysiglib.branched_sig(path, N, lead_lag=True)
     derivs = np.ones_like(bsig)
 
@@ -470,7 +477,7 @@ def test_jax_branched_sig_correction_if_available():
     d, N = 1, 3
     pysiglib.prepare_branched_sig(d + 1, N)
     path = np.array([[0.0], [0.3], [0.1]], dtype=np.float32)
-    correction = ito_level2_correction(d, local_segment_dt(path), dtype=path.dtype)
+    correction = per_segment_correction(path, ito_level2_correction(d, local_segment_dt(path), dtype=path.dtype))
     expected = pysiglib.branched_sig(path, N, time_aug=True, correction=correction)
 
     actual = np.asarray(jax_api.branched_sig(jnp.asarray(path), N, time_aug=True, correction=jnp.asarray(correction)))
@@ -493,7 +500,7 @@ def test_jax_branched_sig_correction_rejects_lead_lag_if_available():
     jnp = pytest.importorskip("jax.numpy")
 
     path = np.array([[0.0], [0.3]], dtype=np.float32)
-    correction = ito_level2_correction(1, 0.5, dtype=path.dtype)
+    correction = per_segment_correction(path, ito_level2_correction(1, 0.5, dtype=path.dtype))
 
     with pytest.raises(ValueError, match="lead_lag"):
         jax_api.branched_sig(jnp.asarray(path), 2, lead_lag=True, correction=jnp.asarray(correction))
@@ -517,7 +524,9 @@ def test_branched_sig_correction_matches_stochastax_degree2_if_available():
     )
 
     expected = np.asarray(stoch_sig.flatten())
-    actual = pysiglib.branched_sig(path, N, correction=ito_level2_correction(d, dt), end_time=end_time)
+    actual = pysiglib.branched_sig(
+        path, N, correction=per_segment_correction(path, ito_level2_correction(d, dt)),
+        end_time=end_time)
     np.testing.assert_allclose(actual, expected, atol=1e-10)
 
 
@@ -848,7 +857,7 @@ def test_branched_sig_backprop_correction_finite_diff(time_aug):
     pysiglib.prepare_branched_sig(aug_dim, N)
     np.random.seed(4011)
     path = np.cumsum(np.random.randn(4, d) * 0.1, axis=0)
-    correction = ito_level2_correction(d, local_segment_dt(path, end_time))
+    correction = per_segment_correction(path, ito_level2_correction(d, local_segment_dt(path, end_time)))
 
     bsig = pysiglib.branched_sig(
         path, N, time_aug=time_aug, end_time=end_time, correction=correction)
@@ -875,7 +884,7 @@ def test_planar_branched_sig_backprop_correction_finite_diff():
     pysiglib.prepare_branched_sig(d, N, planar=True)
     np.random.seed(4012)
     path = np.cumsum(np.random.randn(4, d) * 0.1, axis=0)
-    correction = ito_level2_correction(d, local_segment_dt(path, end_time))
+    correction = per_segment_correction(path, ito_level2_correction(d, local_segment_dt(path, end_time)))
 
     bsig = pysiglib.branched_sig(path, N, end_time=end_time, correction=correction, planar=True)
     derivs = np.random.randn(len(bsig))
@@ -1544,4 +1553,3 @@ def test_planar_branched_sig_backprop_cuda_batch(d, N):
     for i in range(B):
         single_grad = pysiglib.branched_sig_backprop(paths[i], bsigs[i], derivs[i], N, planar=True)
         check_close(batch_grad[i], single_grad, double_atol=1e-10)
-

--- a/tests/test_branched_sig.py
+++ b/tests/test_branched_sig.py
@@ -287,11 +287,43 @@ def test_branched_sig_correction_validation_numpy():
     path = np.zeros((3, d), dtype=np.float64)
 
     with pytest.raises(ValueError, match="correction shape"):
-        pysiglib.branched_sig(path, N, correction=np.zeros(d * d, dtype=path.dtype))
+        pysiglib.branched_sig(path, N, correction=np.array(1.0, dtype=path.dtype))
     with pytest.raises(ValueError, match="prefix"):
         pysiglib.branched_sig(path, N, correction=np.zeros((path.shape[-2] - 1, d * d + 1), dtype=path.dtype))
     with pytest.raises(ValueError, match="same dtype"):
         pysiglib.branched_sig(path, N, correction=np.zeros((path.shape[-2] - 1, d * d), dtype=np.float32))
+
+
+def test_branched_sig_correction_layouts_match_full_batch():
+    d, N = 2, 3
+    pysiglib.prepare_branched_sig(d, N)
+    path = np.array(
+        [
+            [[0.0, 0.0], [0.2, -0.1], [0.5, 0.3]],
+            [[0.1, 0.2], [0.4, 0.0], [0.6, -0.2]],
+        ],
+        dtype=np.float64,
+    )
+    constant = np.array([0.2, -0.1, 0.05, 0.3], dtype=path.dtype)
+    constant_full = np.broadcast_to(
+        constant.reshape(1, 1, -1), (*path.shape[:-2], path.shape[-2] - 1, constant.shape[-1])).copy()
+    shared = np.array(
+        [[0.2, -0.1, 0.05, 0.3], [0.4, 0.0, -0.2, 0.1]],
+        dtype=path.dtype,
+    )
+    shared_full = np.broadcast_to(
+        shared.reshape(1, path.shape[-2] - 1, -1), (*path.shape[:-2], path.shape[-2] - 1, shared.shape[-1])).copy()
+
+    np.testing.assert_allclose(
+        pysiglib.branched_sig(path, N, correction=constant),
+        pysiglib.branched_sig(path, N, correction=constant_full),
+        atol=1e-14,
+    )
+    np.testing.assert_allclose(
+        pysiglib.branched_sig(path, N, correction=shared),
+        pysiglib.branched_sig(path, N, correction=shared_full),
+        atol=1e-14,
+    )
 
 
 def test_torch_branched_sig_correction_validation_dtype():
@@ -876,6 +908,44 @@ def test_branched_sig_backprop_correction_finite_diff(time_aug):
             grad_fd[i, j] = np.dot(derivs, bsig_p - np.array(bsig)) / eps
 
     np.testing.assert_allclose(grad_bp, grad_fd, atol=1e-4)
+
+
+def test_branched_sig_backprop_correction_layouts_match_full_batch():
+    d, N = 2, 3
+    pysiglib.prepare_branched_sig(d, N)
+    path = np.array(
+        [
+            [[0.0, 0.0], [0.2, -0.1], [0.5, 0.3]],
+            [[0.1, 0.2], [0.4, 0.0], [0.6, -0.2]],
+        ],
+        dtype=np.float64,
+    )
+    constant = np.array([0.2, -0.1, 0.05, 0.3], dtype=path.dtype)
+    constant_full = np.broadcast_to(
+        constant.reshape(1, 1, -1), (*path.shape[:-2], path.shape[-2] - 1, constant.shape[-1])).copy()
+    shared = np.array(
+        [[0.2, -0.1, 0.05, 0.3], [0.4, 0.0, -0.2, 0.1]],
+        dtype=path.dtype,
+    )
+    shared_full = np.broadcast_to(
+        shared.reshape(1, path.shape[-2] - 1, -1), (*path.shape[:-2], path.shape[-2] - 1, shared.shape[-1])).copy()
+    derivs = np.ones_like(pysiglib.branched_sig(path, N, correction=constant_full))
+
+    bsig_constant = pysiglib.branched_sig(path, N, correction=constant)
+    bsig_constant_full = pysiglib.branched_sig(path, N, correction=constant_full)
+    np.testing.assert_allclose(
+        pysiglib.branched_sig_backprop(path, bsig_constant, derivs, N, correction=constant),
+        pysiglib.branched_sig_backprop(path, bsig_constant_full, derivs, N, correction=constant_full),
+        atol=1e-14,
+    )
+
+    bsig_shared = pysiglib.branched_sig(path, N, correction=shared)
+    bsig_shared_full = pysiglib.branched_sig(path, N, correction=shared_full)
+    np.testing.assert_allclose(
+        pysiglib.branched_sig_backprop(path, bsig_shared, derivs, N, correction=shared),
+        pysiglib.branched_sig_backprop(path, bsig_shared_full, derivs, N, correction=shared_full),
+        atol=1e-14,
+    )
 
 
 def test_planar_branched_sig_backprop_correction_finite_diff():

--- a/tests/test_jax_api.py
+++ b/tests/test_jax_api.py
@@ -144,7 +144,7 @@ def test_jax_sig_grad_matches_pysiglib(device, jitted, dtype, case):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_jax_sig_correction_matches_pysiglib(device, jitted, dtype):
     x = np.array([[0.0], [3.0]], dtype=dtype)
-    correction = np.array([2.0], dtype=dtype)
+    correction = np.array([[2.0]], dtype=dtype)
     expected = pysiglib.sig(x, 4, scalar_term=True, correction=correction)
 
     x_jax = _as_jax_array(x, device, dtype)
@@ -162,7 +162,7 @@ def test_jax_sig_correction_matches_pysiglib(device, jitted, dtype):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_jax_sig_correction_grad_matches_pysiglib(device, jitted, dtype):
     x = np.array([[0.1, -0.2], [0.4, 0.3], [0.0, 0.7]], dtype=dtype)
-    correction = np.array([0.2, -0.1, 0.05, 0.3], dtype=dtype)
+    correction = np.array([[0.2, -0.1, 0.05, 0.3]] * (x.shape[0] - 1), dtype=dtype)
     sig_ref = pysiglib.sig(x, 3, scalar_term=True, correction=correction)
     weights = np.linspace(-0.5, 0.7, sig_ref.shape[-1]).astype(dtype)
     grad_ref = pysiglib.sig_backprop(x, sig_ref, weights, 3, correction=correction)
@@ -178,6 +178,14 @@ def test_jax_sig_correction_grad_matches_pysiglib(device, jitted, dtype):
     grad_fn = jax.jit(jax.grad(loss_fn)) if jitted else jax.grad(loss_fn)
     grad = grad_fn(x_jax)
     check_close(grad_ref, grad, double_atol=1e-8)
+
+
+def test_jax_sig_rejects_rank1_correction():
+    path = jnp.zeros((2, 2), dtype=jnp.float64)
+    correction = jnp.zeros((4,), dtype=jnp.float64)
+
+    with pytest.raises(ValueError, match="correction shape"):
+        jax_api.sig(path, 2, correction=correction)
 
 
 # =========================================================================

--- a/tests/test_jax_api.py
+++ b/tests/test_jax_api.py
@@ -180,9 +180,19 @@ def test_jax_sig_correction_grad_matches_pysiglib(device, jitted, dtype):
     check_close(grad_ref, grad, double_atol=1e-8)
 
 
-def test_jax_sig_rejects_rank1_correction():
+def test_jax_sig_accepts_rank1_correction():
+    path = np.array([[0.0], [3.0]], dtype=np.float64)
+    correction = np.array([2.0], dtype=np.float64)
+
+    expected = pysiglib.sig(path, 4, scalar_term=True, correction=correction)
+    actual = jax_api.sig(jnp.asarray(path), 4, scalar_term=True, correction=jnp.asarray(correction))
+
+    check_close(expected, actual, double_atol=1e-8)
+
+
+def test_jax_sig_rejects_bad_correction_shape():
     path = jnp.zeros((2, 2), dtype=jnp.float64)
-    correction = jnp.zeros((4,), dtype=jnp.float64)
+    correction = jnp.zeros((1, 1, 4), dtype=jnp.float64)
 
     with pytest.raises(ValueError, match="correction shape"):
         jax_api.sig(path, 2, correction=correction)

--- a/tests/test_log_sig.py
+++ b/tests/test_log_sig.py
@@ -169,7 +169,7 @@ def test_batch_log_signature_lyndon_basis_random(device, deg, dtype, method):
 @pytest.mark.parametrize("device", DEVICES)
 def test_log_signature_method0_correction_matches_sig_to_log_sig(device):
     X = torch.tensor([[0.0], [3.0]], dtype=torch.float64, device=device)
-    correction = torch.tensor([2.0], dtype=torch.float64, device=device)
+    correction = torch.tensor([[2.0]], dtype=torch.float64, device=device)
 
     sig = pysiglib.sig(X, 4, scalar_term=True, correction=correction)
     expected = pysiglib.sig_to_log_sig(sig, 1, 4, method=0)
@@ -181,7 +181,7 @@ def test_log_signature_method0_correction_matches_sig_to_log_sig(device):
 
 def test_log_signature_method3_rejects_correction():
     X = torch.tensor([[0.0], [1.0]], dtype=torch.float64)
-    correction = torch.tensor([1.0], dtype=torch.float64)
+    correction = torch.tensor([[1.0]], dtype=torch.float64)
 
     with pytest.raises(ValueError, match="method=3"):
         pysiglib.log_sig(X, 2, method=3, correction=correction)

--- a/tests/test_sig_backprop.py
+++ b/tests/test_sig_backprop.py
@@ -206,7 +206,11 @@ def test_sig_backprop_correction_matches_finite_difference(device):
         dtype=torch.float64,
         device=device,
     )
-    correction = torch.tensor([0.2, -0.1, 0.05, 0.3], dtype=torch.float64, device=device)
+    correction = torch.tensor(
+        [[0.2, -0.1, 0.05, 0.3]] * (X.shape[0] - 1),
+        dtype=torch.float64,
+        device=device,
+    )
     weights = torch.linspace(
         -0.5, 0.7, pysiglib.sig_length(2, 3, scalar_term=True), dtype=torch.float64, device=device)
 
@@ -236,7 +240,11 @@ def test_torch_sig_correction_autograd_matches_manual_backprop(device):
         device=device,
         requires_grad=True,
     )
-    correction = torch.tensor([0.1, 0.0, -0.2, 0.3], dtype=torch.float64, device=device)
+    correction = torch.tensor(
+        [[0.1, 0.0, -0.2, 0.3]] * (X.shape[0] - 1),
+        dtype=torch.float64,
+        device=device,
+    )
     weights = torch.linspace(
         0.2, 1.1, pysiglib.sig_length(2, 3, scalar_term=True), dtype=torch.float64, device=device)
 
@@ -259,7 +267,7 @@ def test_torch_sig_correction_backward_uses_forward_values():
         dtype=torch.float64,
         requires_grad=True,
     )
-    correction = torch.tensor([0.1, 0.0, -0.2, 0.3], dtype=torch.float64)
+    correction = torch.tensor([[0.1, 0.0, -0.2, 0.3]] * (X.shape[0] - 1), dtype=torch.float64)
     expected_correction = correction.detach().clone()
 
     import pysiglib.torch_api as torch_api

--- a/tests/test_sig_backprop.py
+++ b/tests/test_sig_backprop.py
@@ -233,6 +233,41 @@ def test_sig_backprop_correction_matches_finite_difference(device):
 
 
 @pytest.mark.parametrize("device", DEVICES)
+def test_sig_backprop_correction_layouts_match_full_batch(device):
+    X = torch.tensor(
+        [
+            [[0.0, 0.0], [0.2, -0.1], [0.5, 0.3]],
+            [[0.1, 0.2], [0.4, 0.0], [0.6, -0.2]],
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    constant = torch.tensor([0.2, -0.1, 0.05, 0.3], dtype=X.dtype, device=device)
+    constant_full = constant.reshape(1, 1, -1).expand(X.shape[0], X.shape[1] - 1, -1).clone()
+    shared = torch.tensor(
+        [[0.2, -0.1, 0.05, 0.3], [0.4, 0.0, -0.2, 0.1]],
+        dtype=X.dtype,
+        device=device,
+    )
+    shared_full = shared.reshape(1, X.shape[1] - 1, -1).expand(X.shape[0], -1, -1).clone()
+    weights = torch.ones((X.shape[0], pysiglib.sig_length(2, 3, scalar_term=True)), dtype=X.dtype, device=device)
+
+    sig_constant = pysiglib.sig(X, 3, scalar_term=True, correction=constant)
+    sig_constant_full = pysiglib.sig(X, 3, scalar_term=True, correction=constant_full)
+    check_close(
+        pysiglib.sig_backprop(X, sig_constant, weights, 3, correction=constant),
+        pysiglib.sig_backprop(X, sig_constant_full, weights, 3, correction=constant_full),
+    )
+
+    sig_shared = pysiglib.sig(X, 3, scalar_term=True, correction=shared)
+    sig_shared_full = pysiglib.sig(X, 3, scalar_term=True, correction=shared_full)
+    check_close(
+        pysiglib.sig_backprop(X, sig_shared, weights, 3, correction=shared),
+        pysiglib.sig_backprop(X, sig_shared_full, weights, 3, correction=shared_full),
+    )
+
+
+@pytest.mark.parametrize("device", DEVICES)
 def test_torch_sig_correction_autograd_matches_manual_backprop(device):
     X = torch.tensor(
         [[0.2, 0.1], [0.5, -0.2], [0.3, 0.4]],

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -126,7 +126,7 @@ def test_signature_empty_correction_match_default(device):
 @pytest.mark.parametrize("device", DEVICES)
 def test_signature_level2_correction_single_segment(device):
     X = torch.tensor([[0.0], [3.0]], dtype=torch.float64, device=device)
-    correction = torch.tensor([[2.0]], dtype=torch.float64, device=device)
+    correction = torch.tensor([2.0], dtype=torch.float64, device=device)
 
     actual = pysiglib.sig(X, 4, scalar_term=True, correction=correction)
     expected = np.array([1.0, 3.0, 6.5, 10.5, 14.375])
@@ -138,13 +138,42 @@ def test_signature_level2_correction_single_segment(device):
 @pytest.mark.parametrize("device", DEVICES)
 def test_signature_level2_correction_propagate_across_segments(device):
     X = torch.zeros((3, 1), dtype=torch.float64, device=device)
-    correction = torch.tensor([[2.0], [2.0]], dtype=torch.float64, device=device)
+    correction = torch.tensor([2.0], dtype=torch.float64, device=device)
 
     actual = pysiglib.sig(X, 3, scalar_term=True, correction=correction)
     expected = np.array([1.0, 0.0, 4.0, 0.0])
 
     assert_device(actual, device)
     check_close(expected, actual)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_signature_correction_layouts_match_full_batch(device):
+    X = torch.tensor(
+        [
+            [[0.0, 0.0], [0.2, -0.1], [0.5, 0.3]],
+            [[0.1, 0.2], [0.4, 0.0], [0.6, -0.2]],
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    constant = torch.tensor([0.2, -0.1, 0.05, 0.3], dtype=X.dtype, device=device)
+    constant_full = constant.reshape(1, 1, -1).expand(X.shape[0], X.shape[1] - 1, -1).clone()
+    shared = torch.tensor(
+        [[0.2, -0.1, 0.05, 0.3], [0.4, 0.0, -0.2, 0.1]],
+        dtype=X.dtype,
+        device=device,
+    )
+    shared_full = shared.reshape(1, X.shape[1] - 1, -1).expand(X.shape[0], -1, -1).clone()
+
+    check_close(
+        pysiglib.sig(X, 3, scalar_term=True, correction=constant),
+        pysiglib.sig(X, 3, scalar_term=True, correction=constant_full),
+    )
+    check_close(
+        pysiglib.sig(X, 3, scalar_term=True, correction=shared),
+        pysiglib.sig(X, 3, scalar_term=True, correction=shared_full),
+    )
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -163,7 +192,7 @@ def test_signature_correction_validation_numpy():
     X = np.zeros((2, 2), dtype=np.float64)
 
     with pytest.raises(ValueError, match="correction shape"):
-        pysiglib.sig(X, 2, correction=np.zeros((4,), dtype=np.float64))
+        pysiglib.sig(X, 2, correction=np.array(1.0, dtype=np.float64))
 
     with pytest.raises(ValueError, match="same dtype"):
         pysiglib.sig(X, 2, correction=np.zeros((1, 4), dtype=np.float32))

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -126,7 +126,7 @@ def test_signature_empty_correction_match_default(device):
 @pytest.mark.parametrize("device", DEVICES)
 def test_signature_level2_correction_single_segment(device):
     X = torch.tensor([[0.0], [3.0]], dtype=torch.float64, device=device)
-    correction = torch.tensor([2.0], dtype=torch.float64, device=device)
+    correction = torch.tensor([[2.0]], dtype=torch.float64, device=device)
 
     actual = pysiglib.sig(X, 4, scalar_term=True, correction=correction)
     expected = np.array([1.0, 3.0, 6.5, 10.5, 14.375])
@@ -138,7 +138,7 @@ def test_signature_level2_correction_single_segment(device):
 @pytest.mark.parametrize("device", DEVICES)
 def test_signature_level2_correction_propagate_across_segments(device):
     X = torch.zeros((3, 1), dtype=torch.float64, device=device)
-    correction = torch.tensor([2.0], dtype=torch.float64, device=device)
+    correction = torch.tensor([[2.0], [2.0]], dtype=torch.float64, device=device)
 
     actual = pysiglib.sig(X, 3, scalar_term=True, correction=correction)
     expected = np.array([1.0, 0.0, 4.0, 0.0])
@@ -150,7 +150,7 @@ def test_signature_level2_correction_propagate_across_segments(device):
 @pytest.mark.parametrize("device", DEVICES)
 def test_signature_correction_time_aug_zero_time_entries(device):
     X = torch.zeros((2, 1), dtype=torch.float64, device=device)
-    correction = torch.tensor([2.0], dtype=torch.float64, device=device)
+    correction = torch.tensor([[2.0]], dtype=torch.float64, device=device)
 
     actual = pysiglib.sig(X, 2, time_aug=True, scalar_term=True, correction=correction)
     expected = np.array([1.0, 0.0, 1.0, 2.0, 0.0, 0.0, 0.5])
@@ -162,14 +162,14 @@ def test_signature_correction_time_aug_zero_time_entries(device):
 def test_signature_correction_validation_numpy():
     X = np.zeros((2, 2), dtype=np.float64)
 
-    with pytest.raises(ValueError, match="1D"):
-        pysiglib.sig(X, 2, correction=np.zeros((2, 2), dtype=np.float64))
+    with pytest.raises(ValueError, match="correction shape"):
+        pysiglib.sig(X, 2, correction=np.zeros((4,), dtype=np.float64))
 
     with pytest.raises(ValueError, match="same dtype"):
-        pysiglib.sig(X, 2, correction=np.zeros((4,), dtype=np.float32))
+        pysiglib.sig(X, 2, correction=np.zeros((1, 4), dtype=np.float32))
 
     with pytest.raises(ValueError, match="prefix"):
-        pysiglib.sig(X, 3, correction=np.zeros((5,), dtype=np.float64))
+        pysiglib.sig(X, 3, correction=np.zeros((1, 5), dtype=np.float64))
 
     with pytest.raises(ValueError, match="lead_lag"):
-        pysiglib.sig(X, 2, lead_lag=True, correction=np.zeros((4,), dtype=np.float64))
+        pysiglib.sig(X, 2, lead_lag=True, correction=np.zeros((1, 4), dtype=np.float64))


### PR DESCRIPTION
## Summary
Corrections are now always per-segment. A non-empty correction must have the same leading batch shape as the path, one row per time interval, and a final flat correction-level dimension.

This is quite a major change, so I wouldn't merge immediately.

## Use-case

Per-segment corrections allow the lift to use a different quadratic-variation increment for each path segment.

For example, in Heston, $[X]_{s,t} = \int_s^t v_u\,du$, so the level-2 correction depends on the variance accumulated over that specific interval rather than one constant value shared by every segment.

This also makes non-uniform time grids natural, since each correction row can use its own $\Delta t_i$.


```python
# Unbatched path: T points in d channels.
path.shape == (T, d)
correction.shape == (T - 1, L)

# Batched path: B paths, T points in d channels.
path.shape == (B, T, d)
correction.shape == (B, T - 1, L)

# Higher batch dims.
path.shape == (B1, B2, T, d)
correction.shape == (B1, B2, T - 1, L)
```

`L` is a prefix of correction levels:

```python
L = d**2                  # level 2 only
L = d**2 + d**3           # levels 2 and 3
L = d**2 + d**3 + ... + d**m
```

## Behaviour

```python
# Old flat/static corrections are rejected.
pysiglib.sig(path, degree, correction=np.zeros((L,)))          # ValueError
pysiglib.branched_sig(path, degree, correction=np.zeros((L,))) # ValueError

# One row per segment is accepted.
pysiglib.sig(path, degree, correction=np.zeros((T - 1, L)))
pysiglib.branched_sig(batch, degree, correction=np.zeros((B, T - 1, L)))
```

Tensor and branched signatures share the same shape contract, but apply the row to different bases:

```python
# Tensor signature correction[..., seg, :] is added to tensor levels 2..m for segment `seg`.

# Branched signature
correction[..., seg, :] is scattered onto the chain/ladder tree coordinates in the local branched log for segment `seg`.
```

Empty corrections still mean no correction. Corrections remain unsupported with `lead_lag=True`.

## Validation

  `tests/test_branched_sig.py tests/test_signature.py tests/test_sig_backprop.py tests/test_jax_api.py`  (`512 passed, 35 skipped`).
