### PR TITLE
LogSigMethod Enum

### DIFF
--- a/siglib/cpsig/cp_bch.h
+++ b/siglib/cpsig/cp_bch.h
@@ -136,7 +136,7 @@ inline std::vector<double> compute_bch_coefficients(uint64_t degree) {
 	std::vector<double> bch_coefs(lslen, 0.0);
 
 	// Use log_sig_lyndon_basis: first get Lyndon word indices, then project
-	set_basis_cache(dim2, degree, 2, false);
+	set_basis_cache(dim2, degree, LogSigMethod::LyndonBasis, false);
 	log_sig_lyndon_basis<double>(result.data(), bch_coefs.data(), dim2, degree);
 
 	return bch_coefs;
@@ -258,7 +258,7 @@ inline void build_commutator_table(BchCache& cache) {
 
 	// Get the Lyndon word tensor indices and P^{-1} matrix from BasisCache
 	// (set_basis_cache has already been called before build_commutator_table)
-	const BasisCache& bc = get_basis_cache(dim, deg, 2);
+	const BasisCache& bc = get_basis_cache(dim, deg, LogSigMethod::LyndonBasis);
 	uint64_t n_lyndon = bc.lyndon_idx.size(); // = m
 
 	// Initialize commutator table
@@ -459,7 +459,7 @@ inline void set_bch_cache(uint64_t dimension, uint64_t degree) {
 	}
 
 	// Ensure the d-letter basis cache is set (needed for commutator table)
-	set_basis_cache(dimension, degree, 2, false);
+	set_basis_cache(dimension, degree, LogSigMethod::LyndonBasis, false);
 
 	auto cache = std::make_unique<BchCache>();
 	cache->dimension = dimension;
@@ -476,7 +476,7 @@ inline void set_bch_cache(uint64_t dimension, uint64_t degree) {
 	else {
 		// Fallback for degree > 12: compute at runtime
 		// This requires a 2-letter basis cache for the Lyndon projection
-		set_basis_cache(2, degree, 2, false);
+		set_basis_cache(2, degree, LogSigMethod::LyndonBasis, false);
 		cache->bch_coefficients = compute_bch_coefficients(degree);
 		compute_factorization_indices(2, degree, cache->bch_left_factor, cache->bch_right_factor);
 	}

--- a/siglib/cpsig/cp_exp_signature.h
+++ b/siglib/cpsig/cp_exp_signature.h
@@ -15,6 +15,7 @@
 
 #pragma once
 #include "cppch.h"
+#include "log_sig_method.h"
 
 #include "multithreading.h"
 #include "words.h"
@@ -260,7 +261,7 @@ template<std::floating_point T>
 std::unique_ptr<T[]> build_bracket_expansions_(
 	uint64_t dimension, uint64_t degree
 ) {
-	const BasisCache& cache = get_basis_cache(dimension, degree, 2);
+	const BasisCache& cache = get_basis_cache(dimension, degree, LogSigMethod::LyndonBasis);
 	const uint64_t sig_len = ::sig_length(dimension, degree);
 	const uint64_t m = cache.lyndon_idx.size();
 
@@ -318,9 +319,9 @@ void expand_lyndon_to_tensor_(
 	T* expanded,
 	uint64_t dimension,
 	uint64_t degree,
-	int method
+	LogSigMethod method
 ) {
-	const BasisCache& cache = get_basis_cache(dimension, degree, 2);
+	const BasisCache& cache = get_basis_cache(dimension, degree, LogSigMethod::LyndonBasis);
 	const uint64_t sig_len = ::sig_length(dimension, degree);
 	const uint64_t m = cache.lyndon_idx.size();
 
@@ -328,7 +329,7 @@ void expand_lyndon_to_tensor_(
 	auto coefs_uptr = std::make_unique<T[]>(m);
 	T* coefs = coefs_uptr.get();
 	std::memcpy(coefs, lyndon_coefs, m * sizeof(T));
-	if (method == 1)
+	if (method == LogSigMethod::LyndonWords)
 		cache.inv_proj_mat.mul_vec_inplace_lower(coefs);
 
 	auto expansions = build_bracket_expansions_<T>(dimension, degree);
@@ -348,14 +349,14 @@ void get_logsig_to_sig_(
 	T* out,
 	uint64_t dimension,
 	uint64_t degree,
-	int method = 0
+	LogSigMethod method = LogSigMethod::Expanded
 ) {
 	switch (method) {
-	case 0:
+	case LogSigMethod::Expanded:
 		sig_from_logsig_expanded<T>(log_sig, out, dimension, degree);
 		break;
-	case 1:
-	case 2: {
+	case LogSigMethod::LyndonWords:
+	case LogSigMethod::LyndonBasis: {
 		const uint64_t sig_len = ::sig_length(dimension, degree);
 		auto expanded = std::make_unique<T[]>(sig_len);
 		expand_lyndon_to_tensor_<T>(log_sig, expanded.get(), dimension, degree, method);
@@ -378,16 +379,16 @@ void get_logsig_to_sig_backprop_(
 	const T* log_sig,
 	uint64_t dimension,
 	uint64_t degree,
-	int method = 0
+	LogSigMethod method = LogSigMethod::Expanded
 ) {
 	switch (method) {
-	case 0:
+	case LogSigMethod::Expanded:
 		tensor_exp_backprop_<T>(d_logsig, d_sig, log_sig, dimension, degree);
 		break;
-	case 1:
-	case 2: {
+	case LogSigMethod::LyndonWords:
+	case LogSigMethod::LyndonBasis: {
 		const uint64_t sig_len = ::sig_length(dimension, degree);
-		const BasisCache& cache = get_basis_cache(dimension, degree, 2);
+		const BasisCache& cache = get_basis_cache(dimension, degree, LogSigMethod::LyndonBasis);
 		const uint64_t m = cache.lyndon_idx.size();
 
 		auto expanded = std::make_unique<T[]>(sig_len);
@@ -409,7 +410,7 @@ void get_logsig_to_sig_backprop_(
 		}
 
 		// method=1: forward used P^{-1}, so backward applies (P^{-1})^T
-		if (method == 1)
+		if (method == LogSigMethod::LyndonWords)
 			cache.inv_proj_mat_transpose.mul_vec_inplace_upper(d_coefs.get());
 
 		std::memcpy(d_logsig, d_coefs.get(), m * sizeof(T));
@@ -433,7 +434,7 @@ void logsig_to_sig_(
 	uint64_t degree,
 	bool time_aug = false,
 	bool lead_lag = false,
-	int method = 0,
+	LogSigMethod method = LogSigMethod::Expanded,
 	bool scalar_term = true,
 	int n_jobs = 1
 ) {
@@ -443,8 +444,8 @@ void logsig_to_sig_(
 	uint64_t aug_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t sig_len = ::sig_length(aug_dimension, degree);
 	// Input: logsig-shaped (method>0, unaffected by scalar_term) or sig-shaped (method==0)
-	const uint64_t full_in_len = method ? ::log_sig_length(aug_dimension, degree) : sig_len;
-	const uint64_t in_stride = (method == 0 && !scalar_term) ? (sig_len - 1) : full_in_len;
+	const uint64_t full_in_len = method == LogSigMethod::Expanded ? sig_len : ::log_sig_length(aug_dimension, degree);
+	const uint64_t in_stride = (method == LogSigMethod::Expanded && !scalar_term) ? (sig_len - 1) : full_in_len;
 	// Output is always sig-shaped
 	const uint64_t out_stride = scalar_term ? sig_len : sig_len - 1;
 
@@ -459,7 +460,7 @@ void logsig_to_sig_(
 			// Prepare full input if method==0 (sig-shaped, prepend scalar)
 			const T* actual_in = in_ptr;
 			std::vector<T> in_full;
-			if (method == 0) {
+			if (method == LogSigMethod::Expanded) {
 				in_full.resize(sig_len);
 				in_full[0] = static_cast<T>(1);
 				std::memcpy(in_full.data() + 1, in_ptr, (sig_len - 1) * sizeof(T));
@@ -489,7 +490,7 @@ void logsig_to_sig_backprop_(
 	uint64_t degree,
 	bool time_aug = false,
 	bool lead_lag = false,
-	int method = 0,
+	LogSigMethod method = LogSigMethod::Expanded,
 	bool scalar_term = true,
 	int n_jobs = 1
 ) {
@@ -499,12 +500,12 @@ void logsig_to_sig_backprop_(
 	uint64_t aug_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 	const uint64_t sig_len = ::sig_length(aug_dimension, degree);
 	// Input log_sig: logsig-shaped (method>0) or sig-shaped (method==0)
-	const uint64_t full_in_len = method ? ::log_sig_length(aug_dimension, degree) : sig_len;
-	const uint64_t in_stride = (method == 0 && !scalar_term) ? (sig_len - 1) : full_in_len;
+	const uint64_t full_in_len = method == LogSigMethod::Expanded ? sig_len : ::log_sig_length(aug_dimension, degree);
+	const uint64_t in_stride = (method == LogSigMethod::Expanded && !scalar_term) ? (sig_len - 1) : full_in_len;
 	// d_sig (incoming grad) is sig-shaped
 	const uint64_t dsig_stride = scalar_term ? sig_len : sig_len - 1;
 	// d_logsig (output grad) is logsig-shaped (method>0) or sig-shaped (method==0)
-	const uint64_t dout_stride = (method == 0 && !scalar_term) ? (sig_len - 1) : full_in_len;
+	const uint64_t dout_stride = (method == LogSigMethod::Expanded && !scalar_term) ? (sig_len - 1) : full_in_len;
 
 	if (scalar_term) {
 		auto batch_func = [&](uint64_t start, uint64_t end) {
@@ -527,7 +528,7 @@ void logsig_to_sig_backprop_(
 				// Prepare log_sig input (if method==0, prepend scalar)
 				const T* actual_in;
 				std::vector<T> in_full;
-				if (method == 0) {
+				if (method == LogSigMethod::Expanded) {
 					in_full.resize(sig_len);
 					in_full[0] = static_cast<T>(1);
 					std::memcpy(in_full.data() + 1, log_sig + i * in_stride, in_stride * sizeof(T));
@@ -536,7 +537,7 @@ void logsig_to_sig_backprop_(
 					actual_in = log_sig + i * in_stride;
 				}
 
-				if (method == 0) {
+				if (method == LogSigMethod::Expanded) {
 					// Output is sig-shaped, strip
 					std::vector<T> dout_full(sig_len);
 					get_logsig_to_sig_backprop_<T>(

--- a/siglib/cpsig/cp_log_signature.h
+++ b/siglib/cpsig/cp_log_signature.h
@@ -21,6 +21,7 @@
 
 #include "cp_path.h"
 #include "cp_bch.h"
+#include "log_sig_method.h"
 
 template<std::floating_point T>
 void get_log_sig_(
@@ -28,17 +29,17 @@ void get_log_sig_(
 	T* out,
 	uint64_t dimension,
 	uint64_t degree,
-	int method = 0
+	LogSigMethod method = LogSigMethod::Expanded
 )
 {
 	switch (method) {
-	case 0:
+	case LogSigMethod::Expanded:
 		log_sig_expanded<T>(sig, out, dimension, degree);
 		break;
-	case 1:
+	case LogSigMethod::LyndonWords:
 		log_sig_lyndon_words<T>(sig, out, dimension, degree);
 		break;
-	case 2:
+	case LogSigMethod::LyndonBasis:
 		log_sig_lyndon_basis<T>(sig, out, dimension, degree);
 		break;
 	default:
@@ -55,7 +56,7 @@ void sig_to_log_sig_(
 	uint64_t degree,
 	bool time_aug = false,
 	bool lead_lag = false,
-	int method = 0,
+	LogSigMethod method = LogSigMethod::Expanded,
 	bool scalar_term = true,
 	int n_jobs = 1
 )
@@ -68,9 +69,9 @@ void sig_to_log_sig_(
 
 	const uint64_t sig_len = ::sig_length(aug_dimension, degree);
 	const uint64_t logsig_len = ::log_sig_length(aug_dimension, degree);
-	const uint64_t full_out_len = method ? logsig_len : sig_len;
+	const uint64_t full_out_len = method == LogSigMethod::Expanded ? sig_len : logsig_len;
 	const uint64_t in_stride = scalar_term ? sig_len : sig_len - 1;
-	const uint64_t out_stride = (method == 0 && !scalar_term) ? (sig_len - 1) : full_out_len;
+	const uint64_t out_stride = (method == LogSigMethod::Expanded && !scalar_term) ? (sig_len - 1) : full_out_len;
 
 	if (scalar_term) {
 		auto f = [&](const T* sig_ptr, T* out_ptr) {
@@ -83,7 +84,7 @@ void sig_to_log_sig_(
 			std::vector<T> sig_full(sig_len);
 			sig_full[0] = static_cast<T>(1);
 			std::memcpy(sig_full.data() + 1, sig_ptr, (sig_len - 1) * sizeof(T));
-			if (method == 0) {
+			if (method == LogSigMethod::Expanded) {
 				std::vector<T> out_full(sig_len);
 				get_log_sig_<T>(sig_full.data(), out_full.data(), aug_dimension, degree, method);
 				std::memcpy(out_ptr, out_full.data() + 1, (sig_len - 1) * sizeof(T));
@@ -108,16 +109,16 @@ void get_sig_to_log_sig_backprop_(
 	T* log_sig_derivs,
 	uint64_t dimension,
 	uint64_t degree,
-	int method = 0
+	LogSigMethod method = LogSigMethod::Expanded
 ) {
 	switch (method) {
-	case 0:
+	case LogSigMethod::Expanded:
 		tensor_log_backprop_<T>(out, log_sig_derivs, sig, dimension, degree);
 		break;
-	case 1:
+	case LogSigMethod::LyndonWords:
 		tensor_log_backprop_lyndon_words<T>(out, log_sig_derivs, sig, dimension, degree);
 		break;
-	case 2:
+	case LogSigMethod::LyndonBasis:
 		tensor_log_backprop_lyndon_basis<T>(out, log_sig_derivs, sig, dimension, degree);
 		break;
 	default:
@@ -135,7 +136,7 @@ void sig_to_log_sig_backprop_(
 	uint64_t degree,
 	bool time_aug = false,
 	bool lead_lag = false,
-	int method = 0,
+	LogSigMethod method = LogSigMethod::Expanded,
 	bool scalar_term = true,
 	int n_jobs = 1
 ) {
@@ -144,12 +145,12 @@ void sig_to_log_sig_backprop_(
 	uint64_t aug_dimension = (lead_lag ? 2 * dimension : dimension) + (time_aug ? 1 : 0);
 
 	const uint64_t sig_len_ = ::sig_length(aug_dimension, degree);
-	const uint64_t log_sig_len_ = method ? ::log_sig_length(aug_dimension, degree) : sig_len_;
+	const uint64_t log_sig_len_ = method == LogSigMethod::Expanded ? sig_len_ : ::log_sig_length(aug_dimension, degree);
 
 	// Determine caller strides
 	const uint64_t sig_in_stride = scalar_term ? sig_len_ : sig_len_ - 1;
 	// log_sig_derivs: logsig-shaped (method>0, unaffected) or sig-shaped (method==0, may be stripped)
-	const uint64_t lsd_stride = (method == 0 && !scalar_term) ? (sig_len_ - 1) : log_sig_len_;
+	const uint64_t lsd_stride = (method == LogSigMethod::Expanded && !scalar_term) ? (sig_len_ - 1) : log_sig_len_;
 	// Output is sig-shaped
 	const uint64_t out_stride = scalar_term ? sig_len_ : sig_len_ - 1;
 
@@ -172,7 +173,7 @@ void sig_to_log_sig_backprop_(
 		auto log_sig_derivs_copy_uptr = std::make_unique<T[]>(log_sig_len_ * batch_size);
 		T* log_sig_derivs_copy = log_sig_derivs_copy_uptr.get();
 
-		if (method == 0) {
+		if (method == LogSigMethod::Expanded) {
 			// log_sig_derivs is sig-shaped with scalar stripped
 			for (uint64_t b = 0; b < batch_size; ++b) {
 				log_sig_derivs_copy[b * log_sig_len_] = static_cast<T>(0);

--- a/siglib/cpsig/cp_log_signatures.cpp
+++ b/siglib/cpsig/cp_log_signatures.cpp
@@ -18,39 +18,40 @@
 #include "cp_log_signature.h"
 #include "cp_exp_signature.h"
 #include "macros.h"
+#include "log_sig_method.h"
 
 extern "C" {
 
 	CPSIG_API int sig_to_log_sig_f(const float* sig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(sig_to_log_sig_<float>(sig, out, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(sig_to_log_sig_<float>(sig, out, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int sig_to_log_sig_d(const double* sig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(sig_to_log_sig_<double>(sig, out, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(sig_to_log_sig_<double>(sig, out, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int sig_to_log_sig_backprop_f(const float* sig, float* out, const float* log_sig_derivs, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(sig_to_log_sig_backprop_<float>(sig, out, log_sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(sig_to_log_sig_backprop_<float>(sig, out, log_sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int sig_to_log_sig_backprop_d(const double* sig, double* out, const double* log_sig_derivs, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(sig_to_log_sig_backprop_<double>(sig, out, log_sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(sig_to_log_sig_backprop_<double>(sig, out, log_sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int logsig_to_sig_f(const float* log_sig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(logsig_to_sig_<float>(log_sig, out, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(logsig_to_sig_<float>(log_sig, out, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int logsig_to_sig_d(const double* log_sig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(logsig_to_sig_<double>(log_sig, out, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(logsig_to_sig_<double>(log_sig, out, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int logsig_to_sig_backprop_f(const float* log_sig, float* out, const float* sig_derivs, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(logsig_to_sig_backprop_<float>(log_sig, out, sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(logsig_to_sig_backprop_<float>(log_sig, out, sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 	CPSIG_API int logsig_to_sig_backprop_d(const double* log_sig, double* out, const double* sig_derivs, uint64_t batch_size, uint64_t dimension, uint64_t degree, bool time_aug, bool lead_lag, int method, bool scalar_term, int n_jobs) noexcept {
-		SAFE_CALL(logsig_to_sig_backprop_<double>(log_sig, out, sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, method, scalar_term, n_jobs));
+		SAFE_CALL(logsig_to_sig_backprop_<double>(log_sig, out, sig_derivs, batch_size, dimension, degree, time_aug, lead_lag, parse_log_sig_conversion_method(method), scalar_term, n_jobs));
 	}
 
 }

--- a/siglib/cpsig/cp_tensor_log.h
+++ b/siglib/cpsig/cp_tensor_log.h
@@ -142,7 +142,7 @@ void log_sig_lyndon_words(
 	uint64_t dimension,
 	uint64_t degree
 ) {
-	const BasisCache& cache_ = get_basis_cache(dimension, degree, 1);
+	const BasisCache& cache_ = get_basis_cache(dimension, degree, LogSigMethod::LyndonWords);
 
 	auto log_sig_uptr = std::make_unique<T[]>(::sig_length(dimension, degree));
 	T* log_sig = log_sig_uptr.get();
@@ -164,7 +164,7 @@ void log_sig_lyndon_basis(
 	uint64_t degree
 ) {
 	log_sig_lyndon_words(sig, out, dimension, degree);
-	const BasisCache& cache_ = get_basis_cache(dimension, degree, 2);
+	const BasisCache& cache_ = get_basis_cache(dimension, degree, LogSigMethod::LyndonBasis);
 	cache_.inv_proj_mat.mul_vec_inplace_lower(out);
 }
 
@@ -242,7 +242,7 @@ void tensor_log_backprop_lyndon_words(
 	uint64_t dimension,
 	uint64_t degree
 ) {
-	const BasisCache& cache_ = get_basis_cache(dimension, degree, 1);
+	const BasisCache& cache_ = get_basis_cache(dimension, degree, LogSigMethod::LyndonWords);
 
 	uint64_t sig_len_ = ::sig_length(dimension, degree);
 	auto log_sig_derivs_copy_uptr = std::make_unique<T[]>(sig_len_);
@@ -265,7 +265,7 @@ void tensor_log_backprop_lyndon_basis(
 	uint64_t dimension,
 	uint64_t degree
 ) {
-	const BasisCache& cache_ = get_basis_cache(dimension, degree, 2);
+	const BasisCache& cache_ = get_basis_cache(dimension, degree, LogSigMethod::LyndonBasis);
 
 	cache_.inv_proj_mat_transpose.mul_vec_inplace_upper(log_sig_derivs);
 

--- a/siglib/cpsig/log_sig_cache.cpp
+++ b/siglib/cpsig/log_sig_cache.cpp
@@ -16,6 +16,7 @@
 #pragma once
 #include "cppch.h"
 #include "log_sig_cache.h"
+#include "log_sig_method.h"
 #include "cp_bch.h"
 #include "cp_branched_cache.h"
 
@@ -139,8 +140,8 @@ void set_default_cache_dir() {
 #endif
 }
 
-void set_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_disk) {
-	if (method < 1)
+void set_basis_cache(uint64_t dimension, uint64_t degree, LogSigMethod method, bool use_disk) {
+	if (method == LogSigMethod::Expanded)
 		return;
 
 	auto dir = get_cache_dir();
@@ -171,7 +172,7 @@ void set_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_d
 	std::vector<word> lyndon_words = all_lyndon_words(dimension, degree);
 	std::vector<uint64_t> lyndon_idx = all_lyndon_idx(dimension, degree);
 	SparseIntMatrix p, p_inv, p_inv_t;
-	if (method == 2) {
+	if (method == LogSigMethod::LyndonBasis) {
 		lyndon_proj_matrix(p, lyndon_words, lyndon_idx, dimension, degree);
 		p.inverse(p_inv);
 		p_inv.transpose(p_inv_t);
@@ -192,7 +193,7 @@ void set_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_d
 	reg.map.insert_or_assign(key, std::move(basis_obj));
 }
 
-const BasisCache& get_basis_cache(uint64_t dimension, uint64_t degree, int method) {
+const BasisCache& get_basis_cache(uint64_t dimension, uint64_t degree, LogSigMethod method) {
 
 	std::pair<uint64_t, uint64_t> key(dimension, degree);
 	auto& reg = basis_cache_registry();
@@ -237,7 +238,11 @@ extern "C" {
 	}
 
 	CPSIG_API int prepare_log_sig(uint64_t dimension, uint64_t degree, int method, bool use_disk) noexcept {
-		SAFE_CALL(set_basis_cache(dimension, degree, method, use_disk));
+		SAFE_CALL({
+			LogSigMethod parsed = parse_log_sig_method(method);
+			if (parsed == LogSigMethod::LyndonWords || parsed == LogSigMethod::LyndonBasis)
+				set_basis_cache(dimension, degree, parsed, use_disk);
+		});
 	}
 
 	CPSIG_API int clear_cache(bool use_disk) noexcept {

--- a/siglib/cpsig/log_sig_cache.h
+++ b/siglib/cpsig/log_sig_cache.h
@@ -19,9 +19,10 @@
 #include "words.h"
 #include "sparse.h"
 #include "disk_cache.h"
+#include "log_sig_method.h"
 
 struct BasisCache {
-	int method = 0;
+	LogSigMethod method = LogSigMethod::Expanded;
 	std::vector<uint64_t> lyndon_idx;
 	SparseIntMatrix inv_proj_mat;
 	SparseIntMatrix inv_proj_mat_transpose;
@@ -29,7 +30,7 @@ struct BasisCache {
 	BasisCache() = default;
 
 	BasisCache(
-		int method_,
+		LogSigMethod method_,
 		std::vector<uint64_t>&& lyndon_idx_,
 		SparseIntMatrix&& inv_proj_mat_,
 		SparseIntMatrix&& inv_proj_mat_transpose_
@@ -40,14 +41,17 @@ struct BasisCache {
 	}
 
 	void serialize(std::ostream& out) const {
-		out.write(reinterpret_cast<const char*>(&method), sizeof(method));
+		const int stored_method = log_sig_method_value(method);
+		out.write(reinterpret_cast<const char*>(&stored_method), sizeof(stored_method));
 		serialize_vector(out, lyndon_idx);
 		inv_proj_mat.serialize(out);
 		inv_proj_mat_transpose.serialize(out);
 	}
 
 	void deserialize(std::istream& in) {
-		in.read(reinterpret_cast<char*>(&method), sizeof(method));
+		int stored_method;
+		in.read(reinterpret_cast<char*>(&stored_method), sizeof(stored_method));
+		method = parse_log_sig_conversion_method(stored_method);
 		deserialize_vector(in, lyndon_idx);
 		SparseIntMatrix::deserialize(in, inv_proj_mat);
 		SparseIntMatrix::deserialize(in, inv_proj_mat_transpose);
@@ -104,6 +108,6 @@ private:
 	std::filesystem::path file_path;
 };
 
-void set_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_disk = false);
-const BasisCache& get_basis_cache(uint64_t dimension, uint64_t degree, int method);
+void set_basis_cache(uint64_t dimension, uint64_t degree, LogSigMethod method, bool use_disk = false);
+const BasisCache& get_basis_cache(uint64_t dimension, uint64_t degree, LogSigMethod method);
 void clear_cache_(bool use_disk);

--- a/siglib/cusig/cu_exp_host.cpp
+++ b/siglib/cusig/cu_exp_host.cpp
@@ -109,7 +109,7 @@ template<typename T>
 static void build_expansion_matrix_impl(
 	T* h_expand,
 	uint64_t sig_len, uint64_t m,
-	uint64_t dimension, uint64_t degree, int method
+	uint64_t dimension, uint64_t degree, LogSigMethod method
 ) {
 	auto level_index = std::make_unique<uint64_t[]>(degree + 2);
 	host_populate_level_index(level_index.get(), dimension, degree + 2);
@@ -164,7 +164,7 @@ static void build_expansion_matrix_impl(
 
 	std::fill(h_expand, h_expand + sig_len * m, static_cast<T>(0));
 
-	if (method == 2) {
+	if (method == LogSigMethod::LyndonBasis) {
 		for (uint64_t i = 0; i < m; ++i)
 			for (uint64_t j = 0; j < sig_len; ++j)
 				h_expand[j * m + i] = expansions[i * sig_len + j];
@@ -212,14 +212,14 @@ static void build_expansion_matrix_impl(
 
 void build_expansion_matrix_f(
 	float* h_expand, uint64_t sig_len, uint64_t m,
-	uint64_t dimension, uint64_t degree, int method
+	uint64_t dimension, uint64_t degree, LogSigMethod method
 ) {
 	build_expansion_matrix_impl<float>(h_expand, sig_len, m, dimension, degree, method);
 }
 
 void build_expansion_matrix_d(
 	double* h_expand, uint64_t sig_len, uint64_t m,
-	uint64_t dimension, uint64_t degree, int method
+	uint64_t dimension, uint64_t degree, LogSigMethod method
 ) {
 	build_expansion_matrix_impl<double>(h_expand, sig_len, m, dimension, degree, method);
 }

--- a/siglib/cusig/cu_exp_host.h
+++ b/siglib/cusig/cu_exp_host.h
@@ -15,6 +15,7 @@
 
 #pragma once
 #include <cstdint>
+#include "log_sig_method.h"
 
 // Host-side functions for logsig_to_sig methods 1/2.
 // Compiled by MSVC C++20, callable from CUDA host code.
@@ -22,13 +23,13 @@
 void build_expansion_matrix_f(
 	float* h_expand,
 	uint64_t sig_len, uint64_t m,
-	uint64_t dimension, uint64_t degree, int method
+	uint64_t dimension, uint64_t degree, LogSigMethod method
 );
 
 void build_expansion_matrix_d(
 	double* h_expand,
 	uint64_t sig_len, uint64_t m,
-	uint64_t dimension, uint64_t degree, int method
+	uint64_t dimension, uint64_t degree, LogSigMethod method
 );
 
 uint64_t get_lyndon_count(uint64_t dimension, uint64_t degree);

--- a/siglib/cusig/cu_exp_signature.cu
+++ b/siglib/cusig/cu_exp_signature.cu
@@ -18,6 +18,7 @@
 #include "cu_utils.h"
 #include "cu_atomic.h"
 #include "cu_exp_host.h"
+#include "log_sig_method.h"
 #include <type_traits>
 
 // =========================================================================
@@ -515,7 +516,7 @@ void logsig_to_sig_cuda_core_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method
+	LogSigMethod method
 );
 template<typename T>
 void logsig_to_sig_backprop_cuda_core_(
@@ -525,7 +526,7 @@ void logsig_to_sig_backprop_cuda_core_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method
+	LogSigMethod method
 );
 
 template<typename T>
@@ -535,11 +536,9 @@ void logsig_to_sig_cuda_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method,
+	LogSigMethod method,
 	bool scalar_term = true
 ) {
-	if (method < 0 || method > 2)
-		throw std::invalid_argument("logsig_to_sig_cuda: method must be 0, 1, or 2");
 	if (dimension == 0)
 		throw std::invalid_argument("logsig_to_sig_cuda received dimension 0");
 	if (degree == 0)
@@ -554,7 +553,7 @@ void logsig_to_sig_cuda_(
 	const uint64_t full_len = host_sig_length(dimension, degree);
 	CudaBuf<T> d_out_full(batch_size * full_len * sizeof(T));
 
-	if (method == 0) {
+	if (method == LogSigMethod::Expanded) {
 		CudaBuf<T> d_ls_full(batch_size * full_len * sizeof(T));
 		exp_stage_prepend_<T>(log_sig, d_ls_full.get(), batch_size, full_len, /*prepend_one=*/false);
 		logsig_to_sig_cuda_core_<T>(d_ls_full.get(), d_out_full.get(), batch_size, dimension, degree, method);
@@ -572,11 +571,9 @@ void logsig_to_sig_backprop_cuda_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method,
+	LogSigMethod method,
 	bool scalar_term = true
 ) {
-	if (method < 0 || method > 2)
-		throw std::invalid_argument("logsig_to_sig_backprop_cuda: method must be 0, 1, or 2");
 	if (dimension == 0)
 		throw std::invalid_argument("logsig_to_sig_backprop_cuda received dimension 0");
 	if (degree == 0)
@@ -598,7 +595,7 @@ void logsig_to_sig_backprop_cuda_(
 	CudaBuf<T> d_dsig_full(batch_size * full_len * sizeof(T));
 	exp_stage_prepend_<T>(d_sig, d_dsig_full.get(), batch_size, full_len, /*prepend_one=*/false);
 
-	if (method == 0) {
+	if (method == LogSigMethod::Expanded) {
 		CudaBuf<T> d_ls_full(batch_size * full_len * sizeof(T));
 		exp_stage_prepend_<T>(log_sig, d_ls_full.get(), batch_size, full_len, /*prepend_one=*/false);
 		CudaBuf<T> d_dlogsig_full(batch_size * full_len * sizeof(T));
@@ -617,7 +614,7 @@ void logsig_to_sig_cuda_core_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method
+	LogSigMethod method
 ) {
 	const uint64_t sig_len = host_sig_length(dimension, degree);
 
@@ -634,7 +631,7 @@ void logsig_to_sig_cuda_core_(
 
 	uint64_t m = 0;
 	std::unique_ptr<T[]> h_expand;
-	if (method != 0) {
+	if (method != LogSigMethod::Expanded) {
 		m = get_lyndon_count(dimension, degree);
 		h_expand = std::make_unique<T[]>(sig_len * m);
 		if constexpr (std::is_same_v<T, float>)
@@ -645,7 +642,7 @@ void logsig_to_sig_cuda_core_(
 
 	std::lock_guard<std::mutex> lock(g_exp_workspace_mu);
 
-	if (method == 0) {
+	if (method == LogSigMethod::Expanded) {
 		g_exp_workspace.ensure_forward(sizeof(T) * batch_size * 2 * sig_len);
 
 		configure_dynamic_smem(
@@ -692,11 +689,11 @@ void logsig_to_sig_backprop_cuda_core_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method
+	LogSigMethod method
 ) {
 	const uint64_t sig_len = host_sig_length(dimension, degree);
 
-	if (degree == 1 && method == 0) {
+	if (degree == 1 && method == LogSigMethod::Expanded) {
 		cudaMemcpy(d_logsig, d_sig, batch_size * sig_len * sizeof(T), cudaMemcpyDeviceToDevice);
 		cudaMemset2D(d_logsig, sig_len * sizeof(T), 0, sizeof(T), batch_size);
 		return;
@@ -715,7 +712,7 @@ void logsig_to_sig_backprop_cuda_core_(
 
 	uint64_t m = 0;
 	std::unique_ptr<T[]> h_expand;
-	if (method != 0) {
+	if (method != LogSigMethod::Expanded) {
 		m = get_lyndon_count(dimension, degree);
 		h_expand = std::make_unique<T[]>(sig_len * m);
 		if constexpr (std::is_same_v<T, float>)
@@ -726,7 +723,7 @@ void logsig_to_sig_backprop_cuda_core_(
 
 	std::lock_guard<std::mutex> lock(g_exp_workspace_mu);
 
-	if (method == 0) {
+	if (method == LogSigMethod::Expanded) {
 		g_exp_workspace.ensure_backward(
 			sizeof(T) * batch_size * degree * sig_len,   // P_all
 			sizeof(T) * batch_size * 2 * sig_len         // dP + dP_next
@@ -785,14 +782,14 @@ extern "C" {
 		const float* log_sig, float* out,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(logsig_to_sig_cuda_<float>(log_sig, out, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(logsig_to_sig_cuda_<float>(log_sig, out, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 	CUSIG_API int logsig_to_sig_cuda_d(
 		const double* log_sig, double* out,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(logsig_to_sig_cuda_<double>(log_sig, out, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(logsig_to_sig_cuda_<double>(log_sig, out, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 
@@ -800,14 +797,14 @@ extern "C" {
 		const float* log_sig, float* d_logsig, const float* d_sig,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(logsig_to_sig_backprop_cuda_<float>(log_sig, d_logsig, d_sig, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(logsig_to_sig_backprop_cuda_<float>(log_sig, d_logsig, d_sig, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 	CUSIG_API int logsig_to_sig_backprop_cuda_d(
 		const double* log_sig, double* d_logsig, const double* d_sig,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(logsig_to_sig_backprop_cuda_<double>(log_sig, d_logsig, d_sig, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(logsig_to_sig_backprop_cuda_<double>(log_sig, d_logsig, d_sig, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 }

--- a/siglib/cusig/cu_log_sig_cache.cu
+++ b/siglib/cusig/cu_log_sig_cache.cu
@@ -17,6 +17,7 @@
 #include "cusig.h"
 #include "cu_log_sig_cache.h"
 #include "cu_log_sig_combine.h"
+#include "log_sig_method.h"
 
 // =========================================================================
 // SAFE_CALL macro
@@ -33,7 +34,11 @@ extern "C" {
 	CUSIG_API int prepare_log_sig_cuda(
 		uint64_t dimension, uint64_t degree, int method, bool use_disk
 	) noexcept {
-		CUSIG_SAFE_CALL(prepare_log_sig_cuda_(dimension, degree, method, use_disk));
+		CUSIG_SAFE_CALL({
+			LogSigMethod parsed = parse_log_sig_method(method);
+			if (parsed == LogSigMethod::LyndonWords || parsed == LogSigMethod::LyndonBasis)
+				prepare_log_sig_cuda_(dimension, degree, parsed, use_disk);
+		});
 	}
 
 	CUSIG_API int clear_cache_cuda(bool use_disk) noexcept {

--- a/siglib/cusig/cu_log_sig_cache.h
+++ b/siglib/cusig/cu_log_sig_cache.h
@@ -16,6 +16,7 @@
 #pragma once
 #include "cupch.h"
 #include "cu_utils.h"
+#include "log_sig_method.h"
 #include <unordered_map>
 #include <unordered_set>
 #include <cstdint>
@@ -610,7 +611,7 @@ public:
 		return std::filesystem::exists(file_path_);
 	}
 
-	void write(int method, const std::vector<uint64_t>& lyndon_idx,
+	void write(LogSigMethod method, const std::vector<uint64_t>& lyndon_idx,
 	           const CuSparseIntMatrix& inv_proj_mat,
 	           const CuSparseIntMatrix& inv_proj_mat_t) const {
 		std::ofstream out(file_path_, std::ios::binary);
@@ -619,13 +620,14 @@ public:
 				"Failed to open CUDA cache file for writing", file_path_,
 				std::make_error_code(std::errc::io_error));
 		out.write(reinterpret_cast<const char*>(&cu_cache_magic_number), sizeof(cu_cache_magic_number));
-		out.write(reinterpret_cast<const char*>(&method), sizeof(method));
+		const int stored_method = log_sig_method_value(method);
+		out.write(reinterpret_cast<const char*>(&stored_method), sizeof(stored_method));
 		cu_serialize_vector_(out, lyndon_idx);
 		inv_proj_mat.serialize(out);
 		inv_proj_mat_t.serialize(out);
 	}
 
-	void read(int& method, std::vector<uint64_t>& lyndon_idx,
+	void read(LogSigMethod& method, std::vector<uint64_t>& lyndon_idx,
 	          CuSparseIntMatrix& inv_proj_mat,
 	          CuSparseIntMatrix& inv_proj_mat_t) const {
 		std::ifstream in(file_path_, std::ios::binary);
@@ -637,7 +639,9 @@ public:
 		in.read(reinterpret_cast<char*>(&magic), sizeof(magic));
 		if (magic != cu_cache_magic_number)
 			throw corrupted_cache_error("Tried to read an invalid cache file. Cache may have been corrupted.");
-		in.read(reinterpret_cast<char*>(&method), sizeof(method));
+		int stored_method;
+		in.read(reinterpret_cast<char*>(&stored_method), sizeof(stored_method));
+		method = parse_log_sig_conversion_method(stored_method);
 		cu_deserialize_vector_(in, lyndon_idx);
 		CuSparseIntMatrix::deserialize(in, inv_proj_mat);
 		CuSparseIntMatrix::deserialize(in, inv_proj_mat_t);
@@ -676,7 +680,7 @@ inline void populate_cuda_cache_entry_(
 	entry.threads_per_block = host_choose_threads_per_block(max_level_size);
 }
 
-inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, int method, bool use_disk) {
+inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, LogSigMethod method, bool use_disk) {
 	auto key = std::make_pair(dimension, degree);
 	auto& cache_map = get_cuda_log_sig_cache_map_();
 	std::lock_guard<std::mutex> lock(get_cuda_log_sig_cache_mu_());
@@ -684,17 +688,17 @@ inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, int metho
 	auto it = cache_map.find(key);
 	if (it != cache_map.end()) {
 		// Entry exists - upgrade to method 2 if needed
-		if (method == 2 && it->second.d_sparse_row_ptr == nullptr) {
+		if (method == LogSigMethod::LyndonBasis && it->second.d_sparse_row_ptr == nullptr) {
 			// Try loading sparse matrices from disk
 			if (use_disk) {
 				ensure_cuda_cache_dir_();
 				CuCacheFile file(dimension, degree);
 				if (file.exists()) {
-					int disk_method;
+					LogSigMethod disk_method;
 					std::vector<uint64_t> disk_lyndon_idx;
 					CuSparseIntMatrix disk_inv, disk_inv_t;
 					file.read(disk_method, disk_lyndon_idx, disk_inv, disk_inv_t);
-					if (disk_method >= 2) {
+					if (disk_method >= LogSigMethod::LyndonBasis) {
 						upload_csr_to_gpu_(disk_inv, it->second.d_sparse_vals, it->second.d_sparse_cols, it->second.d_sparse_row_ptr);
 						upload_csr_to_gpu_(disk_inv_t, it->second.d_sparse_vals_t, it->second.d_sparse_cols_t, it->second.d_sparse_row_ptr_t);
 						return;
@@ -711,7 +715,7 @@ inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, int metho
 		ensure_cuda_cache_dir_();
 		CuCacheFile file(dimension, degree);
 		if (file.exists()) {
-			int disk_method;
+			LogSigMethod disk_method;
 			std::vector<uint64_t> lyndon_idx;
 			CuSparseIntMatrix inv_proj_mat, inv_proj_mat_t;
 			file.read(disk_method, lyndon_idx, inv_proj_mat, inv_proj_mat_t);
@@ -720,7 +724,7 @@ inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, int metho
 				CUDALogSigCache entry;
 				populate_cuda_cache_entry_(entry, lyndon_idx, dimension, degree);
 
-				if (method == 2 && disk_method >= 2) {
+				if (method == LogSigMethod::LyndonBasis && disk_method >= LogSigMethod::LyndonBasis) {
 					upload_csr_to_gpu_(inv_proj_mat, entry.d_sparse_vals, entry.d_sparse_cols, entry.d_sparse_row_ptr);
 					upload_csr_to_gpu_(inv_proj_mat_t, entry.d_sparse_vals_t, entry.d_sparse_cols_t, entry.d_sparse_row_ptr_t);
 				}
@@ -739,7 +743,7 @@ inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, int metho
 
 	// For method 2, compute and upload the sparse matrix
 	CuSparseIntMatrix inv_proj_mat, inv_proj_mat_t;
-	if (method == 2) {
+	if (method == LogSigMethod::LyndonBasis) {
 		std::vector<cu_word> lyndon_words = cu_all_lyndon_words(dimension, degree);
 		CuSparseIntMatrix proj_mat;
 		cu_lyndon_proj_matrix(proj_mat, lyndon_words, lyndon_idx, dimension, degree);
@@ -759,7 +763,11 @@ inline void prepare_log_sig_cuda_(uint64_t dimension, uint64_t degree, int metho
 	cache_map.emplace(key, std::move(entry));
 }
 
-inline const CUDALogSigCache& get_cuda_log_sig_cache(uint64_t dimension, uint64_t degree, int method = 1) {
+inline const CUDALogSigCache& get_cuda_log_sig_cache(
+	uint64_t dimension,
+	uint64_t degree,
+	LogSigMethod method = LogSigMethod::LyndonWords
+) {
 	auto key = std::make_pair(dimension, degree);
 	auto& cache_map = get_cuda_log_sig_cache_map_();
 	std::lock_guard<std::mutex> lock(get_cuda_log_sig_cache_mu_());
@@ -772,7 +780,7 @@ inline const CUDALogSigCache& get_cuda_log_sig_cache(uint64_t dimension, uint64_
 			try {
 				CuCacheFile file(dimension, degree);
 				if (file.exists()) {
-					int disk_method;
+					LogSigMethod disk_method;
 					std::vector<uint64_t> lyndon_idx;
 					CuSparseIntMatrix inv_proj_mat, inv_proj_mat_t;
 					file.read(disk_method, lyndon_idx, inv_proj_mat, inv_proj_mat_t);
@@ -780,7 +788,7 @@ inline const CUDALogSigCache& get_cuda_log_sig_cache(uint64_t dimension, uint64_
 					CUDALogSigCache entry;
 					populate_cuda_cache_entry_(entry, lyndon_idx, dimension, degree);
 
-					if (disk_method >= 2) {
+					if (disk_method >= LogSigMethod::LyndonBasis) {
 						upload_csr_to_gpu_(inv_proj_mat, entry.d_sparse_vals, entry.d_sparse_cols, entry.d_sparse_row_ptr);
 						upload_csr_to_gpu_(inv_proj_mat_t, entry.d_sparse_vals_t, entry.d_sparse_cols_t, entry.d_sparse_row_ptr_t);
 					}
@@ -797,7 +805,7 @@ inline const CUDALogSigCache& get_cuda_log_sig_cache(uint64_t dimension, uint64_
 	if (it == cache_map.end()) {
 		throw std::runtime_error("CUDA log sig cache not found - call prepare_log_sig_cuda first");
 	}
-	if (method == 2 && it->second.d_sparse_row_ptr == nullptr) {
+	if (method == LogSigMethod::LyndonBasis && it->second.d_sparse_row_ptr == nullptr) {
 		throw std::runtime_error("CUDA log sig cache not found for method 2 - call prepare_log_sig_cuda with method=2 first");
 	}
 	return it->second;

--- a/siglib/cusig/cu_log_signature.cu
+++ b/siglib/cusig/cu_log_signature.cu
@@ -19,6 +19,7 @@
 #include "cu_log_signature.h"
 #include "cu_log_sig_backprop.h"
 #include "cu_log_sig_cache.h"
+#include "log_sig_method.h"
 
 // =========================================================================
 // Scratch buffer workspace - cached across calls to avoid per-call
@@ -390,7 +391,7 @@ void sig_to_log_sig_cuda_m2_core_(
 	uint64_t dimension,
 	uint64_t degree
 ) {
-	const auto& cache = get_cuda_log_sig_cache(dimension, degree, 2);
+	const auto& cache = get_cuda_log_sig_cache(dimension, degree, LogSigMethod::LyndonBasis);
 	const uint64_t sig_len = cache.sig_len;
 	const uint64_t buff1_len = cache.buff1_len;
 	const uint64_t log_sig_len = cache.log_sig_len;
@@ -778,7 +779,7 @@ void sig_to_log_sig_backprop_cuda_m2_core_(
 	uint64_t dimension,
 	uint64_t degree
 ) {
-	const auto& cache = get_cuda_log_sig_cache(dimension, degree, 2);
+	const auto& cache = get_cuda_log_sig_cache(dimension, degree, LogSigMethod::LyndonBasis);
 	const uint64_t sig_len = cache.sig_len;
 	const uint64_t buff1_len = cache.buff1_len;
 	const uint64_t log_sig_len = cache.log_sig_len;
@@ -819,7 +820,7 @@ void sig_to_log_sig_backprop_cuda_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method,
+	LogSigMethod method,
 	bool scalar_term = true
 ) {
 	if (dimension == 0) throw std::invalid_argument("sig_to_log_sig_backprop_cuda received dimension 0");
@@ -827,13 +828,13 @@ void sig_to_log_sig_backprop_cuda_(
 
 	if (scalar_term) {
 		// Hot path: unchanged.
-		if (method == 0) {
+		if (method == LogSigMethod::Expanded) {
 			sig_to_log_sig_backprop_cuda_core_<T>(sig, out, log_sig_derivs, batch_size, dimension, degree);
 		}
-		else if (method == 1) {
+		else if (method == LogSigMethod::LyndonWords) {
 			sig_to_log_sig_backprop_cuda_m1_core_<T>(sig, out, log_sig_derivs, batch_size, dimension, degree);
 		}
-		else if (method == 2) {
+		else if (method == LogSigMethod::LyndonBasis) {
 			sig_to_log_sig_backprop_cuda_m2_core_<T>(sig, out, log_sig_derivs, batch_size, dimension, degree);
 		}
 		else {
@@ -849,7 +850,7 @@ void sig_to_log_sig_backprop_cuda_(
 
 	CudaBuf<T> d_out_full(batch_size * full_len * sizeof(T));
 
-	if (method == 0) {
+	if (method == LogSigMethod::Expanded) {
 		// log_sig_derivs is stripped; stage into a full-size buffer.
 		CudaBuf<T> d_lsd_full(batch_size * full_len * sizeof(T));
 		// d(log_sig)/d... leading slot is 0 (log_sig[0] is constant).
@@ -857,10 +858,10 @@ void sig_to_log_sig_backprop_cuda_(
 		stage_prepend_<T>(log_sig_derivs, d_lsd_full.get(), batch_size, full_len);
 		sig_to_log_sig_backprop_cuda_core_<T>(d_sig_full.get(), d_out_full.get(), d_lsd_full.get(), batch_size, dimension, degree);
 	}
-	else if (method == 1) {
+	else if (method == LogSigMethod::LyndonWords) {
 		sig_to_log_sig_backprop_cuda_m1_core_<T>(d_sig_full.get(), d_out_full.get(), log_sig_derivs, batch_size, dimension, degree);
 	}
-	else if (method == 2) {
+	else if (method == LogSigMethod::LyndonBasis) {
 		sig_to_log_sig_backprop_cuda_m2_core_<T>(d_sig_full.get(), d_out_full.get(), log_sig_derivs, batch_size, dimension, degree);
 	}
 	else {
@@ -881,7 +882,7 @@ void sig_to_log_sig_cuda_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t degree,
-	int method,
+	LogSigMethod method,
 	bool scalar_term = true
 ) {
 	if (dimension == 0) throw std::invalid_argument("sig_to_log_sig_cuda received dimension 0");
@@ -889,13 +890,13 @@ void sig_to_log_sig_cuda_(
 
 	if (scalar_term) {
 		// Hot path: unchanged.
-		if (method == 0) {
+		if (method == LogSigMethod::Expanded) {
 			sig_to_log_sig_cuda_core_<T>(sig, out, batch_size, dimension, degree);
 		}
-		else if (method == 1) {
+		else if (method == LogSigMethod::LyndonWords) {
 			sig_to_log_sig_cuda_m1_core_<T>(sig, out, batch_size, dimension, degree);
 		}
-		else if (method == 2) {
+		else if (method == LogSigMethod::LyndonBasis) {
 			sig_to_log_sig_cuda_m2_core_<T>(sig, out, batch_size, dimension, degree);
 		}
 		else {
@@ -909,17 +910,17 @@ void sig_to_log_sig_cuda_(
 	CudaBuf<T> d_sig_full(batch_size * full_len * sizeof(T));
 	stage_prepend_<T>(sig, d_sig_full.get(), batch_size, full_len);
 
-	if (method == 0) {
+	if (method == LogSigMethod::Expanded) {
 		// Output is sig-shaped. Stage through a full-sized output buffer.
 		CudaBuf<T> d_out_full(batch_size * full_len * sizeof(T));
 		sig_to_log_sig_cuda_core_<T>(d_sig_full.get(), d_out_full.get(), batch_size, dimension, degree);
 		stage_strip_<T>(d_out_full.get(), out, batch_size, full_len);
 	}
-	else if (method == 1) {
+	else if (method == LogSigMethod::LyndonWords) {
 		// Output is log-sig-shaped (no scalar concept); write directly.
 		sig_to_log_sig_cuda_m1_core_<T>(d_sig_full.get(), out, batch_size, dimension, degree);
 	}
-	else if (method == 2) {
+	else if (method == LogSigMethod::LyndonBasis) {
 		sig_to_log_sig_cuda_m2_core_<T>(d_sig_full.get(), out, batch_size, dimension, degree);
 	}
 	else {
@@ -944,14 +945,14 @@ extern "C" {
 		const float* sig, float* out,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(sig_to_log_sig_cuda_<float>(sig, out, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(sig_to_log_sig_cuda_<float>(sig, out, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 	CUSIG_API int sig_to_log_sig_cuda_d(
 		const double* sig, double* out,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(sig_to_log_sig_cuda_<double>(sig, out, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(sig_to_log_sig_cuda_<double>(sig, out, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 
@@ -959,13 +960,13 @@ extern "C" {
 		const float* sig, float* out, const float* log_sig_derivs,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(sig_to_log_sig_backprop_cuda_<float>(sig, out, log_sig_derivs, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(sig_to_log_sig_backprop_cuda_<float>(sig, out, log_sig_derivs, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 
 	CUSIG_API int sig_to_log_sig_backprop_cuda_d(
 		const double* sig, double* out, const double* log_sig_derivs,
 		uint64_t batch_size, uint64_t dimension, uint64_t degree, int method, bool scalar_term
 	) noexcept {
-		CUSIG_SAFE_CALL(sig_to_log_sig_backprop_cuda_<double>(sig, out, log_sig_derivs, batch_size, dimension, degree, method, scalar_term));
+		CUSIG_SAFE_CALL(sig_to_log_sig_backprop_cuda_<double>(sig, out, log_sig_derivs, batch_size, dimension, degree, parse_log_sig_conversion_method(method), scalar_term));
 	}
 }

--- a/siglib/shared/log_sig_method.h
+++ b/siglib/shared/log_sig_method.h
@@ -1,0 +1,47 @@
+/* Copyright 2026 Daniil Shmelev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================================= */
+
+#pragma once
+
+#include <stdexcept>
+
+enum class LogSigMethod : int {
+	Expanded = 0,
+	LyndonWords = 1,
+	LyndonBasis = 2,
+	DirectBCH = 3,
+};
+
+[[nodiscard]] constexpr int log_sig_method_value(LogSigMethod method) noexcept {
+	return static_cast<int>(method);
+}
+
+[[nodiscard]] inline LogSigMethod parse_log_sig_method(int method) {
+	switch (method) {
+	case 0: return LogSigMethod::Expanded;
+	case 1: return LogSigMethod::LyndonWords;
+	case 2: return LogSigMethod::LyndonBasis;
+	case 3: return LogSigMethod::DirectBCH;
+	default:
+		throw std::invalid_argument("log signature method must be 0, 1, 2, or 3");
+	}
+}
+
+[[nodiscard]] inline LogSigMethod parse_log_sig_conversion_method(int method) {
+	LogSigMethod parsed = parse_log_sig_method(method);
+	if (parsed == LogSigMethod::DirectBCH)
+		throw std::invalid_argument("log signature conversion method must be 0, 1, or 2");
+	return parsed;
+}


### PR DESCRIPTION
Internal C++ used raw `0`–`3` values for log-signature methods. This gives them names while keeping the C ABI and cache files integer-compatible.

```cpp
enum class LogSigMethod : int {
    Expanded = 0,
    LyndonWords = 1,
    LyndonBasis = 2,
    DirectBCH = 3,
};
```

Integer conversion now happens at boundaries:

```cpp
parse_log_sig_conversion_method(method)
```

Internal branches use the enum directly:

```cpp
if (method == LogSigMethod::LyndonBasis) {
    // build the Lyndon projection cache
}
```

Next, I think we should consider annotating with a similar enum or Literal on the Python side. Imo a Literal is cleaner here, providing nicer IDE integration.

Checks: 154 CPU C++ tests, 1,779 Python tests, and 111 CUDA C++ tests.
