### PR TITLE
Changed test app name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,8 +195,8 @@ endif()
 if(PYSIGLIB_TESTS AND TARGET cusig_tests)
     list(APPEND _pysiglib_cpp_solution_targets cusig_tests)
 endif()
-if(PYSIGLIB_TEST_APP AND TARGET pysiglib_test_app)
-    list(APPEND _pysiglib_cpp_solution_targets pysiglib_test_app)
+if(PYSIGLIB_TEST_APP AND TARGET test_app)
+    list(APPEND _pysiglib_cpp_solution_targets test_app)
 endif()
 
 add_custom_target(pysiglib_cpp_solution ALL

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -172,7 +172,7 @@
       "configuration": "Debug",
       "jobs": 1,
       "targets": [
-        "pysiglib_test_app"
+        "test_app"
       ]
     },
     {
@@ -182,7 +182,7 @@
       "configuration": "Release",
       "jobs": 1,
       "targets": [
-        "pysiglib_test_app"
+        "test_app"
       ]
     },
     {
@@ -214,7 +214,7 @@
     {
       "name": "windows-cpp-solution-debug",
       "displayName": "Windows: Full C++ Solution Debug",
-      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and pysiglib_test_app.",
+      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and test_app.",
       "configurePreset": "windows-cpp-solution",
       "configuration": "Debug",
       "jobs": 1,
@@ -225,7 +225,7 @@
     {
       "name": "windows-cpp-solution-release",
       "displayName": "Windows: Full C++ Solution Release",
-      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and pysiglib_test_app.",
+      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and test_app.",
       "configurePreset": "windows-cpp-solution",
       "configuration": "Release",
       "jobs": 1,
@@ -290,7 +290,7 @@
       "displayName": "Linux/WSL: Test App Debug",
       "configurePreset": "linux-cpp-solution-debug",
       "targets": [
-        "pysiglib_test_app"
+        "test_app"
       ]
     },
     {
@@ -298,13 +298,13 @@
       "displayName": "Linux/WSL: Test App Release",
       "configurePreset": "linux-cpp-solution-release",
       "targets": [
-        "pysiglib_test_app"
+        "test_app"
       ]
     },
     {
       "name": "linux-cpp-solution-debug",
       "displayName": "Linux/WSL: Full C++ Solution Debug",
-      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and pysiglib_test_app.",
+      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and test_app.",
       "configurePreset": "linux-cpp-solution-debug",
       "targets": [
         "pysiglib_cpp_solution"
@@ -313,7 +313,7 @@
     {
       "name": "linux-cpp-solution-release",
       "displayName": "Linux/WSL: Full C++ Solution Release",
-      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and pysiglib_test_app.",
+      "description": "Build cpsig, cusig, cpsig_tests, cusig_tests, and test_app.",
       "configurePreset": "linux-cpp-solution-release",
       "targets": [
         "pysiglib_cpp_solution"

--- a/scripts/profile_cuda.ps1
+++ b/scripts/profile_cuda.ps1
@@ -196,9 +196,9 @@ function Resolve-NvidiaProfiler {
 
 function Get-TestAppCandidates {
     return @(
-        "out\build\windows-cpp-solution\siglib\test_app\Release\pysiglib_test_app.exe",
-        "out\build\windows-cpp-solution\siglib\test_app\RelWithDebInfo\pysiglib_test_app.exe",
-        "out\build\windows-cpp-solution\siglib\test_app\Debug\pysiglib_test_app.exe"
+        "out\build\windows-cpp-solution\siglib\test_app\Release\test_app.exe",
+        "out\build\windows-cpp-solution\siglib\test_app\RelWithDebInfo\test_app.exe",
+        "out\build\windows-cpp-solution\siglib\test_app\Debug\test_app.exe"
     )
 }
 
@@ -225,7 +225,7 @@ function Resolve-TestAppPath {
 
     $fallback = ConvertTo-FullPath -Path (Get-TestAppCandidates | Select-Object -First 1) -BasePath $repoRoot
     if ($Required) {
-        throw "Could not find pysiglib_test_app.exe. Run with -BuildIfMissing or pass -TestAppPath."
+        throw "Could not find test_app.exe. Run with -BuildIfMissing or pass -TestAppPath."
     }
     return $fallback
 }

--- a/scripts/profile_vtune.ps1
+++ b/scripts/profile_vtune.ps1
@@ -39,7 +39,7 @@ function Show-Usage {
 Usage:
   .\scripts\profile_vtune.ps1
   .\scripts\profile_vtune.ps1 -BuildIfMissing
-  .\scripts\profile_vtune.ps1 -TestAppPath .\out\build\windows-cpp-solution\siglib\test_app\Release\pysiglib_test_app.exe
+  .\scripts\profile_vtune.ps1 -TestAppPath .\out\build\windows-cpp-solution\siglib\test_app\Release\test_app.exe
   .\scripts\profile_vtune.ps1 -DllDir .\pysiglib -AppArgs @("extra", "test", "args")
 
 Important options:
@@ -161,9 +161,9 @@ function Resolve-VTune {
 
 function Get-TestAppCandidates {
     return @(
-        "out\build\windows-cpp-solution\siglib\test_app\Release\pysiglib_test_app.exe",
-        "out\build\windows-cpp-solution\siglib\test_app\RelWithDebInfo\pysiglib_test_app.exe",
-        "out\build\windows-cpp-solution\siglib\test_app\Debug\pysiglib_test_app.exe"
+        "out\build\windows-cpp-solution\siglib\test_app\Release\test_app.exe",
+        "out\build\windows-cpp-solution\siglib\test_app\RelWithDebInfo\test_app.exe",
+        "out\build\windows-cpp-solution\siglib\test_app\Debug\test_app.exe"
     )
 }
 
@@ -190,7 +190,7 @@ function Resolve-TestAppPath {
 
     $fallback = ConvertTo-FullPath -Path (Get-TestAppCandidates | Select-Object -First 1) -BasePath $repoRoot
     if ($Required) {
-        throw "Could not find pysiglib_test_app.exe. Run with -BuildIfMissing or pass -TestAppPath."
+        throw "Could not find test_app.exe. Run with -BuildIfMissing or pass -TestAppPath."
     }
     return $fallback
 }

--- a/siglib/test_app/CMakeLists.txt
+++ b/siglib/test_app/CMakeLists.txt
@@ -1,39 +1,39 @@
 find_package(CUDAToolkit REQUIRED)
 
-add_executable(pysiglib_test_app
+add_executable(test_app
     dll_funcs.cpp
     test_app.cpp
     tests.cpp
     utils.cpp
 )
 
-target_compile_features(pysiglib_test_app PRIVATE cxx_std_20)
-target_include_directories(pysiglib_test_app PRIVATE
+target_compile_features(test_app PRIVATE cxx_std_20)
+target_include_directories(test_app PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
 )
-target_link_libraries(pysiglib_test_app PRIVATE CUDA::cudart ${CMAKE_DL_LIBS})
+target_link_libraries(test_app PRIVATE CUDA::cudart ${CMAKE_DL_LIBS})
 
 if(TARGET cpsig)
-    add_dependencies(pysiglib_test_app cpsig)
-    add_custom_command(TARGET pysiglib_test_app POST_BUILD
+    add_dependencies(test_app cpsig)
+    add_custom_command(TARGET test_app POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             $<TARGET_FILE:cpsig>
-            $<TARGET_FILE_DIR:pysiglib_test_app>
+            $<TARGET_FILE_DIR:test_app>
     )
     if(WIN32)
-        add_custom_command(TARGET pysiglib_test_app POST_BUILD
+        add_custom_command(TARGET test_app POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 $<TARGET_FILE:tbb>
-                $<TARGET_FILE_DIR:pysiglib_test_app>
+                $<TARGET_FILE_DIR:test_app>
         )
     endif()
 endif()
 
 if(TARGET cusig)
-    add_dependencies(pysiglib_test_app cusig)
-    add_custom_command(TARGET pysiglib_test_app POST_BUILD
+    add_dependencies(test_app cusig)
+    add_custom_command(TARGET test_app POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             $<TARGET_FILE:cusig>
-            $<TARGET_FILE_DIR:pysiglib_test_app>
+            $<TARGET_FILE_DIR:test_app>
     )
 endif()


### PR DESCRIPTION
Stack layer 1 of 8. This layer aligns the native CMake configuration, Windows presets, profiling scripts, and test application build settings. It provides a stable build foundation for the functional changes above it. Validation: full Python unit suite, 2587 passed and 10 skipped.