### PR TITLE
3x BCH Speedup

### DIFF
--- a/siglib/cpsig/cp_bch.h
+++ b/siglib/cpsig/cp_bch.h
@@ -63,6 +63,12 @@ struct BchCache {
 	std::vector<uint32_t> comm_ij_k;    // [nnz] output index
 	std::vector<double>   comm_ij_c;    // [nnz] coefficient (pre-cast)
 
+#ifdef VEC
+	// Structurally possible output range for each BCH node when the second
+	// input has degree one.
+	std::vector<std::pair<uint64_t, uint64_t>> linear_range;
+#endif
+
 	// Standard factorization of each d-letter Lyndon word (as index pairs)
 	// For degree-1 words: left_factor[i] = right_factor[i] = UINT64_MAX
 	std::vector<uint64_t> left_factor;
@@ -446,6 +452,28 @@ inline void build_commutator_table(BchCache& cache) {
 	}
 }
 
+#ifdef VEC
+inline void build_linear_bch_ranges(BchCache& cache) {
+	const uint64_t m2 = cache.bch_coefficients.size();
+
+	std::vector<uint64_t> min_degree(m2, 1);
+	std::vector<uint64_t> max_degree(m2, cache.degree);
+	if (m2 > 1) max_degree[1] = 1;
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t lf = cache.bch_left_factor[w];
+		const uint64_t rf = cache.bch_right_factor[w];
+		min_degree[w] = min_degree[lf] + min_degree[rf];
+		max_degree[w] = std::min(cache.degree, max_degree[lf] + max_degree[rf]);
+	}
+	cache.linear_range.resize(m2);
+	for (uint64_t w = 0; w < m2; ++w) {
+		const uint64_t begin = min_degree[w] == 1
+			? 0 : ::log_sig_length(cache.dimension, min_degree[w] - 1);
+		cache.linear_range[w] = {begin, ::log_sig_length(cache.dimension, max_degree[w])};
+	}
+}
+#endif
+
 // ========================================================================
 // BCH cache management
 // ========================================================================
@@ -483,6 +511,9 @@ inline void set_bch_cache(uint64_t dimension, uint64_t degree) {
 
 	// Build commutator table for d-letter Lyndon basis
 	build_commutator_table(*cache);
+#ifdef VEC
+	build_linear_bch_ranges(*cache);
+#endif
 
 	std::unique_lock wlock(reg.mu);
 	reg.map.insert_or_assign(key, std::move(cache));
@@ -696,8 +727,7 @@ inline void bch_combine_impl_x4_(
 		}
 	}
 }
-// Like bch_combine_impl_x4_ but uses precomputed sparse bounds when
-// one BCH operand is the displacement (node 1).
+// 4-wide BCH with a degree-one second input.
 inline void bch_combine_linear_impl_x4_(
 	const double* RESTRICT ls1, const double* RESTRICT ls2, double* RESTRICT out,
 	const BchCache& cache, double* memo
@@ -717,7 +747,6 @@ inline void bch_combine_linear_impl_x4_(
 	const uint32_t* k_i = cache.comm_k_i.data();
 	const uint32_t* k_j = cache.comm_k_j.data();
 	const double* k_val_d = cache.comm_k_val_d.data();
-	const uint32_t* k_sparse_end = cache.comm_k_sparse_end.data();
 
 	for (uint64_t w = 2; w < m2; ++w) {
 		const uint64_t lf = cache.bch_left_factor[w];
@@ -726,19 +755,20 @@ inline void bch_combine_linear_impl_x4_(
 		const double* v2 = memo + rf * m * 4;
 		double* result = memo + w * m * 4;
 		const double c_w = cache.bch_coefficients[w];
-		const bool sparse = (rf == 1 || lf == 1);
+		const auto [begin, end] = cache.linear_range[w];
+		std::memset(result, 0, begin * 4 * sizeof(double));
+		std::memset(result + end * 4, 0, (m - end) * 4 * sizeof(double));
 
-		for (uint64_t k = 0; k < m; ++k) {
+		for (uint64_t k = begin; k < end; ++k) {
 			vec4_commutator_accum(&result[k * 4], v1, v2, k_i, k_j, k_val_d,
-				k_ptr[k], sparse ? k_sparse_end[k] : k_ptr[k + 1]);
+				k_ptr[k], k_ptr[k + 1]);
 			if (c_w != 0.0)
 				vec4_fmadd(&out[k * 4], &result[k * 4], c_w, 1);
 		}
 	}
 }
-// 4-wide BCH backprop: interleaved layout, processes 4 batch elements.
-// Uses pair-grouped table for forward recompute and reverse BCH.
-inline void bch_combine_backprop_impl_x4_(
+// 4-wide BCH backprop for a degree-one second input.
+inline void bch_combine_linear_backprop_impl_x4_(
 	const double* RESTRICT d_out, double* RESTRICT d_ls1, double* RESTRICT d_ls2,
 	const double* RESTRICT ls1, const double* RESTRICT ls2,
 	const BchCache& cache, double* workspace
@@ -746,11 +776,11 @@ inline void bch_combine_backprop_impl_x4_(
 	uint64_t m = cache.m;
 	uint64_t m2 = cache.bch_coefficients.size();
 
-	// d_ls1 = d_out, d_ls2 = d_out
-	std::memcpy(d_ls1, d_out, m * 4 * sizeof(double));
-	std::memcpy(d_ls2, d_out, m * 4 * sizeof(double));
-
-	if (m2 <= 2) return;
+	if (m2 <= 2) {
+		std::memcpy(d_ls1, d_out, m * 4 * sizeof(double));
+		std::memcpy(d_ls2, d_out, m * 4 * sizeof(double));
+		return;
+	}
 
 	double* memo = workspace;
 	double* d_memo = workspace + m2 * m * 4;
@@ -758,6 +788,10 @@ inline void bch_combine_backprop_impl_x4_(
 	std::memcpy(memo, ls1, m * 4 * sizeof(double));
 	std::memcpy(memo + m * 4, ls2, m * 4 * sizeof(double));
 
+	const uint32_t* k_ptr = cache.comm_k_ptr.data();
+	const uint32_t* k_i = cache.comm_k_i.data();
+	const uint32_t* k_j = cache.comm_k_j.data();
+	const double* k_c = cache.comm_k_val_d.data();
 	const uint32_t* ij_i = cache.comm_ij_i.data();
 	const uint32_t* ij_j = cache.comm_ij_j.data();
 	const uint32_t* ij_ptr = cache.comm_ij_ptr.data();
@@ -765,17 +799,19 @@ inline void bch_combine_backprop_impl_x4_(
 	const double* ij_c = cache.comm_ij_c.data();
 	const uint32_t n_pairs = cache.n_pairs;
 
-	// Forward recompute (pair-grouped, 4-wide)
+	// Forward recompute (output-grouped, 4-wide)
 	for (uint64_t w = 2; w < m2; ++w) {
 		const uint64_t lf = cache.bch_left_factor[w];
 		const uint64_t rf = cache.bch_right_factor[w];
 		const double* v1 = memo + lf * m * 4;
 		const double* v2 = memo + rf * m * 4;
 		double* result = memo + w * m * 4;
-		std::memset(result, 0, m * 4 * sizeof(double));
-
-		for (uint32_t p = 0; p < n_pairs; ++p)
-			vec4_bracket_scatter(result, v1, v2, ij_i[p], ij_j[p], ij_k, ij_c, ij_ptr[p], ij_ptr[p + 1]);
+		const auto [begin, end] = cache.linear_range[w];
+		std::memset(result, 0, begin * 4 * sizeof(double));
+		std::memset(result + end * 4, 0, (m - end) * 4 * sizeof(double));
+		for (uint64_t k = begin; k < end; ++k)
+			vec4_commutator_accum(&result[k * 4], v1, v2, k_i, k_j, k_c,
+				k_ptr[k], k_ptr[k + 1]);
 	}
 
 	// d_memo init
@@ -800,12 +836,13 @@ inline void bch_combine_backprop_impl_x4_(
 		double* dm_rf = d_memo + rf * m * 4;
 
 		for (uint32_t p = 0; p < n_pairs; ++p)
-			vec4_bracket_grad(dm_lf, dm_rf, dm_w, v1, v2, ij_i[p], ij_j[p], ij_k, ij_c, ij_ptr[p], ij_ptr[p + 1]);
+			vec4_bracket_grad(dm_lf, dm_rf, dm_w, v1, v2, ij_i[p], ij_j[p],
+				ij_k, ij_c, ij_ptr[p], ij_ptr[p + 1]);
 	}
 
-	// Accumulate leaf gradients
-	vec4_add_inplace(d_ls1, d_memo, m);
-	vec4_add_inplace(d_ls2, d_memo + m * 4, m);
+	// Add the direct gradient to the accumulated BCH leaf gradients.
+	vec4_add(d_ls1, d_out, d_memo, m);
+	vec4_add(d_ls2, d_out, d_memo + m * 4, m);
 }
 #endif // VEC
 

--- a/siglib/cpsig/cp_bch.h
+++ b/siglib/cpsig/cp_bch.h
@@ -63,11 +63,9 @@ struct BchCache {
 	std::vector<uint32_t> comm_ij_k;    // [nnz] output index
 	std::vector<double>   comm_ij_c;    // [nnz] coefficient (pre-cast)
 
-#ifdef VEC
 	// Structurally possible output range for each BCH node when the second
 	// input has degree one.
 	std::vector<std::pair<uint64_t, uint64_t>> linear_range;
-#endif
 
 	// Standard factorization of each d-letter Lyndon word (as index pairs)
 	// For degree-1 words: left_factor[i] = right_factor[i] = UINT64_MAX
@@ -452,7 +450,6 @@ inline void build_commutator_table(BchCache& cache) {
 	}
 }
 
-#ifdef VEC
 inline void build_linear_bch_ranges(BchCache& cache) {
 	const uint64_t m2 = cache.bch_coefficients.size();
 
@@ -472,7 +469,6 @@ inline void build_linear_bch_ranges(BchCache& cache) {
 		cache.linear_range[w] = {begin, ::log_sig_length(cache.dimension, max_degree[w])};
 	}
 }
-#endif
 
 // ========================================================================
 // BCH cache management
@@ -511,9 +507,7 @@ inline void set_bch_cache(uint64_t dimension, uint64_t degree) {
 
 	// Build commutator table for d-letter Lyndon basis
 	build_commutator_table(*cache);
-#ifdef VEC
 	build_linear_bch_ranges(*cache);
-#endif
 
 	std::unique_lock wlock(reg.mu);
 	reg.map.insert_or_assign(key, std::move(cache));
@@ -674,12 +668,15 @@ void bch_combine_linear_impl_(
 		const T* v2 = memo + rf * m;
 		T* result = memo + w * m;
 		const T c_w = static_cast<T>(cache.bch_coefficients[w]);
+		const auto [begin, end] = cache.linear_range[w];
+		std::fill(result, result + begin, T(0));
+		std::fill(result + end, result + m, T(0));
 
 		// When one operand is node 1 (the sparse displacement), use
 		// precomputed sparse_end bounds - no per-entry branch needed.
 		const bool sparse = (rf == 1 || lf == 1);
 
-		for (uint64_t k = 0; k < m; ++k) {
+		for (uint64_t k = begin; k < end; ++k) {
 			T sum = T(0);
 			const uint32_t start = k_ptr[k];
 			const uint32_t end = sparse ? k_sparse_end[k] : k_ptr[k + 1];
@@ -850,7 +847,7 @@ inline void bch_combine_linear_backprop_impl_x4_(
 // bch_combine_backprop_impl_: backward pass through BCH
 // ========================================================================
 
-template<std::floating_point T>
+template<std::floating_point T, bool linear_input = false>
 void bch_combine_backprop_impl_(
 	const T* RESTRICT d_out, T* RESTRICT d_ls1, T* RESTRICT d_ls2,
 	const T* RESTRICT ls1, const T* RESTRICT ls2,
@@ -869,7 +866,7 @@ void bch_combine_backprop_impl_(
 	T* memo = workspace;
 	T* d_memo = workspace + m2 * m;
 
-	// Recompute forward memo using pair-grouped table
+	// Linear inputs use the range-aware combiner; otherwise recompute below.
 	std::memcpy(memo, ls1, m * sizeof(T));
 	std::memcpy(memo + m, ls2, m * sizeof(T));
 
@@ -880,7 +877,10 @@ void bch_combine_backprop_impl_(
 	const double* ij_c = cache.comm_ij_c.data();
 	const uint32_t n_pairs = cache.n_pairs;
 
-	for (uint64_t w = 2; w < m2; ++w) {
+	if constexpr (linear_input)
+		bch_combine_linear_impl_(ls1, ls2, d_memo, cache, memo);
+	const uint64_t first_w = linear_input ? m2 : 2;
+	for (uint64_t w = first_w; w < m2; ++w) {
 		const uint64_t lf = cache.bch_left_factor[w];
 		const uint64_t rf = cache.bch_right_factor[w];
 		const T* v1 = memo + lf * m;

--- a/siglib/cpsig/cp_log_signature.h
+++ b/siglib/cpsig/cp_log_signature.h
@@ -609,6 +609,33 @@ void batch_log_sig_from_path_(
 
 	uint64_t m2 = cache.bch_coefficients.size();
 	uint64_t path_stride = length * dimension;
+	uint64_t scalar_start = 0;
+
+#ifdef VEC
+	if constexpr (std::same_as<T, double>) {
+		const uint64_t x4_batch_size = batch_size / 4;
+		auto x4_func = [&](const double* p, double* o) {
+			thread_local std::vector<double> tl_memo;
+			thread_local std::vector<double> tl_seg;
+			thread_local std::vector<double> tl_temp;
+			tl_memo.resize((m2 + 1) * m * 4);
+			tl_seg.resize(m * 4);
+			tl_temp.resize(m * 4);
+
+			const double* paths[4];
+			double* outs[4];
+			for (uint64_t b = 0; b < 4; ++b) {
+				paths[b] = p + b * path_stride;
+				outs[b] = o + b * m;
+			}
+			log_sig_from_path_x4_(paths, outs, length, dimension, cache,
+				tl_memo.data(), tl_seg.data(), tl_temp.data());
+		};
+		multi_threaded_batch(x4_func, x4_batch_size, n_jobs,
+			make_batch(path, path_stride * 4), make_batch(out, m * 4));
+		scalar_start = x4_batch_size * 4;
+	}
+#endif
 
 	auto func = [&](const T* p, T* o) {
 		thread_local std::vector<T> tl_memo;
@@ -619,8 +646,9 @@ void batch_log_sig_from_path_(
 		tl_temp.resize(m);
 		log_sig_from_path_<T>(p, o, length, dimension, cache, tl_memo.data(), tl_seg.data(), tl_temp.data());
 	};
-	multi_threaded_batch(func, batch_size, n_jobs,
-		make_batch(path, path_stride), make_batch(out, m));
+	multi_threaded_batch(func, batch_size - scalar_start, n_jobs,
+		make_batch(path + scalar_start * path_stride, path_stride),
+		make_batch(out + scalar_start * m, m));
 }
 
 // ========================================================================
@@ -745,14 +773,42 @@ void batch_log_sig_from_path_backprop_(
 	uint64_t path_stride = length * dimension;
 	// Workspace: 4*m (curr, prev, seg, neg_seg) + 3*m2*m (bch_ws + bch_bp_ws) + 3*m (d_acc, d_ls1, d_ls2)
 	uint64_t ws_size = 7 * m + 3 * m2 * m;
+	uint64_t scalar_start = 0;
+
+#ifdef VEC
+	if constexpr (std::same_as<T, double>) {
+		const uint64_t x4_batch_size = batch_size / 4;
+		auto x4_func = [&](const double* dout, double* dp, const double* p) {
+			thread_local std::vector<double> tl_ws;
+			tl_ws.resize(ws_size * 4);
+
+			const double* douts[4];
+			double* dpaths[4];
+			const double* paths[4];
+			for (uint64_t b = 0; b < 4; ++b) {
+				douts[b] = dout + b * m;
+				dpaths[b] = dp + b * path_stride;
+				paths[b] = p + b * path_stride;
+			}
+			log_sig_from_path_backprop_x4_(douts, dpaths, paths,
+				length, dimension, cache, tl_ws.data());
+		};
+		multi_threaded_batch(x4_func, x4_batch_size, n_jobs,
+			make_batch(d_out, m * 4), make_batch(d_path, path_stride * 4),
+			make_batch(path, path_stride * 4));
+		scalar_start = x4_batch_size * 4;
+	}
+#endif
 
 	auto func = [&](const T* dout, T* dp, const T* p) {
 		thread_local std::vector<T> tl_ws;
 		tl_ws.resize(ws_size);
 		log_sig_from_path_backprop_<T>(dout, dp, p, length, dimension, cache, tl_ws.data());
 	};
-	multi_threaded_batch(func, batch_size, n_jobs,
-		make_batch(d_out, m), make_batch(d_path, path_stride), make_batch(path, path_stride));
+	multi_threaded_batch(func, batch_size - scalar_start, n_jobs,
+		make_batch(d_out + scalar_start * m, m),
+		make_batch(d_path + scalar_start * path_stride, path_stride),
+		make_batch(path + scalar_start * path_stride, path_stride));
 }
 
 

--- a/siglib/cpsig/cp_log_signature.h
+++ b/siglib/cpsig/cp_log_signature.h
@@ -700,7 +700,7 @@ void log_sig_from_path_backprop_(
 			seg[k] = pb[k] - pa[k];
 
 		// curr = BCH(curr, seg) - reuse prev as temp output, then swap
-		bch_combine_impl_<T>(curr, seg, prev, cache, bch_bp_ws);
+		bch_combine_linear_impl_<T>(curr, seg, prev, cache, bch_bp_ws);
 		std::swap(curr, prev);
 	}
 
@@ -719,10 +719,10 @@ void log_sig_from_path_backprop_(
 		}
 
 		// Recover prev = BCH(curr, -seg) - the "uncombine" step
-		bch_combine_impl_<T>(curr, neg_seg, prev, cache, bch_bp_ws);
+		bch_combine_linear_impl_<T>(curr, neg_seg, prev, cache, bch_bp_ws);
 
 		// Backprop through BCH(prev, seg) -> curr
-		bch_combine_backprop_impl_<T>(d_acc, d_ls1, d_ls2, prev, seg, cache, bch_bp_ws);
+		bch_combine_backprop_impl_<T, true>(d_acc, d_ls1, d_ls2, prev, seg, cache, bch_bp_ws);
 
 		for (uint64_t k = 0; k < dimension; ++k) {
 			d_path[(s + 1) * dimension + k] += d_ls2[k];

--- a/siglib/cpsig/cp_log_signature.h
+++ b/siglib/cpsig/cp_log_signature.h
@@ -532,7 +532,7 @@ inline void log_sig_from_path_backprop_x4_(
 			for (int b = 0; b < 4; ++b)
 				seg[k * 4 + b] = paths[b][(s + 1) * dimension + k] - paths[b][s * dimension + k];
 
-		bch_combine_impl_x4_(curr, seg, prev, cache, bch_ws);
+		bch_combine_linear_impl_x4_(curr, seg, prev, cache, bch_ws);
 		std::swap(curr, prev);
 	}
 
@@ -557,10 +557,10 @@ inline void log_sig_from_path_backprop_x4_(
 		}
 
 		// Uncombine: prev = BCH(curr, -seg)
-		bch_combine_impl_x4_(curr, neg_seg, prev, cache, bch_ws);
+		bch_combine_linear_impl_x4_(curr, neg_seg, prev, cache, bch_ws);
 
 		// Backprop through BCH(prev, seg) -> curr
-		bch_combine_backprop_impl_x4_(d_acc, d_ls1, d_ls2, prev, seg, cache, bch_bp_ws);
+		bch_combine_linear_backprop_impl_x4_(d_acc, d_ls1, d_ls2, prev, seg, cache, bch_bp_ws);
 
 		// Scatter d_ls2 to path gradients
 		for (uint64_t k = 0; k < dimension; ++k) {

--- a/siglib/cpsig/cp_log_signature.h
+++ b/siglib/cpsig/cp_log_signature.h
@@ -508,14 +508,12 @@ inline void log_sig_from_path_backprop_x4_(
 	uint64_t m2 = cache.bch_coefficients.size();
 	uint64_t n_segs = length - 1;
 
-	// Workspace: curr[m*4] + prev[m*4] + seg[m*4] + neg_seg[m*4]
-	//          + bch_ws[m2*m*4] + bch_bp_ws[2*m2*m*4] + d_acc[m*4] + d_ls1[m*4] + d_ls2[m*4]
+	// The forward memo reuses the first half of the backprop workspace.
 	double* curr = workspace;
 	double* prev = curr + m * 4;
 	double* seg = prev + m * 4;
 	double* neg_seg = seg + m * 4;
-	double* bch_ws = neg_seg + m * 4;
-	double* bch_bp_ws = bch_ws + m2 * m * 4;
+	double* bch_bp_ws = neg_seg + m * 4;
 	double* d_acc = bch_bp_ws + 2 * m2 * m * 4;
 	double* d_ls1 = d_acc + m * 4;
 	double* d_ls2 = d_ls1 + m * 4;
@@ -532,7 +530,7 @@ inline void log_sig_from_path_backprop_x4_(
 			for (int b = 0; b < 4; ++b)
 				seg[k * 4 + b] = paths[b][(s + 1) * dimension + k] - paths[b][s * dimension + k];
 
-		bch_combine_linear_impl_x4_(curr, seg, prev, cache, bch_ws);
+		bch_combine_linear_impl_x4_(curr, seg, prev, cache, bch_bp_ws);
 		std::swap(curr, prev);
 	}
 
@@ -557,7 +555,7 @@ inline void log_sig_from_path_backprop_x4_(
 		}
 
 		// Uncombine: prev = BCH(curr, -seg)
-		bch_combine_linear_impl_x4_(curr, neg_seg, prev, cache, bch_ws);
+		bch_combine_linear_impl_x4_(curr, neg_seg, prev, cache, bch_bp_ws);
 
 		// Backprop through BCH(prev, seg) -> curr
 		bch_combine_linear_backprop_impl_x4_(d_acc, d_ls1, d_ls2, prev, seg, cache, bch_bp_ws);
@@ -674,16 +672,14 @@ void log_sig_from_path_backprop_(
 	// prev: m (previous accumulator, recovered via BCH(curr, -seg))
 	// seg: m (segment log-sig buffer)
 	// neg_seg: m (negated segment for uncombination)
-	// bch_ws: m2 * m (BCH forward memo, shared between combine and backprop)
-	// bch_bp_ws: 2 * m2 * m (backprop workspace: memo + d_memo)
+	// bch_bp_ws: 2 * m2 * m (forward memo, then backprop memo + d_memo)
 	// d_acc: m (gradient flowing backward)
 	// d_ls1: m, d_ls2: m
 	T* curr = workspace;
 	T* prev = curr + m;
 	T* seg = prev + m;
 	T* neg_seg = seg + m;
-	T* bch_ws = neg_seg + m;
-	T* bch_bp_ws = bch_ws + m2 * m;
+	T* bch_bp_ws = neg_seg + m;
 	T* d_acc = bch_bp_ws + 2 * m2 * m;
 	T* d_ls1 = d_acc + m;
 	T* d_ls2 = d_ls1 + m;
@@ -704,7 +700,7 @@ void log_sig_from_path_backprop_(
 			seg[k] = pb[k] - pa[k];
 
 		// curr = BCH(curr, seg) - reuse prev as temp output, then swap
-		bch_combine_impl_<T>(curr, seg, prev, cache, bch_ws);
+		bch_combine_impl_<T>(curr, seg, prev, cache, bch_bp_ws);
 		std::swap(curr, prev);
 	}
 
@@ -723,7 +719,7 @@ void log_sig_from_path_backprop_(
 		}
 
 		// Recover prev = BCH(curr, -seg) - the "uncombine" step
-		bch_combine_impl_<T>(curr, neg_seg, prev, cache, bch_ws);
+		bch_combine_impl_<T>(curr, neg_seg, prev, cache, bch_bp_ws);
 
 		// Backprop through BCH(prev, seg) -> curr
 		bch_combine_backprop_impl_<T>(d_acc, d_ls1, d_ls2, prev, seg, cache, bch_bp_ws);
@@ -771,8 +767,7 @@ void batch_log_sig_from_path_backprop_(
 
 	uint64_t m2 = cache.bch_coefficients.size();
 	uint64_t path_stride = length * dimension;
-	// Workspace: 4*m (curr, prev, seg, neg_seg) + 3*m2*m (bch_ws + bch_bp_ws) + 3*m (d_acc, d_ls1, d_ls2)
-	uint64_t ws_size = 7 * m + 3 * m2 * m;
+	uint64_t ws_size = 7 * m + 2 * m2 * m;
 	uint64_t scalar_start = 0;
 
 #ifdef VEC

--- a/siglib/cpsig/cp_vector_funcs.h
+++ b/siglib/cpsig/cp_vector_funcs.h
@@ -443,30 +443,14 @@ FORCE_INLINE void vec4_commutator_accum(
 	__m256d sum = _mm256_setzero_pd();
 	for (uint32_t idx = start; idx < end; ++idx) {
 		const uint32_t ci = ki[idx], cj = kj[idx];
+		const __m256d bracket = _mm256_fmsub_pd(
+			_mm256_loadu_pd(&v1[ci * 4]), _mm256_loadu_pd(&v2[cj * 4]),
+			_mm256_mul_pd(_mm256_loadu_pd(&v1[cj * 4]), _mm256_loadu_pd(&v2[ci * 4])));
 		sum = _mm256_fmadd_pd(_mm256_set1_pd(kval[idx]),
-			_mm256_sub_pd(
-				_mm256_mul_pd(_mm256_loadu_pd(&v1[ci * 4]), _mm256_loadu_pd(&v2[cj * 4])),
-				_mm256_mul_pd(_mm256_loadu_pd(&v1[cj * 4]), _mm256_loadu_pd(&v2[ci * 4]))),
+			bracket,
 			sum);
 	}
 	_mm256_storeu_pd(result, sum);
-}
-
-FORCE_INLINE void vec4_bracket_scatter(
-	double* RESTRICT result,
-	const double* RESTRICT v1, const double* RESTRICT v2,
-	uint32_t i, uint32_t j,
-	const uint32_t* ij_k, const double* ij_c,
-	uint32_t start, uint32_t end
-) {
-	__m256d prod = _mm256_sub_pd(
-		_mm256_mul_pd(_mm256_loadu_pd(&v1[i * 4]), _mm256_loadu_pd(&v2[j * 4])),
-		_mm256_mul_pd(_mm256_loadu_pd(&v1[j * 4]), _mm256_loadu_pd(&v2[i * 4])));
-	for (uint32_t idx = start; idx < end; ++idx) {
-		const uint32_t k = ij_k[idx];
-		_mm256_storeu_pd(&result[k * 4],
-			_mm256_fmadd_pd(_mm256_set1_pd(ij_c[idx]), prod, _mm256_loadu_pd(&result[k * 4])));
-	}
 }
 
 FORCE_INLINE void vec4_bracket_grad(
@@ -478,13 +462,16 @@ FORCE_INLINE void vec4_bracket_grad(
 ) {
 	__m256d S = _mm256_setzero_pd();
 	for (uint32_t idx = start; idx < end; ++idx)
-		S = _mm256_fmadd_pd(_mm256_set1_pd(ij_c[idx]), _mm256_loadu_pd(&dm_w[ij_k[idx] * 4]), S);
-	__m256d v1i = _mm256_loadu_pd(&v1[i * 4]), v1j = _mm256_loadu_pd(&v1[j * 4]);
-	__m256d v2i = _mm256_loadu_pd(&v2[i * 4]), v2j = _mm256_loadu_pd(&v2[j * 4]);
+		S = _mm256_add_pd(S, _mm256_mul_pd(
+			_mm256_set1_pd(ij_c[idx]), _mm256_loadu_pd(&dm_w[ij_k[idx] * 4])));
+	const __m256d v1i = _mm256_loadu_pd(&v1[i * 4]);
+	const __m256d v1j = _mm256_loadu_pd(&v1[j * 4]);
+	const __m256d v2i = _mm256_loadu_pd(&v2[i * 4]);
+	const __m256d v2j = _mm256_loadu_pd(&v2[j * 4]);
 	_mm256_storeu_pd(&dm_lf[i * 4], _mm256_fmadd_pd(S, v2j, _mm256_loadu_pd(&dm_lf[i * 4])));
-	_mm256_storeu_pd(&dm_lf[j * 4], _mm256_sub_pd(_mm256_loadu_pd(&dm_lf[j * 4]), _mm256_mul_pd(S, v2i)));
+	_mm256_storeu_pd(&dm_lf[j * 4], _mm256_fnmadd_pd(S, v2i, _mm256_loadu_pd(&dm_lf[j * 4])));
 	_mm256_storeu_pd(&dm_rf[j * 4], _mm256_fmadd_pd(S, v1i, _mm256_loadu_pd(&dm_rf[j * 4])));
-	_mm256_storeu_pd(&dm_rf[i * 4], _mm256_sub_pd(_mm256_loadu_pd(&dm_rf[i * 4]), _mm256_mul_pd(S, v1j)));
+	_mm256_storeu_pd(&dm_rf[i * 4], _mm256_fnmadd_pd(S, v1j, _mm256_loadu_pd(&dm_rf[i * 4])));
 }
 
 #else
@@ -774,34 +761,15 @@ FORCE_INLINE void vec4_commutator_accum(
 	for (uint32_t idx = start; idx < end; ++idx) {
 		const uint32_t ci = ki[idx], cj = kj[idx];
 		float64x2_t val = vdupq_n_f64(kval[idx]);
-		float64x2_t blo = vsubq_f64(vmulq_f64(vld1q_f64(&v1[ci * 4]),     vld1q_f64(&v2[cj * 4])),
-		                             vmulq_f64(vld1q_f64(&v1[cj * 4]),     vld1q_f64(&v2[ci * 4])));
-		float64x2_t bhi = vsubq_f64(vmulq_f64(vld1q_f64(&v1[ci * 4 + 2]), vld1q_f64(&v2[cj * 4 + 2])),
-		                             vmulq_f64(vld1q_f64(&v1[cj * 4 + 2]), vld1q_f64(&v2[ci * 4 + 2])));
+		float64x2_t blo = vfmaq_f64(vnegq_f64(vmulq_f64(vld1q_f64(&v1[cj * 4]),     vld1q_f64(&v2[ci * 4]))),
+		                             vld1q_f64(&v1[ci * 4]),     vld1q_f64(&v2[cj * 4]));
+		float64x2_t bhi = vfmaq_f64(vnegq_f64(vmulq_f64(vld1q_f64(&v1[cj * 4 + 2]), vld1q_f64(&v2[ci * 4 + 2]))),
+		                             vld1q_f64(&v1[ci * 4 + 2]), vld1q_f64(&v2[cj * 4 + 2]));
 		sum_lo = vfmaq_f64(sum_lo, val, blo);
 		sum_hi = vfmaq_f64(sum_hi, val, bhi);
 	}
 	vst1q_f64(result, sum_lo);
 	vst1q_f64(result + 2, sum_hi);
-}
-
-FORCE_INLINE void vec4_bracket_scatter(
-	double* RESTRICT result,
-	const double* RESTRICT v1, const double* RESTRICT v2,
-	uint32_t i, uint32_t j,
-	const uint32_t* ij_k, const double* ij_c,
-	uint32_t start, uint32_t end
-) {
-	float64x2_t plo = vsubq_f64(vmulq_f64(vld1q_f64(&v1[i * 4]),     vld1q_f64(&v2[j * 4])),
-	                             vmulq_f64(vld1q_f64(&v1[j * 4]),     vld1q_f64(&v2[i * 4])));
-	float64x2_t phi = vsubq_f64(vmulq_f64(vld1q_f64(&v1[i * 4 + 2]), vld1q_f64(&v2[j * 4 + 2])),
-	                             vmulq_f64(vld1q_f64(&v1[j * 4 + 2]), vld1q_f64(&v2[i * 4 + 2])));
-	for (uint32_t idx = start; idx < end; ++idx) {
-		const uint32_t k = ij_k[idx];
-		float64x2_t c = vdupq_n_f64(ij_c[idx]);
-		vst1q_f64(&result[k * 4],     vfmaq_f64(vld1q_f64(&result[k * 4]),     c, plo));
-		vst1q_f64(&result[k * 4 + 2], vfmaq_f64(vld1q_f64(&result[k * 4 + 2]), c, phi));
-	}
 }
 
 FORCE_INLINE void vec4_bracket_grad(
@@ -815,21 +783,21 @@ FORCE_INLINE void vec4_bracket_grad(
 	for (uint32_t idx = start; idx < end; ++idx) {
 		float64x2_t c = vdupq_n_f64(ij_c[idx]);
 		const uint32_t k = ij_k[idx];
-		slo = vfmaq_f64(slo, c, vld1q_f64(&dm_w[k * 4]));
-		shi = vfmaq_f64(shi, c, vld1q_f64(&dm_w[k * 4 + 2]));
+		slo = vaddq_f64(slo, vmulq_f64(c, vld1q_f64(&dm_w[k * 4])));
+		shi = vaddq_f64(shi, vmulq_f64(c, vld1q_f64(&dm_w[k * 4 + 2])));
 	}
-	float64x2_t v1ilo = vld1q_f64(&v1[i * 4]),     v1ihi = vld1q_f64(&v1[i * 4 + 2]);
-	float64x2_t v1jlo = vld1q_f64(&v1[j * 4]),     v1jhi = vld1q_f64(&v1[j * 4 + 2]);
-	float64x2_t v2ilo = vld1q_f64(&v2[i * 4]),     v2ihi = vld1q_f64(&v2[i * 4 + 2]);
-	float64x2_t v2jlo = vld1q_f64(&v2[j * 4]),     v2jhi = vld1q_f64(&v2[j * 4 + 2]);
+	const float64x2_t v1ilo = vld1q_f64(&v1[i * 4]), v1ihi = vld1q_f64(&v1[i * 4 + 2]);
+	const float64x2_t v1jlo = vld1q_f64(&v1[j * 4]), v1jhi = vld1q_f64(&v1[j * 4 + 2]);
+	const float64x2_t v2ilo = vld1q_f64(&v2[i * 4]), v2ihi = vld1q_f64(&v2[i * 4 + 2]);
+	const float64x2_t v2jlo = vld1q_f64(&v2[j * 4]), v2jhi = vld1q_f64(&v2[j * 4 + 2]);
 	vst1q_f64(&dm_lf[i * 4],     vfmaq_f64(vld1q_f64(&dm_lf[i * 4]),     slo, v2jlo));
 	vst1q_f64(&dm_lf[i * 4 + 2], vfmaq_f64(vld1q_f64(&dm_lf[i * 4 + 2]), shi, v2jhi));
-	vst1q_f64(&dm_lf[j * 4],     vsubq_f64(vld1q_f64(&dm_lf[j * 4]),     vmulq_f64(slo, v2ilo)));
-	vst1q_f64(&dm_lf[j * 4 + 2], vsubq_f64(vld1q_f64(&dm_lf[j * 4 + 2]), vmulq_f64(shi, v2ihi)));
+	vst1q_f64(&dm_lf[j * 4],     vfmsq_f64(vld1q_f64(&dm_lf[j * 4]),     slo, v2ilo));
+	vst1q_f64(&dm_lf[j * 4 + 2], vfmsq_f64(vld1q_f64(&dm_lf[j * 4 + 2]), shi, v2ihi));
 	vst1q_f64(&dm_rf[j * 4],     vfmaq_f64(vld1q_f64(&dm_rf[j * 4]),     slo, v1ilo));
 	vst1q_f64(&dm_rf[j * 4 + 2], vfmaq_f64(vld1q_f64(&dm_rf[j * 4 + 2]), shi, v1ihi));
-	vst1q_f64(&dm_rf[i * 4],     vsubq_f64(vld1q_f64(&dm_rf[i * 4]),     vmulq_f64(slo, v1jlo)));
-	vst1q_f64(&dm_rf[i * 4 + 2], vsubq_f64(vld1q_f64(&dm_rf[i * 4 + 2]), vmulq_f64(shi, v1jhi)));
+	vst1q_f64(&dm_rf[i * 4],     vfmsq_f64(vld1q_f64(&dm_rf[i * 4]),     slo, v1jlo));
+	vst1q_f64(&dm_rf[i * 4 + 2], vfmsq_f64(vld1q_f64(&dm_rf[i * 4 + 2]), shi, v1jhi));
 }
 
 #endif


### PR DESCRIPTION
## Summary

Dispatch double-precision batches in groups of four to the existing x4 BCH kernels. Basically `log_sig_from_path_x4_` and `log_sig_from_path_backprop_x4_` just weren't hooked up. Let me know if you have problems with how I am calling them on lines 614 and 778.

I am also now skipping impossible BCH terms for the linear segments which appear in `log_sig_from_path`.

## Validation

- Compared x4 outputs and gradients with scalar calls for batches containing scalar remainders. They match to about $7 \times10^{-15}$.
- Checked threaded execution.
- Built with vectorization enabled and disabled.
