### PR TITLE
Fix type hints: change torch.tensor to torch.Tensor

### DIFF
--- a/pysiglib/linear_sig.py
+++ b/pysiglib/linear_sig.py
@@ -26,13 +26,13 @@ from .data_handlers import SigInputHandler, SigOutputHandler
 
 
 def linear_sig(
-        displacement : Union[np.ndarray, torch.tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         scalar_term : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the truncated signature of a single linear segment defined by a displacement vector.
     Given a displacement vector :math:`v \\in \\mathbb{R}^d`, this computes the signature of the

--- a/pysiglib/log_sig.py
+++ b/pysiglib/log_sig.py
@@ -225,7 +225,7 @@ def clear_cache(
             raise Exception("Error in pysiglib.clear_cache (CUDA): " + err_msg(err_code))
 
 def sig_to_log_sig(
-        sig : Union[np.ndarray, torch.tensor],
+        sig : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -233,7 +233,7 @@ def sig_to_log_sig(
         lead_lag : bool = False,
         method : int = 1,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the log signature from the signature, using the specified method. For details,
     see the page :doc:`Computing Log Signatures </pages/log_signatures/log_sig_methods>`.
@@ -313,7 +313,7 @@ def sig_to_log_sig(
     return result.data
 
 def log_sig(
-        path : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
         degree : int,
         *,
         time_aug : bool = False,
@@ -323,7 +323,7 @@ def log_sig(
         scalar_term : bool = False,
         correction = None,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the log signature using the specified method. For details,
     see the page :doc:`Computing Log Signatures </pages/log_signatures/log_sig_methods>`.

--- a/pysiglib/log_sig_backprop.py
+++ b/pysiglib/log_sig_backprop.py
@@ -28,8 +28,8 @@ from .data_handlers import SigOutputHandler, SigInputHandler, PathInputHandler, 
 
 
 def sig_to_log_sig_backprop(
-        sig : Union[np.ndarray, torch.tensor],
-        log_sig_derivs : Union[np.ndarray, torch.tensor],
+        sig : Union[np.ndarray, torch.Tensor],
+        log_sig_derivs : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -37,7 +37,7 @@ def sig_to_log_sig_backprop(
         lead_lag : bool = False,
         method : int = 1,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Backpropagates through the ``pysiglib.sig_to_log_sig`` function.
     Given the derivatives of a scalar function :math:`F` with respect to the
@@ -135,12 +135,12 @@ def sig_to_log_sig_backprop(
 
 
 def _log_sig_from_path_backprop(
-        grad_output : Union[np.ndarray, torch.tensor],
-        path : Union[np.ndarray, torch.tensor],
+        grad_output : Union[np.ndarray, torch.Tensor],
+        path : Union[np.ndarray, torch.Tensor],
         degree : int,
         *,
         n_jobs : int = 1,
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """Backpropagates through the method=3 log-signature-from-path computation."""
     check_type(degree, "degree", int)
     check_non_neg(degree, "degree")

--- a/pysiglib/log_sig_combine.py
+++ b/pysiglib/log_sig_combine.py
@@ -26,15 +26,15 @@ from .data_handlers import MultipleSigInputHandler, SigOutputHandler
 
 
 def log_sig_combine(
-        log_sig1: Union[np.ndarray, torch.tensor],
-        log_sig2: Union[np.ndarray, torch.tensor],
+        log_sig1: Union[np.ndarray, torch.Tensor],
+        log_sig2: Union[np.ndarray, torch.Tensor],
         dimension: int,
         degree: int,
         *,
         time_aug: bool = False,
         lead_lag: bool = False,
         n_jobs: int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Combines two truncated log-signatures (Lyndon basis) of the same degree and dimension
     using the Baker-Campbell-Hausdorff (BCH) formula. In particular, let :math:`x_1, x_2`
@@ -99,9 +99,9 @@ def log_sig_combine(
 
 
 def log_sig_combine_backprop(
-        deriv: Union[np.ndarray, torch.tensor],
-        ls1: Union[np.ndarray, torch.tensor],
-        ls2: Union[np.ndarray, torch.tensor],
+        deriv: Union[np.ndarray, torch.Tensor],
+        ls1: Union[np.ndarray, torch.Tensor],
+        ls2: Union[np.ndarray, torch.Tensor],
         dimension: int,
         degree: int,
         *,

--- a/pysiglib/log_sig_join.py
+++ b/pysiglib/log_sig_join.py
@@ -26,13 +26,13 @@ from .data_handlers import SigInputHandler, SigOutputHandler
 
 
 def log_sig_join(
-        log_sig : Union[np.ndarray, torch.tensor],
-        displacement : Union[np.ndarray, torch.tensor],
+        log_sig : Union[np.ndarray, torch.Tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Extends a truncated log-signature by a single displacement vector using the
     Baker-Campbell-Hausdorff (BCH) formula. This is the log-signature analogue of

--- a/pysiglib/log_sig_join_backprop.py
+++ b/pysiglib/log_sig_join_backprop.py
@@ -26,9 +26,9 @@ from .data_handlers import SigInputHandler, SigOutputHandler
 
 
 def log_sig_join_backprop(
-        d_out : Union[np.ndarray, torch.tensor],
-        log_sig : Union[np.ndarray, torch.tensor],
-        displacement : Union[np.ndarray, torch.tensor],
+        d_out : Union[np.ndarray, torch.Tensor],
+        log_sig : Union[np.ndarray, torch.Tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,

--- a/pysiglib/logsig_to_sig.py
+++ b/pysiglib/logsig_to_sig.py
@@ -27,7 +27,7 @@ from .data_handlers import SigOutputHandler, SigInputHandler
 
 
 def logsig_to_sig(
-        log_sig : Union[np.ndarray, torch.tensor],
+        log_sig : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -36,7 +36,7 @@ def logsig_to_sig(
         method : int = 1,
         scalar_term : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the signature from the log-signature via the truncated tensor exponential.
     This is the inverse of :func:`pysiglib.sig_to_log_sig`.

--- a/pysiglib/logsig_to_sig_backprop.py
+++ b/pysiglib/logsig_to_sig_backprop.py
@@ -27,8 +27,8 @@ from .data_handlers import SigOutputHandler, SigInputHandler
 
 
 def logsig_to_sig_backprop(
-        log_sig : Union[np.ndarray, torch.tensor],
-        sig_derivs : Union[np.ndarray, torch.tensor],
+        log_sig : Union[np.ndarray, torch.Tensor],
+        sig_derivs : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -37,7 +37,7 @@ def logsig_to_sig_backprop(
         method : int = 1,
         scalar_term : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Backpropagation through :func:`pysiglib.logsig_to_sig`.
 

--- a/pysiglib/sig.py
+++ b/pysiglib/sig.py
@@ -26,15 +26,15 @@ from .sig_length import sig_length, aug_dim, _infer_scalar_term
 from .data_handlers import PathInputHandler, MultipleSigInputHandler, SigOutputHandler, CorrectionInputHandler
 
 def sig_combine(
-        sig1 : Union[np.ndarray, torch.tensor],
-        sig2 : Union[np.ndarray, torch.tensor],
+        sig1 : Union[np.ndarray, torch.Tensor],
+        sig2 : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         time_aug : bool = False,
         lead_lag : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Combines two truncated signatures of the same degree and dimension into one signature. In particular, let :math:`x_1, x_2`
     be two paths such that the first point of :math:`x_2` is the last point of :math:`x_1`. Let :math:`S(x_1), S(x_2)`
@@ -124,7 +124,7 @@ def sig_combine(
     return result.data
 
 def sig(
-        path : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
         degree : int,
         *,
         time_aug : bool = False,
@@ -134,7 +134,7 @@ def sig(
         scalar_term : bool = False,
         correction = None,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the truncated signature of single path or a batch of paths. For
     a single path :math:`x`, the signature is given by

--- a/pysiglib/sig_backprop.py
+++ b/pysiglib/sig_backprop.py
@@ -25,9 +25,9 @@ from .dtypes import CPSIG_SIG_BACKPROP, CPSIG_SIG_COMBINE_BACKPROP, CUSIG_SIG_BA
 from .sig_length import sig_length, aug_dim, _infer_scalar_term
 
 def sig_combine_backprop(
-        deriv : Union[np.ndarray, torch.tensor],
-        sig1 : Union[np.ndarray, torch.tensor],
-        sig2 : Union[np.ndarray, torch.tensor],
+        deriv : Union[np.ndarray, torch.Tensor],
+        sig1 : Union[np.ndarray, torch.Tensor],
+        sig2 : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -124,9 +124,9 @@ def sig_combine_backprop(
     return sig1_deriv.data, sig2_deriv.data
 
 def sig_backprop(
-        path : Union[np.ndarray, torch.tensor],
-        sig : Union[np.ndarray, torch.tensor],
-        sig_derivs : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
+        sig : Union[np.ndarray, torch.Tensor],
+        sig_derivs : Union[np.ndarray, torch.Tensor],
         degree : int,
         *,
         time_aug : bool = False,
@@ -134,7 +134,7 @@ def sig_backprop(
         end_time : float = 1.,
         correction = None,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     This function is required to backpropagate through the signature computation.
     Given the derivatives of a scalar function :math:`F` with respect to the

--- a/pysiglib/sig_coef.py
+++ b/pysiglib/sig_coef.py
@@ -27,19 +27,19 @@ from .words import word_to_idx
 from .data_handlers import SigInputHandler, PathInputHandler, SigOutputHandler
 
 def extract_sig_coef(
-        sig : Union[np.ndarray, torch.tensor],
+        sig : Union[np.ndarray, torch.Tensor],
         words: Union[tuple[int, ...], list[tuple[int, ...]]],
         dimension: int,
         *,
         time_aug: bool = False,
         lead_lag: bool = False,
         scalar_term: bool = False,
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Extracts signature coefficients from a signature or batch of signatures.
 
     :param sig: The signature or batch of signatures, of shape ``(..., sig_length)``.
-    :type sig: numpy.ndarray | torch.tensor
+    :type sig: numpy.ndarray | torch.Tensor
     :param words: Word or list of words at which to extract coefficients.
     :type words: tuple[int, ...] | list[tuple[int, ...]]]
     :param dimension: Dimension of the underlying path(s).
@@ -54,7 +54,7 @@ def extract_sig_coef(
     :type scalar_term: bool
     :return: Signature coefficients of shape ``(..., num_words)``, matching the leading
         batch dimensions of ``sig``.
-    :rtype: numpy.ndarray | torch.tensor
+    :rtype: numpy.ndarray | torch.Tensor
 
     Example:
     ---------
@@ -105,7 +105,7 @@ def extract_sig_coef(
     return sig[..., idx]
 
 def sig_coef(
-        path : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
         words : Union[tuple[int, ...], list[tuple[int, ...]]],
         *,
         time_aug : bool = False,
@@ -113,7 +113,7 @@ def sig_coef(
         end_time : float = 1.,
         prefixes : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes specific signature coefficients for a single path or a batch of paths. For
     a single path :math:`x`, the signature coefficient at a multi-index
@@ -124,7 +124,7 @@ def sig_coef(
         S(x)^I_{[s,t]} := \\int_{s < t_1 < \\cdots < t_k < t} dx^{i_1}_{t_1} \\otimes dx^{i_2}_{t_2} \\otimes \\cdots \\otimes dx^{i_k}_{t_k}.
 
     :param path: The underlying path or batch of paths, of shape ``(..., length, dimension)``.
-    :type path: numpy.ndarray | torch.tensor
+    :type path: numpy.ndarray | torch.Tensor
     :param words: Multi-indices :math:`I` at which to evaluate signature coefficients, given as a list
         of lists of integers in :math:`[0, d-1]`, where :math:`d` is the dimension of the path(s). For example,
         for a 2-dimensional path, one could pass ``[(0,), (1,0), (0,1,1)]`` to compute the coefficients at
@@ -149,7 +149,7 @@ def sig_coef(
     :type n_jobs: int
     :return: Signature coefficients of shape ``(..., num_words)``, matching the leading
         batch dimensions of ``path``.
-    :rtype: numpy.ndarray | torch.tensor
+    :rtype: numpy.ndarray | torch.Tensor
 
     .. note::
 

--- a/pysiglib/sig_coef_backprop.py
+++ b/pysiglib/sig_coef_backprop.py
@@ -26,16 +26,16 @@ from .data_handlers import PathInputHandler, MultipleSigInputHandler, PathOutput
 
 
 def sig_coef_backprop(
-        path : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
         words : Union[tuple[int, ...], list[tuple[int, ...]]],
-        coefs : Union[np.ndarray, torch.tensor],
-        derivs : Union[np.ndarray, torch.tensor],
+        coefs : Union[np.ndarray, torch.Tensor],
+        derivs : Union[np.ndarray, torch.Tensor],
         *,
         time_aug : bool = False,
         lead_lag : bool = False,
         end_time : float = 1.,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     This function is required to backpropagate through signature coefficient computation.
     Given the derivatives of a scalar function :math:`F` with respect to the
@@ -46,17 +46,17 @@ def sig_coef_backprop(
     with respect to this extended array.
 
     :param path: The underlying path or batch of paths, of shape ``(..., length, dimension)``.
-    :type path: numpy.ndarray | torch.tensor
+    :type path: numpy.ndarray | torch.Tensor
     :param words: Multi-indices :math:`I` indexing the signature coefficients, given as a list
         of lists of integers in :math:`[0, d-1]`, where :math:`d` is the dimension of the path(s).
     :type words: tuple[int, ...] | list[tuple[int, ...]]
     :param coefs: Signature coefficients of the path or batch of paths, generated using
         ``pysiglib.sig_coef`` using ``prefixes=True``.
-    :type coefs: numpy.ndarray | torch.tensor
+    :type coefs: numpy.ndarray | torch.Tensor
     :param derivs: Derivatives of the scalar function :math:`F` with respect to the signature coefficients,
         :math:`\\partial F / \\partial S(x)^I`. This must be an array of the same shape as the
         provided coefficients. **On CPU, this buffer is modified in-place.**
-    :type derivs: numpy.ndarray | torch.tensor
+    :type derivs: numpy.ndarray | torch.Tensor
     :param time_aug: Whether the signature coefficients were computed with ``time_aug=True``.
     :type time_aug: bool
     :param lead_lag: Whether the signature coefficients were computed with ``lead_lag=True``.
@@ -69,7 +69,7 @@ def sig_coef_backprop(
     :type n_jobs: int
     :return: Derivatives of the scalar function :math:`F` with respect to the path(s), :math:`\\partial F / \\partial x`.
         This is an array of the same shape as the provided path(s).
-    :rtype: numpy.ndarray | torch.tensor
+    :rtype: numpy.ndarray | torch.Tensor
 
     Example:
     ---------

--- a/pysiglib/sig_join.py
+++ b/pysiglib/sig_join.py
@@ -26,14 +26,14 @@ from .data_handlers import SigInputHandler, SigOutputHandler
 
 
 def sig_join(
-        sig : Union[np.ndarray, torch.tensor],
-        displacement : Union[np.ndarray, torch.tensor],
+        sig : Union[np.ndarray, torch.Tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         prepend : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Extends a truncated signature by a single displacement vector. This is equivalent to
     computing ``sig_combine(sig, linear_sig(displacement))``, but is more efficient as it

--- a/pysiglib/sig_join_backprop.py
+++ b/pysiglib/sig_join_backprop.py
@@ -26,9 +26,9 @@ from .data_handlers import SigInputHandler, SigOutputHandler
 
 
 def sig_join_backprop(
-        d_out : Union[np.ndarray, torch.tensor],
-        sig : Union[np.ndarray, torch.tensor],
-        displacement : Union[np.ndarray, torch.tensor],
+        d_out : Union[np.ndarray, torch.Tensor],
+        sig : Union[np.ndarray, torch.Tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,

--- a/pysiglib/sig_kernel.py
+++ b/pysiglib/sig_kernel.py
@@ -59,8 +59,8 @@ from .data_handlers import MultiplePathInputHandler, ScalarOutputHandler, GridOu
 from .static_kernels import StaticKernel, LinearKernel, Context
 
 def sig_kernel(
-        path1 : Union[np.ndarray, torch.tensor],
-        path2 : Union[np.ndarray, torch.tensor],
+        path1 : Union[np.ndarray, torch.Tensor],
+        path2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -70,7 +70,7 @@ def sig_kernel(
         n_jobs : int = 1,
         return_grid: bool = False,
         normalize : bool = False
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes a single signature kernel or a batch of signature kernels.
     The signature kernel of two :math:`d`-dimensional paths :math:`x,y`
@@ -265,8 +265,8 @@ def sig_kernel(
 
 
 def sig_kernel_gram(
-        path1 : Union[np.ndarray, torch.tensor],
-        path2 : Union[np.ndarray, torch.tensor],
+        path1 : Union[np.ndarray, torch.Tensor],
+        path2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -277,7 +277,7 @@ def sig_kernel_gram(
         max_batch : int = -1,
         return_grid : bool = False,
         normalize : bool = False
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Given batches of paths :math:`\\{x_i\\}_{i=1}^{B_1}` and :math:`\\{y_j\\}_{j=1}^{B_2}`, computes the gram matrix of signature kernels
 

--- a/pysiglib/sig_kernel_backprop.py
+++ b/pysiglib/sig_kernel_backprop.py
@@ -32,13 +32,13 @@ from .static_kernels import StaticKernel, LinearKernel, Context
 def gram_deriv(
         derivs_data,
         data,
-        gram : Union[np.ndarray, torch.tensor],
-        k_grid_data : Union[np.ndarray, torch.tensor],
+        gram : Union[np.ndarray, torch.Tensor],
+        k_grid_data : Union[np.ndarray, torch.Tensor],
         dyadic_order_1,
         dyadic_order_2,
         return_grid : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
 
     result = GridOutputHandler(data.length[0] - 1, data.length[1] - 1, derivs_data) #Derivatives with respect to gram matrix
     gram_ptr = cast(gram.data_ptr(), POINTER(DTYPES[str(gram.dtype)[6:]]))
@@ -58,9 +58,9 @@ def gram_deriv(
     return torch.as_tensor(result.data)
 
 def sig_kernel_backprop(
-        derivs : Union[np.ndarray, torch.tensor],
-        path1 : Union[np.ndarray, torch.tensor],
-        path2 : Union[np.ndarray, torch.tensor],
+        derivs : Union[np.ndarray, torch.Tensor],
+        path1 : Union[np.ndarray, torch.Tensor],
+        path2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -69,10 +69,10 @@ def sig_kernel_backprop(
         end_time : float = 1.,
         left_deriv : bool = True,
         right_deriv : bool = False,
-        k_grid : Union[np.ndarray, torch.tensor] = None,
+        k_grid : Union[np.ndarray, torch.Tensor] = None,
         n_jobs : int = 1,
         return_grid: bool = False
-) -> Union[np.ndarray, torch.tensor, Tuple[np.ndarray, np.ndarray], Tuple[torch.tensor, torch.tensor]]:
+) -> Union[np.ndarray, torch.Tensor, Tuple[np.ndarray, np.ndarray], Tuple[torch.Tensor, torch.Tensor]]:
     """
     This function is required to backpropagate through ``pysiglib.sig_kernel``.
     Given the derivatives of a scalar function :math:`F` with respect to a
@@ -86,14 +86,14 @@ def sig_kernel_backprop(
         If ``return_grid=False``, this should be of shape ``(...)`` matching the leading
         batch dimensions of the paths. If ``return_grid=True``, this should have the same
         shape as the PDE grid returned by ``pysiglib.sig_kernel(..., return_grid=True)``.
-    :type derivs: numpy.ndarray | torch.tensor
+    :type derivs: numpy.ndarray | torch.Tensor
     :param path1: The first underlying path or batch of paths, of shape
         ``(..., length_1, dimension)``.
-    :type path1: numpy.ndarray | torch.tensor
+    :type path1: numpy.ndarray | torch.Tensor
     :param path2: The second underlying path or batch of paths, of shape
         ``(..., length_2, dimension)``. Leading batch dimensions must match those of
         ``path1``.
-    :type path2: numpy.ndarray | torch.tensor
+    :type path2: numpy.ndarray | torch.Tensor
     :param dyadic_order: The dyadic order(s) used to compute the signature kernels.
     :type dyadic_order: int | tuple
     :param static_kernel: Static kernel. If ``None`` (default), the linear kernel will be used.
@@ -114,7 +114,7 @@ def sig_kernel_backprop(
         ``True``, returns both derivatives as a tuple.
     :type right_deriv: bool
     :param k_grid: Signature kernel PDE grid. If ``None``, the grid will be recomputed.
-    :type k_grid: numpy.ndarray | torch.tensor
+    :type k_grid: numpy.ndarray | torch.Tensor
     :param n_jobs: (Only applicable to CPU computation) Number of threads to run in parallel.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
         are used. For n_jobs below -1, (max_threads + 1 + n_jobs) threads are used. For example
@@ -127,7 +127,7 @@ def sig_kernel_backprop(
         this tuple is  :math:`\\{\\partial F / x_{t_i}\\}_{i=0}^{L_1}`, otherwise
         it is ``None``. Similarly for ``right_deriv`` and
         :math:`\\{\\partial F / y_{t_i}\\}_{i=0}^{L_2}`.
-    :rtype: numpy.ndarray | torch.tensor | Tuple[numpy.ndarray | numpy.ndarray] | Tuple[torch.tensor | torch.tensor]
+    :rtype: numpy.ndarray | torch.Tensor | Tuple[numpy.ndarray | numpy.ndarray] | Tuple[torch.Tensor | torch.Tensor]
 
     Example:
     ---------
@@ -257,9 +257,9 @@ def sig_kernel_backprop(
 
 
 def sig_kernel_gram_backprop(
-        derivs : Union[np.ndarray, torch.tensor],
-        path1 : Union[np.ndarray, torch.tensor],
-        path2 : Union[np.ndarray, torch.tensor],
+        derivs : Union[np.ndarray, torch.Tensor],
+        path1 : Union[np.ndarray, torch.Tensor],
+        path2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -268,7 +268,7 @@ def sig_kernel_gram_backprop(
         end_time : float = 1.,
         left_deriv : bool = True,
         right_deriv : bool = False,
-        k_grid : Union[np.ndarray, torch.tensor] = None,
+        k_grid : Union[np.ndarray, torch.Tensor] = None,
         n_jobs : int = 1,
         return_grid : bool = False,
         max_batch : int = -1

--- a/pysiglib/sig_metrics.py
+++ b/pysiglib/sig_metrics.py
@@ -7,8 +7,8 @@ from .static_kernels import StaticKernel
 from .sig_kernel import sig_kernel_gram, _ensure_3d
 
 def sig_score(
-        sample : Union[np.ndarray, torch.tensor],
-        y : Union[np.ndarray, torch.tensor],
+        sample : Union[np.ndarray, torch.Tensor],
+        y : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         lam : float = 1.,
@@ -18,7 +18,7 @@ def sig_score(
         end_time : float = 1.,
         n_jobs : int = 1,
         max_batch : int = -1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the (generalised) signature kernel score
 
@@ -151,8 +151,8 @@ def sig_score(
     return res
 
 def expected_sig_score(
-        sample1 : Union[np.ndarray, torch.tensor],
-        sample2 : Union[np.ndarray, torch.tensor],
+        sample1 : Union[np.ndarray, torch.Tensor],
+        sample2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         lam : float = 1.,
@@ -162,7 +162,7 @@ def expected_sig_score(
         end_time : float = 1.,
         n_jobs : int = 1,
         max_batch : int = -1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the expected (generalised) signature kernel score
 
@@ -255,8 +255,8 @@ def expected_sig_score(
     return res.mean().reshape(1)
 
 def sig_mmd(
-        sample1 : Union[np.ndarray, torch.tensor],
-        sample2 : Union[np.ndarray, torch.tensor],
+        sample1 : Union[np.ndarray, torch.Tensor],
+        sample2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -265,7 +265,7 @@ def sig_mmd(
         end_time : float = 1.,
         n_jobs : int = 1,
         max_batch : int = -1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     Computes the squared maximum mean discrepancy (MMD)
 

--- a/pysiglib/torch_api/torch_api.py
+++ b/pysiglib/torch_api/torch_api.py
@@ -87,7 +87,7 @@ class Sig(torch.autograd.Function):
         return grad, None, None, None, None, None, None, None, None
 
 def sig(
-        path : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
         degree : int,
         *,
         time_aug : bool = False,
@@ -97,7 +97,7 @@ def sig(
         scalar_term : bool = False,
         correction = None,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     if not isinstance(path, torch.Tensor):
         return sig_forward(path, degree, scalar_term=scalar_term, time_aug=time_aug, lead_lag=lead_lag,
                            end_time=end_time, horner=horner, correction=correction, n_jobs=n_jobs)
@@ -126,15 +126,15 @@ class SigCombine(torch.autograd.Function):
         return sig1_grad, sig2_grad, None, None, None, None, None
 
 def sig_combine(
-        sig1 : Union[np.ndarray, torch.tensor],
-        sig2 : Union[np.ndarray, torch.tensor],
+        sig1 : Union[np.ndarray, torch.Tensor],
+        sig2 : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         time_aug: bool = False,
         lead_lag: bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return SigCombine.apply(sig1, sig2, dimension, degree, time_aug, lead_lag, n_jobs)
 
 
@@ -176,7 +176,7 @@ class SigCoef(torch.autograd.Function):
         return grad, None, None, None, None, None
 
 def sig_coef(
-        path: Union[np.ndarray, torch.tensor],
+        path: Union[np.ndarray, torch.Tensor],
         words: Union[tuple[int, ...], list[tuple[int, ...]]],
         *,
         time_aug: bool = False,
@@ -184,7 +184,7 @@ def sig_coef(
         end_time: float = 1.,
         prefixes: bool = False,
         n_jobs: int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     coefs_ = SigCoef.apply(path, words, time_aug, lead_lag, end_time, n_jobs)
     return _get_coef_from_prefixes(words, coefs_, prefixes)
 
@@ -208,13 +208,13 @@ class TransformPath(torch.autograd.Function):
         return new_derivs, None, None, None, None
 
 def transform_path(
-    path : Union[np.ndarray, torch.tensor],
+    path : Union[np.ndarray, torch.Tensor],
     *,
     time_aug : bool = False,
     lead_lag : bool = False,
     end_time : float = 1.,
     n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return TransformPath.apply(path, time_aug, lead_lag, end_time, n_jobs)
 
 transform_path.__doc__ = transform_path_forward.__doc__
@@ -241,7 +241,7 @@ class SigToLogSig(torch.autograd.Function):
         return grad, None, None, None, None, None, None
 
 def sig_to_log_sig(
-        sig : Union[np.ndarray, torch.tensor],
+        sig : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -249,14 +249,14 @@ def sig_to_log_sig(
         lead_lag : bool = False,
         method : int = 1,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return SigToLogSig.apply(sig, dimension, degree, time_aug, lead_lag, method, n_jobs)
 
 
 sig_to_log_sig.__doc__ = sig_to_log_sig_forward.__doc__
 
 def log_sig(
-        path : Union[np.ndarray, torch.tensor],
+        path : Union[np.ndarray, torch.Tensor],
         degree : int,
         *,
         time_aug : bool = False,
@@ -266,7 +266,7 @@ def log_sig(
         scalar_term : bool = False,
         correction = None,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     if method == 3:
         if not isinstance(path, torch.Tensor) or _has_non_empty_correction(correction):
             return log_sig_forward(
@@ -372,8 +372,8 @@ class SigKernel(torch.autograd.Function):
         return d0, d1, None, None, None, None, None, None, None
 
 def sig_kernel(
-        path1 : Union[np.ndarray, torch.tensor],
-        path2 : Union[np.ndarray, torch.tensor],
+        path1 : Union[np.ndarray, torch.Tensor],
+        path2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -383,7 +383,7 @@ def sig_kernel(
         n_jobs : int = 1,
         return_grid: bool = False,
         normalize : bool = False
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     if normalize and return_grid:
         raise ValueError("normalize=True cannot be used with return_grid=True")
     k = SigKernel.apply(path1, path2, dyadic_order, static_kernel, time_aug, lead_lag, end_time, n_jobs, return_grid)
@@ -434,8 +434,8 @@ class SigKernelGram(torch.autograd.Function):
         return new_derivs[0], new_derivs[1], None, None, None, None, None, None, None, None
 
 def sig_kernel_gram(
-        path1: Union[np.ndarray, torch.tensor],
-        path2: Union[np.ndarray, torch.tensor],
+        path1: Union[np.ndarray, torch.Tensor],
+        path2: Union[np.ndarray, torch.Tensor],
         dyadic_order: Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -446,7 +446,7 @@ def sig_kernel_gram(
         max_batch: int = -1,
         return_grid: bool = False,
         normalize : bool = False
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     if normalize and return_grid:
         raise ValueError("normalize=True cannot be used with return_grid=True")
     gram = SigKernelGram.apply(path1, path2, dyadic_order, static_kernel, time_aug, lead_lag, end_time, n_jobs, max_batch, return_grid)
@@ -496,8 +496,8 @@ class BranchedSigKernel(torch.autograd.Function):
 
 
 def branched_sig_kernel(
-        path1: Union[np.ndarray, torch.tensor],
-        path2: Union[np.ndarray, torch.tensor],
+        path1: Union[np.ndarray, torch.Tensor],
+        path2: Union[np.ndarray, torch.Tensor],
         depth: int,
         dyadic_order: Union[int, tuple],
         *,
@@ -508,7 +508,7 @@ def branched_sig_kernel(
         n_jobs: int = 1,
         return_grid: bool = False,
         normalize: bool = False
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     if normalize and return_grid:
         raise ValueError("normalize=True cannot be used with return_grid=True")
     k = BranchedSigKernel.apply(path1, path2, depth, dyadic_order, static_kernel, time_aug, lead_lag, end_time, n_jobs, return_grid)
@@ -566,8 +566,8 @@ class BranchedSigKernelGram(torch.autograd.Function):
 
 
 def branched_sig_kernel_gram(
-        path1: Union[np.ndarray, torch.tensor],
-        path2: Union[np.ndarray, torch.tensor],
+        path1: Union[np.ndarray, torch.Tensor],
+        path2: Union[np.ndarray, torch.Tensor],
         depth: int,
         dyadic_order: Union[int, tuple],
         *,
@@ -579,7 +579,7 @@ def branched_sig_kernel_gram(
         max_batch: int = -1,
         return_grid: bool = False,
         normalize: bool = False
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     if normalize and return_grid:
         raise ValueError("normalize=True cannot be used with return_grid=True")
     gram = BranchedSigKernelGram.apply(
@@ -595,8 +595,8 @@ def branched_sig_kernel_gram(
 branched_sig_kernel_gram.__doc__ = branched_sig_kernel_gram_forward.__doc__
 
 def sig_score(
-        sample : Union[np.ndarray, torch.tensor],
-        y : Union[np.ndarray, torch.tensor],
+        sample : Union[np.ndarray, torch.Tensor],
+        y : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         lam : float = 1.,
@@ -606,7 +606,7 @@ def sig_score(
         end_time : float = 1.,
         n_jobs : int = 1,
         max_batch : int = -1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     check_type(sample, "sample", torch.Tensor)
     check_type(y, "y", torch.Tensor)
 
@@ -632,8 +632,8 @@ def sig_score(
 sig_score.__doc__ = sig_score_forward.__doc__
 
 def expected_sig_score(
-        sample1 : Union[np.ndarray, torch.tensor],
-        sample2 : Union[np.ndarray, torch.tensor],
+        sample1 : Union[np.ndarray, torch.Tensor],
+        sample2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         lam : float = 1.,
@@ -643,15 +643,15 @@ def expected_sig_score(
         end_time : float = 1.,
         n_jobs : int = 1,
         max_batch : int = -1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     res = sig_score(sample1, sample2, dyadic_order, lam=lam, static_kernel=static_kernel, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time, n_jobs=n_jobs, max_batch=max_batch)
     return res.mean().reshape(1)
 
 expected_sig_score.__doc__ = expected_sig_score_forward.__doc__
 
 def sig_mmd(
-        sample1 : Union[np.ndarray, torch.tensor],
-        sample2 : Union[np.ndarray, torch.tensor],
+        sample1 : Union[np.ndarray, torch.Tensor],
+        sample2 : Union[np.ndarray, torch.Tensor],
         dyadic_order : Union[int, tuple],
         *,
         static_kernel : Optional[StaticKernel] = None,
@@ -660,7 +660,7 @@ def sig_mmd(
         end_time : float = 1.,
         n_jobs : int = 1,
         max_batch : int = -1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     sample1 = _ensure_3d(sample1)
     sample2 = _ensure_3d(sample2)
 
@@ -704,15 +704,15 @@ class LogSigCombine(torch.autograd.Function):
         return ls1_grad, ls2_grad, None, None, None, None, None
 
 def log_sig_combine(
-        log_sig1 : Union[np.ndarray, torch.tensor],
-        log_sig2 : Union[np.ndarray, torch.tensor],
+        log_sig1 : Union[np.ndarray, torch.Tensor],
+        log_sig2 : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         time_aug: bool = False,
         lead_lag: bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return LogSigCombine.apply(log_sig1, log_sig2, dimension, degree, time_aug, lead_lag, n_jobs)
 
 log_sig_combine.__doc__ = log_sig_combine_forward.__doc__
@@ -898,7 +898,7 @@ class LogSigToSig(torch.autograd.Function):
         return grad, None, None, None, None, None, None, None
 
 def logsig_to_sig(
-        log_sig : Union[np.ndarray, torch.tensor],
+        log_sig : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
@@ -907,20 +907,20 @@ def logsig_to_sig(
         method : int = 1,
         scalar_term : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return LogSigToSig.apply(log_sig, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs)
 
 logsig_to_sig.__doc__ = logsig_to_sig_forward.__doc__
 
 
 def linear_sig(
-        displacement : Union[np.ndarray, torch.tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         scalar_term : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     # Delegate to sig() on a 2-point path [0, v] to reuse Sig's autograd.
     if isinstance(displacement, torch.Tensor):
         if displacement.shape[-1] != dimension:
@@ -959,14 +959,14 @@ class SigJoin(torch.autograd.Function):
         return d_sig, d_displacement, None, None, None, None
 
 def sig_join(
-        sig : Union[np.ndarray, torch.tensor],
-        displacement : Union[np.ndarray, torch.tensor],
+        sig : Union[np.ndarray, torch.Tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         prepend : bool = False,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return SigJoin.apply(sig, displacement, dimension, degree, int(prepend), n_jobs)
 
 sig_join.__doc__ = sig_join_forward.__doc__
@@ -990,13 +990,13 @@ class LogSigJoin(torch.autograd.Function):
         return d_logsig, d_displacement, None, None, None
 
 def log_sig_join(
-        log_sig : Union[np.ndarray, torch.tensor],
-        displacement : Union[np.ndarray, torch.tensor],
+        log_sig : Union[np.ndarray, torch.Tensor],
+        displacement : Union[np.ndarray, torch.Tensor],
         dimension : int,
         degree : int,
         *,
         n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     return LogSigJoin.apply(log_sig, displacement, dimension, degree, n_jobs)
 
 log_sig_join.__doc__ = log_sig_join_forward.__doc__

--- a/pysiglib/transform_path.py
+++ b/pysiglib/transform_path.py
@@ -26,13 +26,13 @@ from .dtypes import CPSIG_TRANSFORM_PATH, CUSIG_TRANSFORM_PATH_CUDA
 from .data_handlers import PathInputHandler
 
 def transform_path(
-    path : Union[np.ndarray, torch.tensor],
+    path : Union[np.ndarray, torch.Tensor],
     *,
     time_aug : bool = False,
     lead_lag : bool = False,
     end_time : float = 1.,
     n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     This function applies time-augmentation and/or the lead-lag transformation to a path. Given a
     :math:`d`-dimensional path :math:`(X_{t_i})_{i=1}^L`, the time-augmented path is formed by adding time as the

--- a/pysiglib/transform_path_backprop.py
+++ b/pysiglib/transform_path_backprop.py
@@ -26,13 +26,13 @@ from .dtypes import CPSIG_TRANSFORM_PATH_BACKPROP, CUSIG_TRANSFORM_PATH_BACKPROP
 from .data_handlers import PathInputHandler
 
 def transform_path_backprop(
-    derivs : Union[np.ndarray, torch.tensor],
+    derivs : Union[np.ndarray, torch.Tensor],
     *,
     time_aug : bool = False,
     lead_lag : bool = False,
     end_time : float = 1.,
     n_jobs : int = 1
-) -> Union[np.ndarray, torch.tensor]:
+) -> Union[np.ndarray, torch.Tensor]:
     """
     This function is required to backpropagate through ``pysiglib.transform_path``.
     Given the derivatives of a scalar function :math:`F` with respect to the


### PR DESCRIPTION
This was causing issues with type hinting as torch.tensor is a factory function rather than the type.