### PR TITLE
[codex] Add Julia bindings submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bindings/julia/SigLib.jl"]
+	path = bindings/julia/SigLib.jl
+	url = https://github.com/luke-a-thompson/SigLib.jl


### PR DESCRIPTION
## Summary

Adds a git submodule at `bindings/julia/SigLib.jl` pointing to the Julia wrapper repository:

https://github.com/luke-a-thompson/SigLib.jl

This makes the Julia binding discoverable from the pySigLib repository without vendoring its source into this tree.

## Notes

The submodule is pinned to commit `06cabe596f85b5c72e5b06c5803c453f9cd15474` from `luke-a-thompson/SigLib.jl`.

## Validation

- Verified the submodule entry with `git submodule status`.
- No code tests were run because this only adds repository metadata and a submodule gitlink.

Codex was used to write this PR (but its just a submodile so i think its okay)
