### PR TITLE
Cache Construction Benchmarks

### DIFF
--- a/benchmarks/bench_cpsig.cpp
+++ b/benchmarks/bench_cpsig.cpp
@@ -14,6 +14,7 @@
  * ========================================================================= */
 
 #include <benchmark/benchmark.h>
+#include "cp_bch.h"
 #include "cpsig.h"
 
 #include <cstdint>
@@ -44,6 +45,56 @@ static std::vector<double> random_data(uint64_t n, unsigned seed = 42) {
     for (auto& x : v) x = dist(rng);
     return v;
 }
+
+static void clear_caches_outside_timing(benchmark::State& state) {
+    state.PauseTiming();
+    check(::clear_cache(false), "clear_cache");
+    state.ResumeTiming();
+}
+
+// =========================================================================
+// Cache construction
+// =========================================================================
+
+static void BM_prepare_log_sig_lyndon_words(benchmark::State& state) {
+    for (auto _ : state) {
+        clear_caches_outside_timing(state);
+        check(::prepare_log_sig(3, 4, 1, false), "prepare_log_sig");
+    }
+}
+BENCHMARK(BM_prepare_log_sig_lyndon_words)->Unit(benchmark::kMicrosecond);
+
+static void BM_prepare_log_sig_lyndon_basis(benchmark::State& state) {
+    for (auto _ : state) {
+        clear_caches_outside_timing(state);
+        check(::prepare_log_sig(3, 4, 2, false), "prepare_log_sig");
+    }
+}
+BENCHMARK(BM_prepare_log_sig_lyndon_basis)->Unit(benchmark::kMicrosecond);
+
+static void BM_prepare_log_sig_bch(benchmark::State& state) {
+    for (auto _ : state) {
+        clear_caches_outside_timing(state);
+        set_bch_cache(3, 4);
+    }
+}
+BENCHMARK(BM_prepare_log_sig_bch)->Unit(benchmark::kMicrosecond);
+
+static void BM_prepare_branched_sig_nonplanar(benchmark::State& state) {
+    for (auto _ : state) {
+        clear_caches_outside_timing(state);
+        check(::prepare_branched_sig(3, 4, false, false), "prepare_branched_sig");
+    }
+}
+BENCHMARK(BM_prepare_branched_sig_nonplanar)->Unit(benchmark::kMicrosecond);
+
+static void BM_prepare_branched_sig_planar(benchmark::State& state) {
+    for (auto _ : state) {
+        clear_caches_outside_timing(state);
+        check(::prepare_branched_sig(3, 4, false, true), "prepare_branched_sig");
+    }
+}
+BENCHMARK(BM_prepare_branched_sig_planar)->Unit(benchmark::kMicrosecond);
 
 // =========================================================================
 // Path transforms


### PR DESCRIPTION
One-off planar signatures looked slow. Cache construction seems like a likely chunk of that:

| Method | Cache build | Signature call | Cache / call |
| --- | ---: | ---: | ---: |
| Non-planar | 68.1 µs | 294 µs | 23% |
| Planar | 752 µs | 923 µs | 81% |

The signature calls are batches of eight 32-point paths at dimension 3, degree 4.

This adds CodSpeed cases for planar and non-planar branched caches, plus the Lyndon words, Lyndon basis, and BCH caches. Cache building is worth tracking separately imo.