### PR TITLE
Add CPU MKW Lyndon branched log signatures

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,9 +3,17 @@ name: CodSpeed Benchmarks
 on:
   push:
     branches: ["main"]
-    paths: ["siglib/cpsig/**"]
+    paths:
+      - ".github/workflows/codspeed.yml"
+      - "benchmarks/**"
+      - "siglib/cpsig/**"
+      - "siglib/shared/**"
   pull_request:
-    paths: ["siglib/cpsig/**"]
+    paths:
+      - ".github/workflows/codspeed.yml"
+      - "benchmarks/**"
+      - "siglib/cpsig/**"
+      - "siglib/shared/**"
   workflow_dispatch:
 
 permissions:

--- a/benchmarks/bench_cpsig.cpp
+++ b/benchmarks/bench_cpsig.cpp
@@ -112,13 +112,26 @@ static void BM_prepare_branched_sig_planar(benchmark::State& state) {
 }
 BENCHMARK(BM_prepare_branched_sig_planar)->Unit(benchmark::kMicrosecond);
 
-static void BM_prepare_branched_log_sig(benchmark::State& state) {
+static void BM_prepare_branched_log_sig_nonplanar_method_0(benchmark::State& state) {
     for (auto _ : state) {
         clear_caches_outside_timing(state);
-        check(::prepare_branched_log_sig(3, 4, false, false), "prepare_branched_log_sig");
+        check(::prepare_branched_log_sig(3, 4, 0, false, false),
+              "prepare_branched_log_sig");
     }
 }
-BENCHMARK(BM_prepare_branched_log_sig)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_prepare_branched_log_sig_nonplanar_method_0)
+    ->Unit(benchmark::kMicrosecond);
+
+static void BM_prepare_branched_log_sig_planar(benchmark::State& state) {
+    const int method = static_cast<int>(state.range(0));
+    for (auto _ : state) {
+        clear_caches_outside_timing(state);
+        check(::prepare_branched_log_sig(3, 4, method, false, true),
+              "prepare_branched_log_sig");
+    }
+}
+BENCHMARK(BM_prepare_branched_log_sig_planar)
+    ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
 
 // =========================================================================
 // Path transforms
@@ -798,36 +811,94 @@ static void BM_branched_sig_backprop_correction(benchmark::State& state) {
 }
 BENCHMARK(BM_branched_sig_backprop_correction)->Unit(benchmark::kMicrosecond);
 
-static void BM_branched_sig_to_log_sig(benchmark::State& state) {
-    check(::prepare_branched_log_sig(3, 4, false, false), "prepare_branched_log_sig");
+static void BM_branched_sig_to_log_sig_nonplanar_method_0(
+        benchmark::State& state) {
+    check(::prepare_branched_log_sig(3, 4, 0, false, false),
+          "prepare_branched_log_sig");
     const uint64_t blen = ::branched_sig_length(3, 4, false);
     auto bsig = random_data(64 * blen, 1);
     std::vector<double> out(64 * blen);
     check(::branched_sig_to_log_sig_d(
-        bsig.data(), out.data(), 64, 3, 4), "branched_sig_to_log_sig_d");
+        bsig.data(), out.data(), 64, 3, 4, 0, 1, false, true),
+        "branched_sig_to_log_sig_d");
     for (auto _ : state) {
-        ::branched_sig_to_log_sig_d(bsig.data(), out.data(), 64, 3, 4);
+        ::branched_sig_to_log_sig_d(
+            bsig.data(), out.data(), 64, 3, 4, 0, 1, false, true);
         benchmark::DoNotOptimize(out.data());
     }
 }
-BENCHMARK(BM_branched_sig_to_log_sig)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_branched_sig_to_log_sig_nonplanar_method_0)
+    ->Unit(benchmark::kMicrosecond);
 
-static void BM_branched_sig_to_log_sig_backprop(benchmark::State& state) {
-    check(::prepare_branched_log_sig(3, 4, false, false), "prepare_branched_log_sig");
+static void BM_branched_sig_to_log_sig_planar(benchmark::State& state) {
+    const int method = static_cast<int>(state.range(0));
+    check(::prepare_branched_log_sig(3, 4, method, false, true),
+          "prepare_branched_log_sig");
+    const uint64_t blen = ::branched_sig_length(3, 4, true);
+    const uint64_t out_len = method == 0
+        ? blen
+        : ::branched_log_sig_length(3, 4, true);
+    auto bsig = random_data(64 * blen, 1);
+    std::vector<double> out(64 * out_len);
+    check(::branched_sig_to_log_sig_d(
+        bsig.data(), out.data(), 64, 3, 4, method, 1, true, true),
+        "branched_sig_to_log_sig_d");
+    for (auto _ : state) {
+        ::branched_sig_to_log_sig_d(
+            bsig.data(), out.data(), 64, 3, 4, method, 1, true, true);
+        benchmark::DoNotOptimize(out.data());
+    }
+}
+BENCHMARK(BM_branched_sig_to_log_sig_planar)
+    ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
+
+static void BM_branched_sig_to_log_sig_backprop_nonplanar_method_0(
+        benchmark::State& state) {
+    check(::prepare_branched_log_sig(3, 4, 0, false, false),
+          "prepare_branched_log_sig");
     const uint64_t blen = ::branched_sig_length(3, 4, false);
     auto bsig = random_data(64 * blen, 1);
     auto derivs = random_data(64 * blen, 2);
     std::vector<double> out(64 * blen);
     check(::branched_sig_to_log_sig_backprop_d(
-        bsig.data(), derivs.data(), out.data(), 64, 3, 4),
+        bsig.data(), derivs.data(), out.data(), 64, 3, 4,
+        0, 1, false, true),
         "branched_sig_to_log_sig_backprop_d");
     for (auto _ : state) {
         ::branched_sig_to_log_sig_backprop_d(
-            bsig.data(), derivs.data(), out.data(), 64, 3, 4);
+            bsig.data(), derivs.data(), out.data(), 64, 3, 4,
+            0, 1, false, true);
         benchmark::DoNotOptimize(out.data());
     }
 }
-BENCHMARK(BM_branched_sig_to_log_sig_backprop)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_branched_sig_to_log_sig_backprop_nonplanar_method_0)
+    ->Unit(benchmark::kMicrosecond);
+
+static void BM_branched_sig_to_log_sig_backprop_planar(
+        benchmark::State& state) {
+    const int method = static_cast<int>(state.range(0));
+    check(::prepare_branched_log_sig(3, 4, method, false, true),
+          "prepare_branched_log_sig");
+    const uint64_t blen = ::branched_sig_length(3, 4, true);
+    const uint64_t out_len = method == 0
+        ? blen
+        : ::branched_log_sig_length(3, 4, true);
+    auto bsig = random_data(64 * blen, 1);
+    auto derivs = random_data(64 * out_len, 2);
+    std::vector<double> out(64 * blen);
+    check(::branched_sig_to_log_sig_backprop_d(
+        bsig.data(), derivs.data(), out.data(), 64, 3, 4,
+        method, 1, true, true),
+        "branched_sig_to_log_sig_backprop_d");
+    for (auto _ : state) {
+        ::branched_sig_to_log_sig_backprop_d(
+            bsig.data(), derivs.data(), out.data(), 64, 3, 4,
+            method, 1, true, true);
+        benchmark::DoNotOptimize(out.data());
+    }
+}
+BENCHMARK(BM_branched_sig_to_log_sig_backprop_planar)
+    ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
 
 static void BM_branched_sig_combine(benchmark::State& state) {
     check(::prepare_branched_sig(3, 4, false, false), "prepare_branched_sig");

--- a/benchmarks/bench_cpsig.cpp
+++ b/benchmarks/bench_cpsig.cpp
@@ -112,15 +112,14 @@ static void BM_prepare_branched_sig_planar(benchmark::State& state) {
 }
 BENCHMARK(BM_prepare_branched_sig_planar)->Unit(benchmark::kMicrosecond);
 
-static void BM_prepare_branched_log_sig_nonplanar_method_0(benchmark::State& state) {
+static void BM_prepare_branched_log_sig(benchmark::State& state) {
     for (auto _ : state) {
         clear_caches_outside_timing(state);
         check(::prepare_branched_log_sig(3, 4, 0, false, false),
               "prepare_branched_log_sig");
     }
 }
-BENCHMARK(BM_prepare_branched_log_sig_nonplanar_method_0)
-    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_prepare_branched_log_sig)->Unit(benchmark::kMicrosecond);
 
 static void BM_prepare_branched_log_sig_planar(benchmark::State& state) {
     const int method = static_cast<int>(state.range(0));
@@ -811,8 +810,7 @@ static void BM_branched_sig_backprop_correction(benchmark::State& state) {
 }
 BENCHMARK(BM_branched_sig_backprop_correction)->Unit(benchmark::kMicrosecond);
 
-static void BM_branched_sig_to_log_sig_nonplanar_method_0(
-        benchmark::State& state) {
+static void BM_branched_sig_to_log_sig(benchmark::State& state) {
     check(::prepare_branched_log_sig(3, 4, 0, false, false),
           "prepare_branched_log_sig");
     const uint64_t blen = ::branched_sig_length(3, 4, false);
@@ -827,8 +825,7 @@ static void BM_branched_sig_to_log_sig_nonplanar_method_0(
         benchmark::DoNotOptimize(out.data());
     }
 }
-BENCHMARK(BM_branched_sig_to_log_sig_nonplanar_method_0)
-    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_branched_sig_to_log_sig)->Unit(benchmark::kMicrosecond);
 
 static void BM_branched_sig_to_log_sig_planar(benchmark::State& state) {
     const int method = static_cast<int>(state.range(0));
@@ -852,8 +849,7 @@ static void BM_branched_sig_to_log_sig_planar(benchmark::State& state) {
 BENCHMARK(BM_branched_sig_to_log_sig_planar)
     ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
 
-static void BM_branched_sig_to_log_sig_backprop_nonplanar_method_0(
-        benchmark::State& state) {
+static void BM_branched_sig_to_log_sig_backprop(benchmark::State& state) {
     check(::prepare_branched_log_sig(3, 4, 0, false, false),
           "prepare_branched_log_sig");
     const uint64_t blen = ::branched_sig_length(3, 4, false);
@@ -871,8 +867,7 @@ static void BM_branched_sig_to_log_sig_backprop_nonplanar_method_0(
         benchmark::DoNotOptimize(out.data());
     }
 }
-BENCHMARK(BM_branched_sig_to_log_sig_backprop_nonplanar_method_0)
-    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_branched_sig_to_log_sig_backprop)->Unit(benchmark::kMicrosecond);
 
 static void BM_branched_sig_to_log_sig_backprop_planar(
         benchmark::State& state) {

--- a/docs/pages/branched_log_signatures.rst
+++ b/docs/pages/branched_log_signatures.rst
@@ -11,5 +11,6 @@ the Hopf-algebra logarithm used by branched and planar branched log signatures.
 
    /pages/branched_log_signatures/computing_branched_log_signatures
    /pages/branched_log_signatures/prepare_branched_log_sig
+   /pages/branched_log_signatures/branched_log_sig_length
    /pages/branched_log_signatures/branched_log_sig
    /pages/branched_log_signatures/branched_sig_to_log_sig

--- a/pysiglib/__init__.py
+++ b/pysiglib/__init__.py
@@ -43,7 +43,8 @@ from .branched_sig import prepare_branched_sig, branched_sig, branched_sig_combi
 from .branched_sig_backprop import branched_sig_backprop, branched_sig_combine_backprop
 from .branched_sig_coef import extract_branched_sig_coef, prepare_branched_sig_coef, branched_sig_coef
 from .branched_sig_coef_backprop import branched_sig_coef_backprop
-from .branched_log_sig import prepare_branched_log_sig, branched_sig_to_log_sig, branched_log_sig
+from .branched_log_sig import (branched_log_sig, branched_log_sig_length,
+                               branched_sig_to_log_sig, prepare_branched_log_sig)
 from .branched_log_sig_backprop import branched_sig_to_log_sig_backprop
 from .streams import SigStream, LogSigStream, SigWindowStream, LogSigWindowStream
 

--- a/pysiglib/branched_log_sig.py
+++ b/pysiglib/branched_log_sig.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # =========================================================================
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -34,6 +34,7 @@ from .branched_sig import (
 def prepare_branched_log_sig(
         dimension: int,
         degree: int,
+        method: int,
         *,
         use_disk: bool = False,
         time_aug: bool = False,
@@ -51,6 +52,10 @@ def prepare_branched_log_sig(
     :type dimension: int
     :param degree: Maximum order (number of nodes).
     :type degree: int
+    :param method: Method to prepare. Method 0 computes the expanded branched
+        log signature. Methods 1 and 2 compute compressed MKW log signatures
+        and require ``planar=True``.
+    :type method: int
     :param use_disk: If ``True``, load or save the branched-signature cache on disk.
     :type use_disk: bool
     :param time_aug: If True, prepare for time-augmented paths (dim + 1).
@@ -69,27 +74,73 @@ def prepare_branched_log_sig(
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
     check_type(planar, "planar", bool)
+    check_type(method, "method", int)
+    method = _resolve_branched_log_sig_method(method, planar)
     check_type(device, "device", str)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     if device not in ("cpu", "cuda", "both"):
         raise ValueError("device must be 'cpu', 'cuda', or 'both'")
+    if method and device == "cuda":
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
 
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
     if device in ("cpu", "both"):
         err_code = CPSIG.prepare_branched_log_sig(
-            aug_dimension, degree, use_disk, planar)
+            aug_dimension, degree, method, use_disk, planar)
         if err_code:
             raise Exception(
                 "Error in pysiglib.prepare_branched_log_sig: " + err_msg(err_code))
 
-    if BUILT_WITH_CUDA and device in ("cuda", "both"):
+    if method == 0 and BUILT_WITH_CUDA and device in ("cuda", "both"):
         err_code = CUSIG.prepare_branched_log_sig_cuda(
             aug_dimension, degree, planar, use_disk)
         if err_code:
             raise Exception(
                 "Error in pysiglib.prepare_branched_log_sig (CUDA): "
                 + err_msg(err_code))
+
+
+def _resolve_branched_log_sig_method(method: Optional[int], planar: bool) -> int:
+    check_type(planar, "planar", bool)
+    if method is None:
+        return 1 if planar else 0
+    check_type(method, "method", int)
+    if method == 3:
+        raise NotImplementedError(
+            "branched log signature method 3 is not implemented")
+    if method not in (0, 1, 2):
+        raise ValueError("method must be one of 0, 1 or 2. Got " + str(method) + " instead.")
+    if method and not planar:
+        raise ValueError(
+            "branched log signature methods 1 and 2 require planar=True")
+    return method
+
+
+def branched_log_sig_length(
+        dimension: int,
+        degree: int,
+        *,
+        planar: bool = False,
+) -> int:
+    """Returns the scalar-free length of a branched log signature.
+
+    For ``planar=True``, this is the number of weighted Lyndon forests. For
+    ``planar=False``, this is the number of decorated nonplanar rooted trees.
+    """
+    check_type(dimension, "dimension", int)
+    check_type(degree, "degree", int)
+    check_type(planar, "planar", bool)
+    check_non_neg(dimension, "dimension")
+    check_non_neg(degree, "degree")
+    if dimension > 255:
+        raise ValueError("branched log signature dimension must be <= 255")
+    out = CPSIG.branched_log_sig_length(dimension, degree, planar)
+    if out == 0 and dimension > 0 and degree > 0:
+        raise ValueError(
+            "Invalid parameters or integer overflow in branched_log_sig_length")
+    return out
 
 
 def branched_sig_to_log_sig(
@@ -100,6 +151,7 @@ def branched_sig_to_log_sig(
         time_aug: bool = False,
         lead_lag: bool = False,
         planar: bool = False,
+        method: Optional[int] = None,
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
     """
@@ -120,13 +172,18 @@ def branched_sig_to_log_sig(
     :type lead_lag: bool
     :param planar: If True, use planar branched signatures.
     :type planar: bool
+    :param method: Method to use. Method 0 returns the expanded branched log
+        signature. Methods 1 and 2 return compressed MKW coordinates and
+        require ``planar=True``. If omitted, method 0 is used for nonplanar
+        signatures and method 1 is used for planar signatures.
+    :type method: int | None
     :param n_jobs: Number of threads to run in parallel.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
         are used. For n_jobs below -1, (max_threads + 1 + n_jobs) threads are used. For example
         if n_jobs = -2, all threads but one are used.
     :type n_jobs: int
-    :return: The branched log signature or batch of branched log signatures, in the same
-        scalar-term format as ``bsig``.
+    :return: The branched log signature or batch of branched log signatures. Method 0
+        preserves the scalar-term format of ``bsig``. Methods 1 and 2 are scalar-free.
     :rtype: numpy.ndarray | torch.Tensor
 
     Example usage:
@@ -137,7 +194,7 @@ def branched_sig_to_log_sig(
         import torch
         import pysiglib
 
-        pysiglib.prepare_branched_log_sig(5, 3)
+        pysiglib.prepare_branched_log_sig(5, 3, 0)
         path = torch.rand((10, 100, 5))
         bsig = pysiglib.branched_sig(path, 3)
         blogsig = pysiglib.branched_sig_to_log_sig(bsig, 5, 3)
@@ -148,15 +205,25 @@ def branched_sig_to_log_sig(
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
     check_type(planar, "planar", bool)
+    method = _resolve_branched_log_sig_method(method, planar)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
+    if method and isinstance(bsig, torch.Tensor) and bsig.device.type != "cpu":
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
 
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
     scalar_term = _infer_branched_scalar_term(bsig, aug_dimension, degree, planar=planar)
     bsig_len = branched_sig_length(aug_dimension, degree, planar=planar, scalar_term=scalar_term)
     data = MultipleSigInputHandler([bsig], bsig_len, ["bsig"])
-    result = SigOutputHandler(data, bsig_len)
+    out_len = (bsig_len if method == 0 else
+               branched_log_sig_length(aug_dimension, degree, planar=True))
+    result = SigOutputHandler(data, out_len)
+
+    if method and data.device != "cpu":
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
 
     if data.batch_size == 0:
         return result.data
@@ -164,7 +231,7 @@ def branched_sig_to_log_sig(
     if data.device == "cpu":
         err_code = CPSIG_BRANCHED_SIG_TO_LOG_SIG[data.dtype](
             data.sig_ptr[0], result.data_ptr, data.batch_size,
-            aug_dimension, degree, n_jobs, planar, scalar_term)
+            aug_dimension, degree, method, n_jobs, planar, scalar_term)
     else:
         err_code = CUSIG_BRANCHED_SIG_TO_LOG_SIG_CUDA[data.dtype](
             data.sig_ptr[0], result.data_ptr, data.batch_size,
@@ -184,6 +251,7 @@ def branched_log_sig(
         end_time: float = 1.0,
         planar: bool = False,
         scalar_term: bool = False,
+        method: Optional[int] = None,
         correction = None,
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
@@ -210,6 +278,12 @@ def branched_log_sig(
     :type planar: bool
     :param scalar_term: If True, include the leading scalar coefficient, which is zero.
     :type scalar_term: bool
+    :param method: Method to use. Method 0 returns the expanded branched log
+        signature. Methods 1 and 2 return compressed MKW coordinates and
+        require ``planar=True``. If omitted, method 0 is used for nonplanar
+        signatures and method 1 is used for planar signatures. ``scalar_term``
+        affects only method 0.
+    :type method: int | None
     :param correction: Optional per-segment correction of level
         :math:`\\geq 2` added to the path increment on each path
         segment, before the branched log signature is taken. The
@@ -256,7 +330,7 @@ def branched_log_sig(
         import torch
         import pysiglib
 
-        pysiglib.prepare_branched_log_sig(5, 3)
+        pysiglib.prepare_branched_log_sig(5, 3, 0)
         path = torch.rand((10, 100, 5))
         blogsig = pysiglib.branched_log_sig(path, 3)
         print(blogsig)
@@ -284,15 +358,19 @@ def branched_log_sig(
         correction = np.broadcast_to(
             (-0.5 * np.eye(d) * dt).reshape(1, -1), (n_steps, d * d)).copy()
 
-        pysiglib.prepare_branched_log_sig(d, N)
+        pysiglib.prepare_branched_log_sig(d, N, 0)
         ito_blogsig = pysiglib.branched_log_sig(
             path, N, correction=correction, end_time=T)
         print(ito_blogsig)
     """
+    method = _resolve_branched_log_sig_method(method, planar)
+    if method and isinstance(path, torch.Tensor) and path.device.type != "cpu":
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
     bsig = branched_sig(
         path, degree, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time,
         planar=planar, scalar_term=scalar_term, correction=correction, n_jobs=n_jobs)
     dimension = path.shape[-1]
     return branched_sig_to_log_sig(
         bsig, dimension, degree, time_aug=time_aug, lead_lag=lead_lag,
-        planar=planar, n_jobs=n_jobs)
+        planar=planar, method=method, n_jobs=n_jobs)

--- a/pysiglib/branched_log_sig_backprop.py
+++ b/pysiglib/branched_log_sig_backprop.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # =========================================================================
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -24,11 +24,15 @@ from .dtypes import (
     CPSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP,
     CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA,
 )
-from .data_handlers import MultipleSigInputHandler, SigOutputHandler
+from .data_handlers import SigInputHandler, SigOutputHandler
 from .sig_length import aug_dim
 from .branched_sig import (
     _infer_branched_scalar_term,
     branched_sig_length,
+)
+from .branched_log_sig import (
+    _resolve_branched_log_sig_method,
+    branched_log_sig_length,
 )
 
 
@@ -41,6 +45,7 @@ def branched_sig_to_log_sig_backprop(
         time_aug: bool = False,
         lead_lag: bool = False,
         planar: bool = False,
+        method: Optional[int] = None,
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
     """
@@ -68,6 +73,10 @@ def branched_sig_to_log_sig_backprop(
     :type lead_lag: bool
     :param planar: If True, use planar branched signatures.
     :type planar: bool
+    :param method: Method used in the forward computation. If omitted, method
+        0 is used for nonplanar signatures and method 1 is used for planar
+        signatures.
+    :type method: int | None
     :param n_jobs: Number of threads to run in parallel.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
         are used. For n_jobs below -1, (max_threads + 1 + n_jobs) threads are used. For example
@@ -85,7 +94,7 @@ def branched_sig_to_log_sig_backprop(
         import torch
         import pysiglib
 
-        pysiglib.prepare_branched_log_sig(5, 3)
+        pysiglib.prepare_branched_log_sig(5, 3, 0)
         path = torch.rand((10, 100, 5))
         bsig = pysiglib.branched_sig(path, 3)
         blogsig = pysiglib.branched_sig_to_log_sig(bsig, 5, 3)
@@ -100,26 +109,56 @@ def branched_sig_to_log_sig_backprop(
     check_type(time_aug, "time_aug", bool)
     check_type(lead_lag, "lead_lag", bool)
     check_type(planar, "planar", bool)
+    method = _resolve_branched_log_sig_method(method, planar)
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
+    if method and (
+        isinstance(bsig, torch.Tensor) and bsig.device.type != "cpu"
+        or isinstance(blogsig_derivs, torch.Tensor)
+        and blogsig_derivs.device.type != "cpu"
+    ):
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
 
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
     scalar_term = _infer_branched_scalar_term(bsig, aug_dimension, degree, planar=planar)
     bsig_len = branched_sig_length(aug_dimension, degree, planar=planar, scalar_term=scalar_term)
-    data = MultipleSigInputHandler([bsig, blogsig_derivs], bsig_len, ["bsig", "blogsig_derivs"])
+    blogsig_len = (bsig_len if method == 0 else
+                   branched_log_sig_length(aug_dimension, degree, planar=True))
+    data = SigInputHandler(bsig, bsig_len, "bsig")
+    derivs_data = SigInputHandler(blogsig_derivs, blogsig_len, "blogsig_derivs")
+    if method != 0 and blogsig_derivs.shape[-1] != blogsig_len:
+        raise ValueError(
+            "blogsig_derivs is of incorrect length. Expected "
+            + str(blogsig_len) + ", got " + str(blogsig_derivs.shape[-1]))
+
+    if data.type_ != derivs_data.type_:
+        raise ValueError(
+            "bsig and blogsig_derivs must both be numpy arrays or both be torch tensors")
+    if data.dtype != derivs_data.dtype:
+        raise ValueError("bsig and blogsig_derivs must have the same dtype")
+    if data.batch_shape != derivs_data.batch_shape:
+        raise ValueError("bsig and blogsig_derivs have different batch shapes")
+    if data.device != derivs_data.device:
+        raise ValueError("bsig and blogsig_derivs must be on the same device")
+
     result = SigOutputHandler(data, bsig_len)
+
+    if method and data.device != "cpu":
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
 
     if data.batch_size == 0:
         return result.data
 
     if data.device == "cpu":
         err_code = CPSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP[data.dtype](
-            data.sig_ptr[0], data.sig_ptr[1], result.data_ptr,
-            data.batch_size, aug_dimension, degree, n_jobs, planar, scalar_term)
+            data.data_ptr, derivs_data.data_ptr, result.data_ptr,
+            data.batch_size, aug_dimension, degree, method, n_jobs, planar, scalar_term)
     else:
         err_code = CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA[data.dtype](
-            data.sig_ptr[0], data.sig_ptr[1], result.data_ptr,
+            data.data_ptr, derivs_data.data_ptr, result.data_ptr,
             data.batch_size, aug_dimension, degree, planar, scalar_term)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_to_log_sig_backprop: " + err_msg(err_code))

--- a/pysiglib/jax_api/__init__.py
+++ b/pysiglib/jax_api/__init__.py
@@ -36,7 +36,7 @@ from ..trees import trees, trees_of_order, tree_to_idx, idx_to_tree
 from ..sig_coef import extract_sig_coef
 from ..log_sig import set_cache_dir, prepare_log_sig, clear_cache
 from ..branched_sig import prepare_branched_sig, branched_sig_length
-from ..branched_log_sig import prepare_branched_log_sig
+from ..branched_log_sig import branched_log_sig_length, prepare_branched_log_sig
 from ..branched_sig_coef import extract_branched_sig_coef, prepare_branched_sig_coef
 from ..load_siglib import SYSTEM, BUILT_WITH_CUDA, BUILT_WITH_AVX
 
@@ -98,7 +98,8 @@ __all__ = [
     "sig_score", "expected_sig_score", "sig_mmd",
     "branched_sig", "branched_sig_combine",
     "branched_sig_to_log_sig", "branched_log_sig",
-    "prepare_branched_sig", "prepare_branched_log_sig", "prepare_branched_sig_coef", "branched_sig_length",
+    "prepare_branched_sig", "prepare_branched_log_sig", "prepare_branched_sig_coef",
+    "branched_sig_length", "branched_log_sig_length",
     "sig_length", "log_sig_length",
     "words_of_length", "words", "lyndon_words_of_length", "lyndon_words",
     "is_lyndon", "word_to_idx", "idx_to_word",

--- a/pysiglib/jax_api/_ffi.py
+++ b/pysiglib/jax_api/_ffi.py
@@ -30,6 +30,7 @@ from ..load_siglib import (
 )
 from ..sig_length import sig_length, log_sig_length
 from ..branched_sig import branched_sig_length
+from ..branched_log_sig import branched_log_sig_length
 
 import jax
 
@@ -703,17 +704,26 @@ def branched_sig_combine_backprop_ffi_call(cotangent, bsig1, bsig2, dimension, m
 # branched_sig_to_log_sig
 # ---------------------------------------------------------------------------
 
-def branched_sig_to_log_sig_ffi_call(bsig, dimension, max_nodes, n_jobs, planar):
+def branched_sig_to_log_sig_ffi_call(
+        bsig, dimension, max_nodes, method, n_jobs, planar):
     _normalize_dtype(bsig.dtype)
-    out_type = jax.ShapeDtypeStruct(bsig.shape, bsig.dtype)
+    out_len = (
+        bsig.shape[-1]
+        if method == 0
+        else branched_log_sig_length(dimension, max_nodes, planar=planar)
+    )
+    out_type = jax.ShapeDtypeStruct((*bsig.shape[:-1], out_len), bsig.dtype)
     call_kwargs = dict(dimension=np.int64(dimension), max_nodes=np.int64(max_nodes),
-                       n_jobs=np.int64(n_jobs), planar=np.bool_(planar))
+                       method=np.int64(method), n_jobs=np.int64(n_jobs),
+                       planar=np.bool_(planar))
     return _make_ffi_call("branched_sig_to_log_sig", (bsig,), out_type, call_kwargs)
 
 
-def branched_sig_to_log_sig_backprop_ffi_call(bsig, cotangent, dimension, max_nodes, n_jobs, planar):
+def branched_sig_to_log_sig_backprop_ffi_call(
+        bsig, cotangent, dimension, max_nodes, method, n_jobs, planar):
     _check_same_dtype(bsig, cotangent)
     out_type = jax.ShapeDtypeStruct(bsig.shape, bsig.dtype)
     call_kwargs = dict(dimension=np.int64(dimension), max_nodes=np.int64(max_nodes),
-                       n_jobs=np.int64(n_jobs), planar=np.bool_(planar))
+                       method=np.int64(method), n_jobs=np.int64(n_jobs),
+                       planar=np.bool_(planar))
     return _make_ffi_call("branched_sig_to_log_sig_backprop", (bsig, cotangent), out_type, call_kwargs)

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import Optional
 
 import numpy as np
 
@@ -43,8 +44,11 @@ from ..branched_sig import branched_sig as branched_sig_forward
 from ..branched_sig import branched_sig_combine as branched_sig_combine_forward
 from ..branched_sig_coef import _branched_coef_data
 from ..branched_sig_coef import branched_sig_coef as branched_sig_coef_forward
-from ..branched_log_sig import branched_sig_to_log_sig as branched_sig_to_log_sig_forward
-from ..branched_log_sig import branched_log_sig as branched_log_sig_forward
+from ..branched_log_sig import (
+    _resolve_branched_log_sig_method,
+    branched_sig_to_log_sig as branched_sig_to_log_sig_forward,
+    branched_log_sig as branched_log_sig_forward,
+)
 from ..data_handlers import _infer_correction_degree
 from ..sig_coef import sig_coef as sig_coef_forward
 from ..sig_kernel import sig_kernel as sig_kernel_forward
@@ -1620,26 +1624,42 @@ branched_sig_combine.__doc__ = branched_sig_combine_forward.__doc__
 # branched_sig_to_log_sig
 # ---------------------------------------------------------------------------
 
-@partial(jax.custom_vjp, nondiff_argnums=(1, 2, 3, 4))
-def _branched_sig_to_log_sig(bsig, dimension, degree, n_jobs, planar):
-    return branched_sig_to_log_sig_ffi_call(bsig, dimension, degree, n_jobs, planar)
+@partial(jax.custom_vjp, nondiff_argnums=(1, 2, 3, 4, 5))
+def _branched_sig_to_log_sig(bsig, dimension, degree, method, n_jobs, planar):
+    return branched_sig_to_log_sig_ffi_call(
+        bsig, dimension, degree, method, n_jobs, planar)
 
 
-def _branched_sig_to_log_sig_fwd(bsig, dimension, degree, n_jobs, planar):
-    result = branched_sig_to_log_sig_ffi_call(bsig, dimension, degree, n_jobs, planar)
+def _branched_sig_to_log_sig_fwd(
+    bsig, dimension, degree, method, n_jobs, planar
+):
+    result = branched_sig_to_log_sig_ffi_call(
+        bsig, dimension, degree, method, n_jobs, planar)
     return result, (bsig,)
 
 
 def _branched_sig_to_log_sig_bwd(
-    dimension, degree, n_jobs, planar, residual, cotangent
+    dimension, degree, method, n_jobs, planar, residual, cotangent
 ):
     bsig, = residual
     grad = branched_sig_to_log_sig_backprop_ffi_call(
-        bsig, cotangent, dimension, degree, n_jobs, planar)
+        bsig, cotangent, dimension, degree, method, n_jobs, planar)
     return (grad,)
 
 
 _branched_sig_to_log_sig.defvjp(_branched_sig_to_log_sig_fwd, _branched_sig_to_log_sig_bwd)
+
+
+def _check_branched_log_sig_device(arr, method: int) -> None:
+    if method == 0 or isinstance(arr, jax.core.Tracer):
+        return
+    devices = getattr(arr, "devices", None)
+    if not callable(devices):
+        return
+    if any(device.platform in ("cuda", "gpu") for device in devices()):
+        raise NotImplementedError(
+            "MKW branched log signature methods 1 and 2 are only implemented on CPU."
+        )
 
 
 def branched_sig_to_log_sig(
@@ -1650,6 +1670,7 @@ def branched_sig_to_log_sig(
     time_aug: bool = False,
     lead_lag: bool = False,
     planar: bool = False,
+    method: Optional[int] = None,
     n_jobs: int = 1,
 ):
     ensure_registered()
@@ -1665,14 +1686,17 @@ def branched_sig_to_log_sig(
     check_type(lead_lag, "lead_lag", bool)
     check_type(planar, "planar", bool)
     check_n_jobs(n_jobs)
+    method = _resolve_branched_log_sig_method(method, planar)
+    _check_branched_log_sig_device(bsig, method)
 
     aug_dimension = _augmented_dim(dimension, time_aug, lead_lag)
     scalar_term = _infer_branched_scalar_term_jax(bsig, aug_dimension, degree, planar=planar)
     if not scalar_term:
         bsig = _prepend_scalar_one(bsig)
 
-    result = _branched_sig_to_log_sig(bsig, aug_dimension, degree, n_jobs, planar)
-    if not scalar_term:
+    result = _branched_sig_to_log_sig(
+        bsig, aug_dimension, degree, method, n_jobs, planar)
+    if method == 0 and not scalar_term:
         result = _strip_scalar(result)
     return result
 
@@ -1689,17 +1713,20 @@ def branched_log_sig(
     end_time: float = 1.0,
     planar: bool = False,
     scalar_term: bool = False,
+    method: Optional[int] = None,
     correction = None,
     n_jobs: int = 1,
 ):
     path = jnp.asarray(path)
+    method = _resolve_branched_log_sig_method(method, planar)
+    _check_branched_log_sig_device(path, method)
     bsig = branched_sig(
         path, degree, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time,
         planar=planar, scalar_term=scalar_term, correction=correction, n_jobs=n_jobs)
     dimension = path.shape[-1]
     return branched_sig_to_log_sig(
         bsig, dimension, degree, time_aug=time_aug, lead_lag=lead_lag,
-        planar=planar, n_jobs=n_jobs)
+        planar=planar, method=method, n_jobs=n_jobs)
 
 
 branched_log_sig.__doc__ = branched_log_sig_forward.__doc__

--- a/pysiglib/load_siglib.py
+++ b/pysiglib/load_siglib.py
@@ -581,11 +581,14 @@ if BUILT_WITH_CUDA:
 CPSIG.prepare_branched_sig.argtypes = (c_uint64, c_uint64, c_bool, c_bool)
 CPSIG.prepare_branched_sig.restype = c_int
 
-CPSIG.prepare_branched_log_sig.argtypes = (c_uint64, c_uint64, c_bool, c_bool)
+CPSIG.prepare_branched_log_sig.argtypes = (c_uint64, c_uint64, c_int, c_bool, c_bool)
 CPSIG.prepare_branched_log_sig.restype = c_int
 
 CPSIG.branched_sig_length.argtypes = (c_uint64, c_uint64, c_bool)
 CPSIG.branched_sig_length.restype = c_uint64
+
+CPSIG.branched_log_sig_length.argtypes = (c_uint64, c_uint64, c_bool)
+CPSIG.branched_log_sig_length.restype = c_uint64
 
 CPSIG.prepare_branched_sig_coef.argtypes = (POINTER(c_uint64), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool)
 CPSIG.prepare_branched_sig_coef.restype = c_int
@@ -638,16 +641,16 @@ CPSIG.branched_sig_combine_f.restype = c_int
 CPSIG.branched_sig_combine_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
 CPSIG.branched_sig_combine_d.restype = c_int
 
-CPSIG.branched_sig_to_log_sig_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
+CPSIG.branched_sig_to_log_sig_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_int, c_bool, c_bool)
 CPSIG.branched_sig_to_log_sig_f.restype = c_int
 
-CPSIG.branched_sig_to_log_sig_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
+CPSIG.branched_sig_to_log_sig_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_int, c_bool, c_bool)
 CPSIG.branched_sig_to_log_sig_d.restype = c_int
 
-CPSIG.branched_sig_to_log_sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
+CPSIG.branched_sig_to_log_sig_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_int, c_bool, c_bool)
 CPSIG.branched_sig_to_log_sig_backprop_f.restype = c_int
 
-CPSIG.branched_sig_to_log_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
+CPSIG.branched_sig_to_log_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_int, c_bool, c_bool)
 CPSIG.branched_sig_to_log_sig_backprop_d.restype = c_int
 
 CPSIG.branched_sig_combine_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)

--- a/pysiglib/torch_api/__init__.py
+++ b/pysiglib/torch_api/__init__.py
@@ -22,7 +22,7 @@ from ..sig_coef import extract_sig_coef
 from ..branched_sig_coef import extract_branched_sig_coef
 from ..log_sig import set_cache_dir, prepare_log_sig, clear_cache
 from ..static_kernels import Context, StaticKernel, LinearKernel, ScaledLinearKernel, RBFKernel, PolynomialKernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, RationalQuadraticKernel
-from .torch_api import sig, sig_combine, sig_coef, branched_sig_coef, prepare_branched_sig_coef, transform_path, sig_to_log_sig, log_sig, log_sig_combine, logsig_to_sig, sig_kernel, sig_kernel_gram, branched_sig_kernel, branched_sig_kernel_gram, sig_score, expected_sig_score, sig_mmd, branched_sig, prepare_branched_sig, branched_sig_length, branched_sig_combine, prepare_branched_log_sig, branched_sig_to_log_sig, branched_log_sig, linear_sig, sig_join, log_sig_join
+from .torch_api import sig, sig_combine, sig_coef, branched_sig_coef, prepare_branched_sig_coef, transform_path, sig_to_log_sig, log_sig, log_sig_combine, logsig_to_sig, sig_kernel, sig_kernel_gram, branched_sig_kernel, branched_sig_kernel_gram, sig_score, expected_sig_score, sig_mmd, branched_sig, prepare_branched_sig, branched_sig_length, branched_sig_combine, prepare_branched_log_sig, branched_sig_to_log_sig, branched_log_sig, branched_log_sig_length, linear_sig, sig_join, log_sig_join
 
 from ..streams import (
     SigStream as _SigStream,

--- a/pysiglib/torch_api/torch_api.py
+++ b/pysiglib/torch_api/torch_api.py
@@ -779,8 +779,13 @@ from ..branched_sig import branched_sig as branched_sig_forward, prepare_branche
 from ..branched_sig_backprop import branched_sig_backprop, branched_sig_combine_backprop
 from ..branched_sig_coef import branched_sig_coef as branched_sig_coef_forward, prepare_branched_sig_coef
 from ..branched_sig_coef_backprop import branched_sig_coef_backprop
-from ..branched_log_sig import prepare_branched_log_sig, branched_sig_to_log_sig as branched_sig_to_log_sig_forward
-from ..branched_log_sig import branched_log_sig as branched_log_sig_forward
+from ..branched_log_sig import (
+    _resolve_branched_log_sig_method,
+    branched_log_sig as branched_log_sig_forward,
+    branched_log_sig_length,
+    branched_sig_to_log_sig as branched_sig_to_log_sig_forward,
+    prepare_branched_log_sig,
+)
 from ..branched_log_sig_backprop import branched_sig_to_log_sig_backprop
 
 class BranchedSigCoef(torch.autograd.Function):
@@ -910,16 +915,17 @@ branched_sig_combine.__doc__ = branched_sig_combine_forward.__doc__
 
 class BranchedSigToLogSig(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, bsig, dimension, degree, time_aug, lead_lag, planar, n_jobs):
+    def forward(ctx, bsig, dimension, degree, time_aug, lead_lag, planar, method, n_jobs):
         blogsig = branched_sig_to_log_sig_forward(
             bsig, dimension, degree, time_aug=time_aug, lead_lag=lead_lag,
-            planar=planar, n_jobs=n_jobs)
+            planar=planar, method=method, n_jobs=n_jobs)
         ctx.save_for_backward(bsig)
         ctx.dimension = dimension
         ctx.degree = degree
         ctx.time_aug = time_aug
         ctx.lead_lag = lead_lag
         ctx.planar = planar
+        ctx.method = method
         ctx.n_jobs = n_jobs
         return blogsig
 
@@ -929,8 +935,8 @@ class BranchedSigToLogSig(torch.autograd.Function):
         grad = branched_sig_to_log_sig_backprop(
             bsig, grad_output, ctx.dimension, ctx.degree,
             time_aug=ctx.time_aug, lead_lag=ctx.lead_lag,
-            planar=ctx.planar, n_jobs=ctx.n_jobs)
-        return grad, None, None, None, None, None, None
+            planar=ctx.planar, method=ctx.method, n_jobs=ctx.n_jobs)
+        return grad, None, None, None, None, None, None, None
 
 
 def branched_sig_to_log_sig(
@@ -941,10 +947,12 @@ def branched_sig_to_log_sig(
         time_aug: bool = False,
         lead_lag: bool = False,
         planar: bool = False,
+        method: Optional[int] = None,
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
+    method = _resolve_branched_log_sig_method(method, planar)
     return BranchedSigToLogSig.apply(
-        bsig, dimension, degree, time_aug, lead_lag, planar, n_jobs)
+        bsig, dimension, degree, time_aug, lead_lag, planar, method, n_jobs)
 
 
 branched_sig_to_log_sig.__doc__ = branched_sig_to_log_sig_forward.__doc__
@@ -959,16 +967,21 @@ def branched_log_sig(
         end_time: float = 1.0,
         planar: bool = False,
         scalar_term: bool = False,
+        method: Optional[int] = None,
         correction = None,
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
+    method = _resolve_branched_log_sig_method(method, planar)
+    if method and isinstance(path, torch.Tensor) and path.device.type != "cpu":
+        raise NotImplementedError(
+            "Compressed MKW branched log signatures are only supported on CPU")
     bsig = branched_sig(
         path, degree, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time,
         planar=planar, scalar_term=scalar_term, correction=correction, n_jobs=n_jobs)
     dimension = path.shape[-1]
     return branched_sig_to_log_sig(
         bsig, dimension, degree, time_aug=time_aug, lead_lag=lead_lag,
-        planar=planar, n_jobs=n_jobs)
+        planar=planar, method=method, n_jobs=n_jobs)
 
 
 branched_log_sig.__doc__ = branched_log_sig_forward.__doc__

--- a/siglib/cpsig/cp_branched_cache.cpp
+++ b/siglib/cpsig/cp_branched_cache.cpp
@@ -82,6 +82,8 @@ static void write_branched_cache(const BranchedSigCache& c) {
 	serialize_vector(out, c.chain_indices);
 	serialize_vector(out, c.coproduct_data);
 	serialize_vector(out, c.coproduct_offsets);
+	serialize_vector(out, c.basis_forest_data);
+	serialize_vector(out, c.basis_forest_offsets);
 }
 
 static bool read_branched_cache(uint64_t dimension, uint64_t max_nodes, bool planar, BranchedSigCache& c) {
@@ -133,6 +135,44 @@ static bool read_branched_cache(uint64_t dimension, uint64_t max_nodes, bool pla
 	deserialize_vector(in, tmp.coproduct_offsets);
 
 	if (!in.good()) return false;
+	if (in.peek() != std::char_traits<char>::eof()) {
+		deserialize_vector(in, tmp.basis_forest_data);
+		deserialize_vector(in, tmp.basis_forest_offsets);
+		if (!in.good()) return false;
+	}
+
+	if (planar && tmp.basis_forest_offsets.empty()) {
+		std::vector<DecoratedTreeInfo> trees;
+		std::vector<uint64_t> tree_order_index;
+		enumerate_all_decorated_trees(
+			dimension, max_nodes, trees, tree_order_index, true);
+		std::vector<std::vector<uint64_t>> forests;
+		std::vector<uint64_t> forest_order_index;
+		enumerate_ordered_forest_basis_(
+			trees, max_nodes, forests, forest_order_index);
+		if (forests.size() + 1 != tmp.total_length
+			|| forest_order_index != tmp.order_index)
+			return false;
+		tmp.basis_forest_offsets.resize(tmp.total_length);
+		for (uint64_t i = 0; i < forests.size(); ++i) {
+			tmp.basis_forest_offsets[i] = tmp.basis_forest_data.size();
+			tmp.basis_forest_data.insert(
+				tmp.basis_forest_data.end(), forests[i].begin(), forests[i].end());
+		}
+		tmp.basis_forest_offsets[forests.size()] = tmp.basis_forest_data.size();
+	}
+	if (planar) {
+		if (tmp.basis_forest_offsets.size() != tmp.total_length
+			|| tmp.basis_forest_offsets.empty()
+			|| tmp.basis_forest_offsets.front() != 0
+			|| tmp.basis_forest_offsets.back() != tmp.basis_forest_data.size())
+			return false;
+		for (uint64_t i = 1; i < tmp.basis_forest_offsets.size(); ++i) {
+			if (tmp.basis_forest_offsets[i] < tmp.basis_forest_offsets[i - 1]
+				|| tmp.basis_forest_offsets[i] > tmp.basis_forest_data.size())
+				return false;
+		}
+	}
 
 	c = std::move(tmp);
 	return true;

--- a/siglib/cpsig/cp_branched_log_signature.cpp
+++ b/siglib/cpsig/cp_branched_log_signature.cpp
@@ -17,11 +17,179 @@
 #include "cpsig.h"
 #include "cp_branched_log_signature.h"
 #include "cp_branched_cache.h"
+#include "log_sig_cache.h"
+#include "words.h"
 #include "../shared/branched_log_cache.h"
 #include "multithreading.h"
 #include "macros.h"
 
 namespace {
+constexpr const char* mkw_basis_cache_prefix_ = "mkw_lyndon_";
+
+struct BranchedLogBasisCacheRegistry_ {
+	std::unordered_map<
+		std::pair<uint64_t, uint64_t>,
+		std::unique_ptr<BasisCache>,
+		PairHash
+	> map;
+	std::shared_mutex mu;
+};
+
+BranchedLogBasisCacheRegistry_& branched_log_basis_cache_registry_() {
+	static BranchedLogBasisCacheRegistry_ registry;
+	return registry;
+}
+
+void clear_branched_log_basis_cache_() {
+	auto& registry = branched_log_basis_cache_registry_();
+	std::unique_lock lock(registry.mu);
+	registry.map.clear();
+}
+
+std::unique_ptr<BasisCache> build_branched_log_basis_cache_(
+	const BranchedSigCache& cache,
+	int method
+) {
+	if (!cache.planar)
+		throw std::invalid_argument("compressed branched log signatures require planar=True");
+
+	std::vector<word> lyndon_words;
+	std::vector<uint64_t> lyndon_idx;
+	std::vector<word> flat_words;
+	const uint64_t lyndon_count = compute_branched_log_sig_length(
+		cache.dimension, cache.max_nodes, true);
+	lyndon_idx.reserve(lyndon_count);
+	if (method == 2) {
+		lyndon_words.reserve(lyndon_count);
+		flat_words.resize(cache.total_length);
+	}
+	for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+		const uint64_t start = cache.basis_forest_offsets[basis_idx];
+		const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
+		word forest(
+			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
+			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
+		if (method == 2)
+			flat_words[basis_idx + 1] = forest;
+		if (is_lyndon(forest)) {
+			if (method == 2)
+				lyndon_words.push_back(forest);
+			lyndon_idx.push_back(basis_idx + 1);
+		}
+	}
+
+	if (lyndon_idx.size() != lyndon_count)
+		throw std::runtime_error("MKW Lyndon cache length mismatch");
+
+	SparseIntMatrix projection;
+	SparseIntMatrix inverse;
+	SparseIntMatrix inverse_transpose;
+	if (method == 2) {
+		std::unordered_map<word, uint64_t, WordHash> flat_idx;
+		flat_idx.reserve(flat_words.size());
+		for (uint64_t i = 0; i < flat_words.size(); ++i)
+			flat_idx[flat_words[i]] = i;
+		lyndon_proj_matrix_from_words(
+			projection,
+			lyndon_words,
+			cache.total_length,
+			[&flat_idx](const word& w) {
+				return flat_idx.at(w);
+			},
+			[&flat_words, &flat_idx](uint64_t i, uint64_t j, uint64_t) {
+				return flat_idx.at(concatenate_words(flat_words.at(i), flat_words.at(j)));
+			});
+		projection.inverse(inverse);
+		inverse.transpose(inverse_transpose);
+	}
+
+	return std::make_unique<BasisCache>(
+		method,
+		std::move(lyndon_idx),
+		std::move(inverse),
+		std::move(inverse_transpose));
+}
+
+void prepare_branched_log_basis_cache_(
+	const BranchedSigCache& cache,
+	int method,
+	bool use_disk
+) {
+	if (method < 1)
+		return;
+	if (method == 3)
+		throw std::invalid_argument("branched log signature method 3 is not implemented");
+	if (method > 2)
+		throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+
+	const std::pair<uint64_t, uint64_t> key(cache.dimension, cache.max_nodes);
+	auto& registry = branched_log_basis_cache_registry_();
+	{
+		std::shared_lock lock(registry.mu);
+		auto it = registry.map.find(key);
+		if (it != registry.map.end() && it->second->method >= method)
+			return;
+	}
+
+	std::unique_ptr<CacheFile> file;
+	if (use_disk) {
+		auto dir = get_cache_dir();
+		if (!std::filesystem::exists(dir / cache_folder_name))
+			std::filesystem::create_directory(dir / cache_folder_name);
+		file = std::make_unique<CacheFile>(
+			cache.dimension, cache.max_nodes, mkw_basis_cache_prefix_);
+	}
+	if (file && file->exists()) {
+		auto basis = std::make_unique<BasisCache>();
+		file->read(basis);
+		if (basis->method >= method) {
+			std::unique_lock lock(registry.mu);
+			registry.map.insert_or_assign(key, std::move(basis));
+			return;
+		}
+	}
+
+	auto basis = build_branched_log_basis_cache_(cache, method);
+	if (file)
+		file->write(basis);
+
+	std::unique_lock lock(registry.mu);
+	registry.map.insert_or_assign(key, std::move(basis));
+}
+
+const BasisCache& get_branched_log_basis_cache_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method
+) {
+	const std::pair<uint64_t, uint64_t> key(dimension, max_nodes);
+	auto& registry = branched_log_basis_cache_registry_();
+	{
+		std::shared_lock lock(registry.mu);
+		auto it = registry.map.find(key);
+		if (it != registry.map.end() && it->second->method >= method)
+			return *(it->second);
+	}
+
+	auto dir = get_cache_dir();
+	if (!std::filesystem::exists(dir / cache_folder_name))
+		throw cache_not_found_error(
+			"MKW branched log basis cache not found - call prepare_branched_log_sig first");
+	CacheFile file(dimension, max_nodes, mkw_basis_cache_prefix_);
+	if (!file.exists())
+		throw cache_not_found_error(
+			"MKW branched log basis cache not found - call prepare_branched_log_sig first");
+	auto basis = std::make_unique<BasisCache>();
+	file.read(basis);
+	if (basis->method < method)
+		throw cache_not_found_error(
+			"MKW branched log basis cache does not support the requested method");
+
+	std::unique_lock lock(registry.mu);
+	auto inserted = registry.map.insert_or_assign(key, std::move(basis));
+	return *(inserted.first->second);
+}
+
 std::unordered_map<
 	std::pair<uint64_t, uint64_t>,
 	std::unique_ptr<BranchedLogForestCache>,
@@ -578,6 +746,100 @@ void branched_sig_to_log_sig_backprop_(
 	}
 	spawn_batch_threads(batch_size, n_jobs, work_range);
 }
+
+
+template<std::floating_point T, bool ScalarTerm>
+void branched_sig_to_log_sig_compressed_(
+	const T* bsig,
+	T* out,
+	uint64_t batch_size,
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method,
+	int n_jobs
+) {
+	const auto& cache = get_branched_sig_cache(dimension, max_nodes, true);
+	const uint64_t input_stride = ScalarTerm
+		? cache.total_length
+		: cache.total_length - 1;
+	const auto& forest_cache = get_cached_branched_log_forest_cache(cache);
+	const auto& poly_cache = get_cached_branched_log_poly_cache_(cache, forest_cache);
+	const auto& basis_cache = get_branched_log_basis_cache_(dimension, max_nodes, method);
+	const uint64_t output_stride = basis_cache.lyndon_idx.size();
+	if (output_stride == 0)
+		return;
+
+	auto work_range = [&](uint64_t start, uint64_t end) {
+		std::vector<T> expanded(input_stride);
+		for (uint64_t row = start; row < end; ++row) {
+			const T* bsig_row = bsig + row * input_stride;
+			branched_sig_to_log_sig_poly_range_<T, ScalarTerm>(
+				bsig_row, expanded.data(), 0, 1, input_stride, poly_cache);
+			T* out_row = out + row * output_stride;
+			for (uint64_t i = 0; i < output_stride; ++i) {
+				const uint64_t flat_idx = basis_cache.lyndon_idx[i];
+				out_row[i] = expanded[ScalarTerm ? flat_idx : flat_idx - 1];
+			}
+			if (method == 2)
+				basis_cache.inv_proj_mat.mul_vec_inplace_lower(out_row);
+		}
+	};
+	if (batch_size == 0 || n_jobs == 1 || batch_size == 1) {
+		work_range(0, batch_size);
+		return;
+	}
+	spawn_batch_threads(batch_size, n_jobs, work_range);
+}
+
+
+template<std::floating_point T, bool ScalarTerm>
+void branched_sig_to_log_sig_backprop_compressed_(
+	const T* bsig,
+	const T* derivs,
+	T* out,
+	uint64_t batch_size,
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method,
+	int n_jobs
+) {
+	const auto& cache = get_branched_sig_cache(dimension, max_nodes, true);
+	const uint64_t input_stride = ScalarTerm
+		? cache.total_length
+		: cache.total_length - 1;
+	const auto& forest_cache = get_cached_branched_log_forest_cache(cache);
+	const auto& poly_cache = get_cached_branched_log_poly_cache_(cache, forest_cache);
+	const auto& basis_cache = get_branched_log_basis_cache_(dimension, max_nodes, method);
+	const uint64_t deriv_stride = basis_cache.lyndon_idx.size();
+	if (input_stride == 0)
+		return;
+
+	auto work_range = [&](uint64_t start, uint64_t end) {
+		std::vector<T> compact(deriv_stride);
+		std::vector<T> expanded_derivs(input_stride);
+		for (uint64_t row = start; row < end; ++row) {
+			if (deriv_stride != 0)
+				std::copy_n(derivs + row * deriv_stride, deriv_stride, compact.begin());
+			if (method == 2)
+				basis_cache.inv_proj_mat_transpose.mul_vec_inplace_upper(compact.data());
+			std::fill(expanded_derivs.begin(), expanded_derivs.end(), static_cast<T>(0));
+			for (uint64_t i = 0; i < deriv_stride; ++i) {
+				const uint64_t flat_idx = basis_cache.lyndon_idx[i];
+				expanded_derivs[ScalarTerm ? flat_idx : flat_idx - 1] = compact[i];
+			}
+			branched_sig_to_log_sig_backprop_poly_range_<T, ScalarTerm>(
+				bsig + row * input_stride,
+				expanded_derivs.data(),
+				out + row * input_stride,
+				0, 1, input_stride, poly_cache);
+		}
+	};
+	if (batch_size == 0 || n_jobs == 1 || batch_size == 1) {
+		work_range(0, batch_size);
+		return;
+	}
+	spawn_batch_threads(batch_size, n_jobs, work_range);
+}
 }  // namespace
 
 
@@ -617,6 +879,7 @@ void prepare_branched_log_sig_cache(const BranchedSigCache& cache) {
 
 
 void clear_branched_log_sig_cache() {
+	clear_branched_log_basis_cache_();
 	{
 		std::unique_lock lock(branched_log_forest_cache_mu_);
 		branched_log_forest_cache_registry_.clear();
@@ -633,14 +896,31 @@ void branched_sig_to_log_sig_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	int n_jobs,
 	bool planar,
 	bool scalar_term
 ) {
-	if (scalar_term) {
-		branched_sig_to_log_sig_<T, true>(bsig, out, batch_size, dimension, max_nodes, n_jobs, planar);
+	if (method == 3)
+		throw std::invalid_argument("branched log signature method 3 is not implemented");
+	if (method < 0 || method > 2)
+		throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+	if (method != 0 && !planar)
+		throw std::invalid_argument("compressed branched log signatures require planar=True");
+	if (method == 0) {
+		if (scalar_term) {
+			branched_sig_to_log_sig_<T, true>(
+				bsig, out, batch_size, dimension, max_nodes, n_jobs, planar);
+		} else {
+			branched_sig_to_log_sig_<T, false>(
+				bsig, out, batch_size, dimension, max_nodes, n_jobs, planar);
+		}
+	} else if (scalar_term) {
+		branched_sig_to_log_sig_compressed_<T, true>(
+			bsig, out, batch_size, dimension, max_nodes, method, n_jobs);
 	} else {
-		branched_sig_to_log_sig_<T, false>(bsig, out, batch_size, dimension, max_nodes, n_jobs, planar);
+		branched_sig_to_log_sig_compressed_<T, false>(
+			bsig, out, batch_size, dimension, max_nodes, method, n_jobs);
 	}
 }
 
@@ -653,14 +933,31 @@ void branched_sig_to_log_sig_backprop_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	int n_jobs,
 	bool planar,
 	bool scalar_term
 ) {
-	if (scalar_term) {
-		branched_sig_to_log_sig_backprop_<T, true>(bsig, derivs, out, batch_size, dimension, max_nodes, n_jobs, planar);
+	if (method == 3)
+		throw std::invalid_argument("branched log signature method 3 is not implemented");
+	if (method < 0 || method > 2)
+		throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+	if (method != 0 && !planar)
+		throw std::invalid_argument("compressed branched log signatures require planar=True");
+	if (method == 0) {
+		if (scalar_term) {
+			branched_sig_to_log_sig_backprop_<T, true>(
+				bsig, derivs, out, batch_size, dimension, max_nodes, n_jobs, planar);
+		} else {
+			branched_sig_to_log_sig_backprop_<T, false>(
+				bsig, derivs, out, batch_size, dimension, max_nodes, n_jobs, planar);
+		}
+	} else if (scalar_term) {
+		branched_sig_to_log_sig_backprop_compressed_<T, true>(
+			bsig, derivs, out, batch_size, dimension, max_nodes, method, n_jobs);
 	} else {
-		branched_sig_to_log_sig_backprop_<T, false>(bsig, derivs, out, batch_size, dimension, max_nodes, n_jobs, planar);
+		branched_sig_to_log_sig_backprop_compressed_<T, false>(
+			bsig, derivs, out, batch_size, dimension, max_nodes, method, n_jobs);
 	}
 }
 
@@ -669,29 +966,36 @@ void branched_sig_to_log_sig_backprop_(
 extern "C" {
 
 	CPSIG_API int prepare_branched_log_sig(
-		uint64_t dimension, uint64_t max_nodes, bool use_disk, bool planar
+		uint64_t dimension, uint64_t max_nodes, int method, bool use_disk, bool planar
 	) noexcept {
 		SAFE_CALL(
+			if (method == 3)
+				throw std::invalid_argument("branched log signature method 3 is not implemented");
+			if (method < 0 || method > 2)
+				throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+			if (method != 0 && !planar)
+				throw std::invalid_argument("compressed branched log signatures require planar=True");
 			prepare_branched_sig_cache(dimension, max_nodes, use_disk, planar);
-			prepare_branched_log_sig_cache(
-				get_branched_sig_cache(dimension, max_nodes, planar))
+			const auto& cache = get_branched_sig_cache(dimension, max_nodes, planar);
+			prepare_branched_log_sig_cache(cache);
+			prepare_branched_log_basis_cache_(cache, method, use_disk)
 		);
 	}
 
-	CPSIG_API int branched_sig_to_log_sig_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar, bool scalar_term) noexcept {
-		SAFE_CALL(branched_sig_to_log_sig_<float>(bsig, out, batch_size, dimension, max_nodes, n_jobs, planar, scalar_term));
+	CPSIG_API int branched_sig_to_log_sig_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, int n_jobs, bool planar, bool scalar_term) noexcept {
+		SAFE_CALL(branched_sig_to_log_sig_<float>(bsig, out, batch_size, dimension, max_nodes, method, n_jobs, planar, scalar_term));
 	}
 
-	CPSIG_API int branched_sig_to_log_sig_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar, bool scalar_term) noexcept {
-		SAFE_CALL(branched_sig_to_log_sig_<double>(bsig, out, batch_size, dimension, max_nodes, n_jobs, planar, scalar_term));
+	CPSIG_API int branched_sig_to_log_sig_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, int n_jobs, bool planar, bool scalar_term) noexcept {
+		SAFE_CALL(branched_sig_to_log_sig_<double>(bsig, out, batch_size, dimension, max_nodes, method, n_jobs, planar, scalar_term));
 	}
 
-	CPSIG_API int branched_sig_to_log_sig_backprop_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar, bool scalar_term) noexcept {
-		SAFE_CALL(branched_sig_to_log_sig_backprop_<float>(bsig, derivs, out, batch_size, dimension, max_nodes, n_jobs, planar, scalar_term));
+	CPSIG_API int branched_sig_to_log_sig_backprop_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, int n_jobs, bool planar, bool scalar_term) noexcept {
+		SAFE_CALL(branched_sig_to_log_sig_backprop_<float>(bsig, derivs, out, batch_size, dimension, max_nodes, method, n_jobs, planar, scalar_term));
 	}
 
-	CPSIG_API int branched_sig_to_log_sig_backprop_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs, bool planar, bool scalar_term) noexcept {
-		SAFE_CALL(branched_sig_to_log_sig_backprop_<double>(bsig, derivs, out, batch_size, dimension, max_nodes, n_jobs, planar, scalar_term));
+	CPSIG_API int branched_sig_to_log_sig_backprop_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, int n_jobs, bool planar, bool scalar_term) noexcept {
+		SAFE_CALL(branched_sig_to_log_sig_backprop_<double>(bsig, derivs, out, batch_size, dimension, max_nodes, method, n_jobs, planar, scalar_term));
 	}
 
 }

--- a/siglib/cpsig/cp_branched_log_signature.h
+++ b/siglib/cpsig/cp_branched_log_signature.h
@@ -29,6 +29,7 @@ void branched_sig_to_log_sig_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	int n_jobs,
 	bool planar = false,
 	bool scalar_term = true
@@ -43,6 +44,7 @@ void branched_sig_to_log_sig_backprop_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	int n_jobs,
 	bool planar = false,
 	bool scalar_term = true

--- a/siglib/cpsig/cp_utils.cpp
+++ b/siglib/cpsig/cp_utils.cpp
@@ -140,10 +140,23 @@ uint64_t branched_sig_length_(uint64_t dimension, uint64_t max_nodes, bool plana
     return compute_branched_sig_length(dimension, max_nodes, planar);
 }
 
+uint64_t branched_log_sig_length_(uint64_t dimension, uint64_t max_nodes, bool planar) {
+    return compute_branched_log_sig_length(dimension, max_nodes, planar);
+}
+
 extern "C" {
     CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
         try {
             return branched_sig_length_(dimension, max_nodes, planar);
+        }
+        catch (...) {
+            return 0;
+        }
+    }
+
+    CPSIG_API uint64_t branched_log_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar) noexcept {
+        try {
+            return branched_log_sig_length_(dimension, max_nodes, planar);
         }
         catch (...) {
             return 0;

--- a/siglib/cpsig/cp_utils.h
+++ b/siglib/cpsig/cp_utils.h
@@ -25,3 +25,4 @@ void populate_level_index(uint64_t* level_index, uint64_t dimension, uint64_t de
 
 // Length of a branched signature vector (1 + basis size up to max_nodes).
 uint64_t branched_sig_length_(uint64_t dimension, uint64_t max_nodes, bool planar = false);
+uint64_t branched_log_sig_length_(uint64_t dimension, uint64_t max_nodes, bool planar = false);

--- a/siglib/cpsig/cpsig.h
+++ b/siglib/cpsig/cpsig.h
@@ -601,6 +601,7 @@ extern "C" {
 	/** @brief Prepares the branched-signature cache. */
 	[[nodiscard]] CPSIG_API int prepare_branched_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk = false, bool planar = false) noexcept;
 	CPSIG_API uint64_t branched_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
+	CPSIG_API uint64_t branched_log_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar = false) noexcept;
 
 	[[nodiscard]] CPSIG_API int branched_sig_f(const float* path, float* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, float end_time = 1.f, bool planar = false, bool scalar_term = true, const float* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
 	[[nodiscard]] CPSIG_API int branched_sig_d(const double* path, double* out, uint64_t batch_size, uint64_t dimension, uint64_t length, uint64_t max_nodes, int n_jobs = 1, bool time_aug = false, bool lead_lag = false, double end_time = 1., bool planar = false, bool scalar_term = true, const double* correction = nullptr, uint64_t correction_len = 0, uint64_t correction_batch_stride = 0, uint64_t correction_segment_stride = 0) noexcept;
@@ -701,7 +702,7 @@ extern "C" {
 	* @{
 	*/
 	/** @brief Prepares the branched-signature and derived branched-log caches. */
-	[[nodiscard]] CPSIG_API int prepare_branched_log_sig(uint64_t dimension, uint64_t max_nodes, bool use_disk = false, bool planar = false) noexcept;
+	[[nodiscard]] CPSIG_API int prepare_branched_log_sig(uint64_t dimension, uint64_t max_nodes, int method, bool use_disk = false, bool planar = false) noexcept;
 
 	[[nodiscard]] CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CPSIG_API int branched_sig_combine_d(const double* bsig1, const double* bsig2, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
@@ -709,12 +710,13 @@ extern "C" {
 	/**
 	* @brief Computes the truncated Hopf logarithm of a branched signature.
 	*
-	* The input and output use the same decorated-tree basis and the same scalar-term
-	* convention. If scalar_term is true, the output scalar coefficient is zero.
+	* Method 0 returns the expanded decorated-tree or ordered-forest basis and
+	* preserves the scalar-term convention. Methods 1 and 2 return scalar-free
+	* compressed MKW coordinates and require planar=true.
 	*/
-	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	/** @brief */
-	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 
 	/**
 	* @brief Backpropagation through branched_sig_to_log_sig.
@@ -722,9 +724,9 @@ extern "C" {
 	* Computes the vector-Jacobian product from derivatives with respect to the
 	* branched log signature to derivatives with respect to the branched signature.
 	*/
-	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_backprop_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_backprop_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	/** @brief */
-	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_backprop_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_backprop_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 
 	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;

--- a/siglib/cpsig/log_sig_cache.h
+++ b/siglib/cpsig/log_sig_cache.h
@@ -59,14 +59,14 @@ extern const char* version;
 class CacheFile {
 public:
 
-	CacheFile(uint64_t dimension_, uint64_t degree_) {
+	CacheFile(uint64_t dimension_, uint64_t degree_, std::string prefix = "") {
 		auto dir = get_cache_dir();
 		if (dir.empty() || !std::filesystem::exists(dir / cache_folder_name))
 			throw cache_dir_not_set_error("Unexpected internal error. Cache directory was not set correctly.");
 
 		dimension = dimension_;
 		degree = degree_;
-		file_name = std::to_string(dimension) + "_" + std::to_string(degree) + "_" + version + ".bin";
+		file_name = prefix + std::to_string(dimension) + "_" + std::to_string(degree) + "_" + version + ".bin";
 		file_path = dir / cache_folder_name / file_name;
 	}
 

--- a/siglib/cpsig/words.cpp
+++ b/siglib/cpsig/words.cpp
@@ -133,51 +133,77 @@ void lyndon_proj_matrix(
 	uint64_t dimension,
 	uint64_t degree
 ) {
-	// Note the final output here will drop the diagonal of 1s
-
-	std::unordered_set<word, WordHash> lyndon_set(lyndon_words.begin(), lyndon_words.end());
-	uint64_t n = sig_length(dimension, degree);
+	const uint64_t n = sig_length(dimension, degree);
 	if (n == 0)
 		throw std::overflow_error("lyndon_proj_matrix: sig_length overflow");
-	uint64_t m = lyndon_words.size();
+	if (lyndon_idx.size() != lyndon_words.size())
+		throw std::invalid_argument("lyndon_proj_matrix: index count mismatch");
 
-	auto level_index_uptr = std::make_unique<uint64_t[]>(degree + 2);
-	uint64_t* level_index = level_index_uptr.get();
-	populate_level_index(level_index, dimension, degree + 2);
+	std::unordered_map<word, uint64_t, WordHash> flat_idx;
+	flat_idx.reserve(lyndon_words.size());
+	for (uint64_t i = 0; i < lyndon_words.size(); ++i)
+		flat_idx[lyndon_words[i]] = lyndon_idx[i];
 
-	SparseIntMatrix full_mat_transpose(m, n);
+	lyndon_proj_matrix_from_words(
+		out,
+		lyndon_words,
+		n,
+		[&flat_idx](const word& w) {
+			return flat_idx.at(w);
+		},
+		[dimension](uint64_t i, uint64_t j, uint64_t len_j) {
+			return concatenate_idx(i, j, len_j, dimension);
+		});
+}
 
+void lyndon_proj_matrix_from_words(
+	SparseIntMatrix& out,
+	const std::vector<word>& lyndon_words,
+	uint64_t flat_word_count,
+	const std::function<uint64_t(const word&)>& word_to_flat_idx,
+	const std::function<uint64_t(uint64_t, uint64_t, uint64_t)>& concatenate_flat_idx
+) {
+	std::unordered_set<word, WordHash> lyndon_set(lyndon_words.begin(), lyndon_words.end());
+	const uint64_t m = lyndon_words.size();
+	SparseIntMatrix full_mat_transpose(m, flat_word_count);
 	std::unordered_map<word, uint64_t, WordHash> col_idx;
+	col_idx.reserve(m);
 
-	for (uint64_t i = 0; i < m; ++i) {
+	for (uint64_t i = 0; i < m; ++i)
 		col_idx[lyndon_words[i]] = i;
-	}
 
 	for (uint64_t i = 0; i < m; ++i) {
 		const word& w = lyndon_words[i];
 
 		if (w.size() == 1) {
-			full_mat_transpose.insert_entry(i, w[0] + 1, 1);
+			const uint64_t flat_idx = word_to_flat_idx(w);
+			if (flat_idx >= flat_word_count)
+				throw std::out_of_range("lyndon projection word index out of range");
+			full_mat_transpose.insert_entry(i, flat_idx, 1);
 		}
 		else {
 			word v = longest_lyndon_suffix_(w, lyndon_set);
 			word u(w.begin(), w.end() - v.size());
 
-			uint64_t jw = col_idx[w];
-			uint64_t jv = col_idx[v];
-			uint64_t ju = col_idx[u];
+			const uint64_t jw = col_idx.at(w);
+			const uint64_t jv = col_idx.at(v);
+			const uint64_t ju = col_idx.at(u);
 
 			for (const auto& eu : full_mat_transpose.rows[ju]) {
-				if (eu.val) {
-					for (const auto& ev : full_mat_transpose.rows[jv]) {
-						if (ev.val) {
-							uint64_t ic = concatenate_idx(eu.col, ev.col, v.size(), dimension);
-							int val = eu.val * ev.val;
-							full_mat_transpose.add_to_entry(jw, ic, val);
-							ic = concatenate_idx(ev.col, eu.col, u.size(), dimension);
-							full_mat_transpose.add_to_entry(jw, ic, -val);
-						}
-					}
+				if (eu.val == 0)
+					continue;
+				for (const auto& ev : full_mat_transpose.rows[jv]) {
+					if (ev.val == 0)
+					continue;
+					uint64_t flat_idx = concatenate_flat_idx(eu.col, ev.col, v.size());
+					if (flat_idx >= flat_word_count)
+						throw std::out_of_range("lyndon projection concatenation index out of range");
+					const int coeff = eu.val * ev.val;
+					full_mat_transpose.add_to_entry(jw, flat_idx, coeff);
+					flat_idx = concatenate_flat_idx(ev.col, eu.col, u.size());
+					if (flat_idx >= flat_word_count)
+						throw std::out_of_range("lyndon projection concatenation index out of range");
+					full_mat_transpose.add_to_entry(jw, flat_idx, -coeff);
 				}
 			}
 		}
@@ -185,10 +211,12 @@ void lyndon_proj_matrix(
 
 	SparseIntMatrix full_mat;
 	full_mat_transpose.transpose(full_mat);
-	out.resize(full_mat.m, full_mat.m);
-
+	out.resize(m, m);
 	for (uint64_t i = 0; i < m; ++i) {
-		out.rows[i] = full_mat.rows[lyndon_idx[i]];
+		const uint64_t flat_idx = word_to_flat_idx(lyndon_words[i]);
+		if (flat_idx >= flat_word_count)
+			throw std::out_of_range("lyndon projection word index out of range");
+		out.rows[i] = full_mat.rows[flat_idx];
 	}
 
 	out.drop_diagonal();

--- a/siglib/cpsig/words.h
+++ b/siglib/cpsig/words.h
@@ -65,3 +65,11 @@ void lyndon_proj_matrix(
 	uint64_t degree
 );
 
+void lyndon_proj_matrix_from_words(
+	SparseIntMatrix& out,
+	const std::vector<word>& lyndon_words,
+	uint64_t flat_word_count,
+	const std::function<uint64_t(const word&)>& word_to_flat_idx,
+	const std::function<uint64_t(uint64_t, uint64_t, uint64_t)>& concatenate_flat_idx
+);
+

--- a/siglib/cpsig_unit_testing/cp_test_branched.cpp
+++ b/siglib/cpsig_unit_testing/cp_test_branched.cpp
@@ -14,6 +14,7 @@
  * ========================================================================= */
 
 #include "cp_test_helpers.h"
+#include "branched_cache.h"
 
     TEST(branchedSigCombineTest, ChenIdentity) {
         uint64_t dimension = 2, max_nodes = 3;
@@ -142,5 +143,101 @@
         for (uint64_t i = 0; i < bs_len; ++i) {
             EXPECT_TRUE(abs(out1[i]) < DOUBLE_EPSILON);
             EXPECT_TRUE(abs(out2[i]) < DOUBLE_EPSILON);
+        }
+    }
+
+    TEST(branchedLogSigLengthTest, MatchesExplicitWeightedLyndonEnumeration) {
+        EXPECT_EQ(branched_log_sig_length(0, 3, true), 0);
+        EXPECT_EQ(branched_log_sig_length(2, 0, true), 0);
+        EXPECT_EQ(branched_log_sig_length(2, 3, false),
+            branched_sig_length(2, 3, false) - 1);
+        EXPECT_EQ(branched_log_sig_length(1, UINT64_MAX, true), 0);
+
+        const std::vector<std::pair<uint64_t, uint64_t>> cases = {
+            { 1, 1 }, { 1, 3 }, { 2, 3 }, { 3, 2 }
+        };
+        for (const auto& [dimension, max_nodes] : cases) {
+            const auto cache = build_branched_sig_cache(dimension, max_nodes, true);
+            uint64_t expected = 0;
+            for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+                const uint64_t start = cache.basis_forest_offsets[basis_idx];
+                const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
+                const word forest(
+                    cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
+                    cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
+                expected += is_lyndon(forest);
+            }
+            EXPECT_EQ(branched_log_sig_length(dimension, max_nodes, true), expected);
+        }
+    }
+
+    TEST(branchedLogSigMethodsTest, LyndonCoordinatesAndBasisProjection) {
+        const uint64_t dimension = 2;
+        const uint64_t max_nodes = 3;
+        ASSERT_EQ(prepare_branched_log_sig(
+            dimension, max_nodes, 2, false, true), 0);
+
+        const uint64_t bsig_len = branched_sig_length(dimension, max_nodes, true);
+        const uint64_t logsig_len = branched_log_sig_length(dimension, max_nodes, true);
+        const std::vector<double> path = {
+            0., 0., 0.2, -0.3, 0.7, 0.4, 0.5, 0.8
+        };
+        std::vector<double> bsig(bsig_len);
+        ASSERT_EQ(branched_sig_d(
+            path.data(), bsig.data(), 1, dimension, 4, max_nodes,
+            1, false, false, 1., true, true), 0);
+
+        std::vector<double> expanded(bsig_len);
+        std::vector<double> method_one(logsig_len);
+        std::vector<double> method_two(logsig_len);
+        ASSERT_EQ(branched_sig_to_log_sig_d(
+            bsig.data(), expanded.data(), 1, dimension, max_nodes,
+            0, 1, true, true), 0);
+        ASSERT_EQ(branched_sig_to_log_sig_d(
+            bsig.data(), method_one.data(), 1, dimension, max_nodes,
+            1, 1, true, true), 0);
+        ASSERT_EQ(branched_sig_to_log_sig_d(
+            bsig.data(), method_two.data(), 1, dimension, max_nodes,
+            2, 1, true, true), 0);
+
+        const auto cache = build_branched_sig_cache(dimension, max_nodes, true);
+        std::vector<word> lyndon_words;
+        std::vector<uint64_t> lyndon_idx;
+        std::vector<word> flat_words(cache.total_length);
+        for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+            const uint64_t start = cache.basis_forest_offsets[basis_idx];
+            const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
+            word forest(
+                cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
+                cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
+            flat_words[basis_idx + 1] = forest;
+            if (is_lyndon(forest)) {
+                lyndon_words.push_back(forest);
+                lyndon_idx.push_back(basis_idx + 1);
+            }
+        }
+        ASSERT_EQ(lyndon_idx.size(), logsig_len);
+        for (uint64_t i = 0; i < logsig_len; ++i)
+            EXPECT_NEAR(method_one[i], expanded[lyndon_idx[i]], 1e-12);
+
+        SparseIntMatrix projection;
+        std::unordered_map<word, uint64_t, WordHash> flat_idx;
+        for (uint64_t i = 0; i < flat_words.size(); ++i)
+            flat_idx[flat_words[i]] = i;
+        lyndon_proj_matrix_from_words(
+            projection,
+            lyndon_words,
+            cache.total_length,
+            [&flat_idx](const word& w) {
+                return flat_idx.at(w);
+            },
+            [&flat_words, &flat_idx](uint64_t i, uint64_t j, uint64_t) {
+                return flat_idx.at(concatenate_words(flat_words.at(i), flat_words.at(j)));
+            });
+        for (uint64_t row = 0; row < logsig_len; ++row) {
+            double reconstructed = method_two[row];
+            for (const auto& entry : projection.rows[row])
+                reconstructed += entry.val * method_two[entry.col];
+            EXPECT_NEAR(reconstructed, method_one[row], 1e-12);
         }
     }

--- a/siglib/cusig/cu_branched_signature.cu
+++ b/siglib/cusig/cu_branched_signature.cu
@@ -243,6 +243,8 @@ static void write_branched_cache_(const BranchedSigCache& c) {
 	cu_serialize_vector_(out, c.chain_indices);
 	cu_serialize_vector_(out, c.coproduct_data);
 	cu_serialize_vector_(out, c.coproduct_offsets);
+	cu_serialize_vector_(out, c.basis_forest_data);
+	cu_serialize_vector_(out, c.basis_forest_offsets);
 }
 
 static bool read_branched_cache_(uint64_t dimension, uint64_t max_nodes, bool planar, BranchedSigCache& c) {
@@ -295,6 +297,12 @@ static bool read_branched_cache_(uint64_t dimension, uint64_t max_nodes, bool pl
 
 	if (!in.good())
 		return false;
+	if (in.peek() != std::char_traits<char>::eof()) {
+		cu_deserialize_vector_(in, tmp.basis_forest_data);
+		cu_deserialize_vector_(in, tmp.basis_forest_offsets);
+		if (!in.good())
+			return false;
+	}
 
 	tmp.planar = planar;
 	c = std::move(tmp);

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -2855,7 +2855,8 @@ ffi::Error BranchedSigCombineBackpropCuda(cudaStream_t stream, std::int64_t dime
 
 template <typename T>
 ffi::Error BranchedSigToLogSigCpuImpl(
-    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t method,
+    std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer& bsig, ffi::Result<ffi::AnyBuffer>& out
 ) {
     SigSpec spec;
@@ -2864,14 +2865,15 @@ ffi::Error BranchedSigToLogSigCpuImpl(
     int err_code = CpuFns<T>::bsig_to_log_sig(BufferData<T>(bsig), BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
         static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes),
-        static_cast<int>(n_jobs), planar, true);
+        static_cast<int>(method), static_cast<int>(n_jobs), planar, true);
     if (err_code != 0) return NativeCallError("branched_sig_to_log_sig", err_code);
     return ffi::Error::Success();
 }
 
 template <typename T>
 ffi::Error BranchedSigToLogSigBackpropCpuImpl(
-    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t method,
+    std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer& bsig, ffi::AnyBuffer& cotangent, ffi::Result<ffi::AnyBuffer>& out
 ) {
     SigSpec spec;
@@ -2881,24 +2883,30 @@ ffi::Error BranchedSigToLogSigBackpropCpuImpl(
         BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
         static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes),
-        static_cast<int>(n_jobs), planar, true);
+        static_cast<int>(method), static_cast<int>(n_jobs), planar, true);
     if (err_code != 0) return NativeCallError("branched_sig_to_log_sig_backprop", err_code);
     return ffi::Error::Success();
 }
 
-ffi::Error BranchedSigToLogSigCpu(std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
+ffi::Error BranchedSigToLogSigCpu(
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t method,
+    std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig, ffi::Result<ffi::AnyBuffer> out) {
     if (auto msg = ValidateFloatBuffer("bsig", bsig); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
-        return BranchedSigToLogSigCpuImpl<T>(dimension, max_nodes, n_jobs, planar, bsig, out);
+        return BranchedSigToLogSigCpuImpl<T>(
+            dimension, max_nodes, method, n_jobs, planar, bsig, out);
     });
 }
 
-ffi::Error BranchedSigToLogSigBackpropCpu(std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
+ffi::Error BranchedSigToLogSigBackpropCpu(
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t method,
+    std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig, ffi::AnyBuffer cotangent, ffi::Result<ffi::AnyBuffer> out) {
     if (auto msg = ValidateSameFloatDtype("bsig", bsig, "cotangent", cotangent); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
-        return BranchedSigToLogSigBackpropCpuImpl<T>(dimension, max_nodes, n_jobs, planar, bsig, cotangent, out);
+        return BranchedSigToLogSigBackpropCpuImpl<T>(
+            dimension, max_nodes, method, n_jobs, planar, bsig, cotangent, out);
     });
 }
 
@@ -2932,16 +2940,28 @@ ffi::Error BranchedSigToLogSigBackpropCudaImpl(cudaStream_t stream, std::int64_t
     return ffi::Error::Success();
 }
 
-ffi::Error BranchedSigToLogSigCuda(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
+ffi::Error BranchedSigToLogSigCuda(
+    cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+    std::int64_t method, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig, ffi::Result<ffi::AnyBuffer> out) {
+    if (method != 0) {
+        return InvalidArgument(
+            "MKW branched log signature methods 1 and 2 are only implemented on CPU");
+    }
     if (auto msg = ValidateFloatBuffer("bsig", bsig); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
         return BranchedSigToLogSigCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, bsig, out);
     });
 }
 
-ffi::Error BranchedSigToLogSigBackpropCuda(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs, bool planar,
+ffi::Error BranchedSigToLogSigBackpropCuda(
+    cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+    std::int64_t method, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig, ffi::AnyBuffer cotangent, ffi::Result<ffi::AnyBuffer> out) {
+    if (method != 0) {
+        return InvalidArgument(
+            "MKW branched log signature methods 1 and 2 are only implemented on CPU");
+    }
     if (auto msg = ValidateSameFloatDtype("bsig", bsig, "cotangent", cotangent); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
         return BranchedSigToLogSigBackpropCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, bsig, cotangent, out);
@@ -3166,22 +3186,26 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigCombineBackpropCuda, BranchedSi
 // branched_sig_to_log_sig
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigToLogSigCpu, BranchedSigToLogSigCpu,
-    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
+    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("method").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigToLogSigBackpropCpu, BranchedSigToLogSigBackpropCpu,
-    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
+    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("method").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigToLogSigCuda, BranchedSigToLogSigCuda,
     ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
-        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
+        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("method").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigToLogSigBackpropCuda, BranchedSigToLogSigBackpropCuda,
     ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
-        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
+        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("method").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
 #endif
 

--- a/siglib/shared/branched_trees.h
+++ b/siglib/shared/branched_trees.h
@@ -181,56 +181,167 @@ inline void enumerate_all_decorated_trees(
 // For planar=false, returns 1 + the number of non-planar trees. For
 // planar=true, returns 1 + the number of ordered forests of planar trees. The
 // +1 is the empty scalar term.
+inline uint64_t checked_branched_add_(uint64_t a, uint64_t b, const char* msg) {
+	if (a > UINT64_MAX - b)
+		throw std::overflow_error(msg);
+	return a + b;
+}
+
+inline uint64_t checked_branched_mul_(uint64_t a, uint64_t b, const char* msg) {
+	if (a != 0 && b > UINT64_MAX / a)
+		throw std::overflow_error(msg);
+	return a * b;
+}
+
+inline void compute_planar_branched_counts_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	std::vector<uint64_t>& trees_per_order,
+	std::vector<uint64_t>& forests_per_order
+) {
+	trees_per_order.assign(max_nodes + 1, 0);
+	forests_per_order.assign(max_nodes + 1, 0);
+	forests_per_order[0] = 1;
+	if (dimension == 0 || max_nodes == 0)
+		return;
+
+	trees_per_order[1] = dimension;
+	for (uint64_t order = 1; order <= max_nodes; ++order) {
+		uint64_t sum = 0;
+		for (uint64_t tree_order = 1; tree_order <= order; ++tree_order) {
+			const uint64_t term = checked_branched_mul_(
+				trees_per_order[tree_order],
+				forests_per_order[order - tree_order],
+				"planar branched count overflow");
+			sum = checked_branched_add_(sum, term, "planar branched count overflow");
+		}
+		forests_per_order[order] = sum;
+		if (order < max_nodes) {
+			trees_per_order[order + 1] = checked_branched_mul_(
+				dimension, forests_per_order[order], "planar tree count overflow");
+		}
+	}
+}
+
 inline uint64_t compute_branched_sig_length(uint64_t dimension, uint64_t max_nodes, bool planar = false) {
 	if (dimension > 255)
 		throw std::invalid_argument("branched signature dimension must be <= 255");
 	if (dimension == 0 || max_nodes == 0)
 		return 1;
-
-	std::vector<uint64_t> trees_per_order(max_nodes + 1, 0);
-	trees_per_order[1] = dimension;
-	uint64_t total_trees = dimension;
+	if (max_nodes == UINT64_MAX)
+		throw std::overflow_error("branched signature degree overflow");
 
 	if (planar) {
-		std::vector<uint64_t> ordered_partitions(max_nodes + 1, 0);
-		ordered_partitions[0] = 1;
+		std::vector<uint64_t> trees_per_order;
+		std::vector<uint64_t> forests_per_order;
+		compute_planar_branched_counts_(
+			dimension, max_nodes, trees_per_order, forests_per_order);
 		uint64_t total_forests = 0;
-		for (uint64_t order = 1; order <= max_nodes; ++order) {
-			uint64_t sum = 0;
-			for (uint64_t child_order = 1; child_order <= order; ++child_order)
-				sum += trees_per_order[child_order] * ordered_partitions[order - child_order];
-			ordered_partitions[order] = sum;
-			total_forests += sum;
-			if (order < max_nodes) {
-				trees_per_order[order + 1] = dimension * ordered_partitions[order];
-				total_trees += trees_per_order[order + 1];
-			}
-		}
-		return 1 + total_forests;
+		for (uint64_t order = 1; order <= max_nodes; ++order)
+			total_forests = checked_branched_add_(
+				total_forests, forests_per_order[order], "planar branched length overflow");
+		return checked_branched_add_(1, total_forests, "planar branched length overflow");
 	} else {
+		std::vector<uint64_t> trees_per_order(max_nodes + 1, 0);
+		trees_per_order[1] = dimension;
+		uint64_t total_trees = dimension;
 		std::vector<uint64_t> multiset_partitions(max_nodes + 1, 0);
 		std::vector<uint64_t> divisor_weighted_sum(max_nodes + 1, 0);
 		multiset_partitions[0] = 1;
 		for (uint64_t order = 1; order < max_nodes; ++order) {
 			uint64_t weighted_sum = 0;
-			for (uint64_t divisor = 1; divisor * divisor <= order; ++divisor) {
+			for (uint64_t divisor = 1; divisor <= order / divisor; ++divisor) {
 				if (order % divisor == 0) {
-					weighted_sum += divisor * trees_per_order[divisor];
+					const uint64_t term = checked_branched_mul_(
+						divisor, trees_per_order[divisor], "nonplanar tree count overflow");
+					weighted_sum = checked_branched_add_(
+						weighted_sum, term, "nonplanar tree count overflow");
 					const uint64_t complementary_divisor = order / divisor;
-					if (complementary_divisor != divisor)
-						weighted_sum += complementary_divisor * trees_per_order[complementary_divisor];
+					if (complementary_divisor != divisor) {
+						const uint64_t complementary_term = checked_branched_mul_(
+							complementary_divisor,
+							trees_per_order[complementary_divisor],
+							"nonplanar tree count overflow");
+						weighted_sum = checked_branched_add_(
+							weighted_sum, complementary_term, "nonplanar tree count overflow");
+					}
 				}
 			}
 			divisor_weighted_sum[order] = weighted_sum;
 
 			uint64_t sum = 0;
-			for (uint64_t term = 1; term <= order; ++term)
-				sum += divisor_weighted_sum[term] * multiset_partitions[order - term];
+			for (uint64_t term = 1; term <= order; ++term) {
+				const uint64_t product = checked_branched_mul_(
+					divisor_weighted_sum[term],
+					multiset_partitions[order - term],
+					"nonplanar tree count overflow");
+				sum = checked_branched_add_(sum, product, "nonplanar tree count overflow");
+			}
 			multiset_partitions[order] = sum / order;
 
-			trees_per_order[order + 1] = dimension * multiset_partitions[order];
-			total_trees += trees_per_order[order + 1];
+			trees_per_order[order + 1] = checked_branched_mul_(
+				dimension, multiset_partitions[order], "nonplanar tree count overflow");
+			total_trees = checked_branched_add_(
+				total_trees, trees_per_order[order + 1], "nonplanar branched length overflow");
 		}
+		return checked_branched_add_(1, total_trees, "nonplanar branched length overflow");
 	}
-	return 1 + total_trees;
+}
+
+inline uint64_t compute_branched_log_sig_length(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	bool planar = false
+) {
+	if (dimension > 255)
+		throw std::invalid_argument("branched log signature dimension must be <= 255");
+	if (dimension == 0 || max_nodes == 0)
+		return 0;
+	if (max_nodes == UINT64_MAX)
+		throw std::overflow_error("branched log signature degree overflow");
+	if (!planar)
+		return compute_branched_sig_length(dimension, max_nodes, false) - 1;
+
+	std::vector<uint64_t> trees_per_order;
+	std::vector<uint64_t> words_per_order;
+	compute_planar_branched_counts_(
+		dimension, max_nodes, trees_per_order, words_per_order);
+
+	std::vector<uint64_t> logarithmic_counts(max_nodes + 1, 0);
+	std::vector<uint64_t> lyndon_counts(max_nodes + 1, 0);
+	uint64_t result = 0;
+	for (uint64_t order = 1; order <= max_nodes; ++order) {
+		const uint64_t leading = checked_branched_mul_(
+			order, words_per_order[order], "branched log signature length overflow");
+		uint64_t convolution = 0;
+		for (uint64_t k = 1; k < order; ++k) {
+			const uint64_t term = checked_branched_mul_(
+				logarithmic_counts[k], words_per_order[order - k],
+				"branched log signature length overflow");
+			convolution = checked_branched_add_(
+				convolution, term, "branched log signature length overflow");
+		}
+		if (convolution > leading)
+			throw std::overflow_error("branched log signature length recurrence underflow");
+		logarithmic_counts[order] = leading - convolution;
+
+		uint64_t proper_divisor_sum = 0;
+		for (uint64_t divisor = 1; divisor < order; ++divisor) {
+			if (order % divisor != 0)
+				continue;
+			const uint64_t term = checked_branched_mul_(
+				divisor, lyndon_counts[divisor], "branched log signature length overflow");
+			proper_divisor_sum = checked_branched_add_(
+				proper_divisor_sum, term, "branched log signature length overflow");
+		}
+		if (proper_divisor_sum > logarithmic_counts[order])
+			throw std::overflow_error("branched log signature length recurrence underflow");
+		const uint64_t numerator = logarithmic_counts[order] - proper_divisor_sum;
+		if (numerator % order != 0)
+			throw std::runtime_error("branched log signature length recurrence is not integral");
+		lyndon_counts[order] = numerator / order;
+		result = checked_branched_add_(
+			result, lyndon_counts[order], "branched log signature length overflow");
+	}
+	return result;
 }

--- a/siglib/test_app/dll_funcs.h
+++ b/siglib/test_app/dll_funcs.h
@@ -175,7 +175,7 @@ extern log_sig_combine_backprop_d_fn log_sig_combine_backprop_d;
 extern log_sig_combine_backprop_cuda_d_fn log_sig_combine_backprop_cuda_d;
 
 using prepare_branched_sig_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
-using prepare_branched_log_sig_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
+using prepare_branched_log_sig_fn = int(CDECL_*)(uint64_t, uint64_t, int, bool, bool);
 using prepare_branched_sig_cuda_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
 using prepare_branched_log_sig_cuda_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
 using branched_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t, bool);
@@ -184,7 +184,7 @@ using branched_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, ui
 using prepare_branched_sig_coef_cuda_fn = int(CDECL_*)(const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool);
 using branched_sig_coef_cuda_d_fn = int(CDECL_*)(const double*, double*, const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t, uint64_t, uint64_t);
 using branched_sig_coef_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t, uint64_t, uint64_t);
-using branched_sig_to_log_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, int, bool, bool);
+using branched_sig_to_log_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, int, int, bool, bool);
 using branched_sig_to_log_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, bool, bool);
 
 extern prepare_branched_sig_fn prepare_branched_sig;

--- a/siglib/test_app/tests.cpp
+++ b/siglib/test_app/tests.cpp
@@ -1123,7 +1123,7 @@ void example_batch_branched_log_sig_d(
 
     bool planar = false;
     bool scalar_term = true;
-    prepare_branched_log_sig(dimension, max_nodes, false, planar);
+    prepare_branched_log_sig(dimension, max_nodes, 0, false, planar);
     prepare_branched_log_sig_cuda(dimension, max_nodes, planar, false);
 
     uint64_t bsig_len = branched_sig_length(dimension, max_nodes, planar);
@@ -1135,7 +1135,7 @@ void example_batch_branched_log_sig_d(
     std::vector<double> cuda_out(total, 0.);
 
     branched_sig_d(path.data(), bsig.data(), batch_size, dimension, length, max_nodes, n_jobs, false, false, 1., planar, scalar_term, nullptr, 0, 0, 0);
-    branched_sig_to_log_sig_d(bsig.data(), cpu_out.data(), batch_size, dimension, max_nodes, n_jobs, planar, scalar_term);
+    branched_sig_to_log_sig_d(bsig.data(), cpu_out.data(), batch_size, dimension, max_nodes, 0, n_jobs, planar, scalar_term);
 
     double* d_bsig;
     double* d_out;

--- a/tests/test_branched_log_sig.py
+++ b/tests/test_branched_log_sig.py
@@ -53,7 +53,7 @@ def test_branched_caches_require_preparation(device):
     with pytest.raises(Exception, match="Could not find prepared cache"):
         pysiglib.branched_sig_to_log_sig(bsig, d, N)
 
-    pysiglib.prepare_branched_log_sig(d, N, device=device)
+    pysiglib.prepare_branched_log_sig(d, N, 0, device=device)
     pysiglib.branched_sig_to_log_sig(bsig, d, N)
 
     pysiglib.clear_cache()
@@ -133,7 +133,7 @@ def test_branched_sig_to_log_sig_stochastax_degree2_fixture():
     fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
     d = fixture["dimension"]
     N = fixture["degree"]
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
 
     bsig = np.array(fixture["signature_scalar"], dtype=np.float64)
     expected = np.array(fixture["log_signature_scalar"], dtype=np.float64)
@@ -148,7 +148,7 @@ def test_branched_sig_to_log_sig_stochastax_degree2_fixture():
 
 def test_branched_sig_to_log_sig_single_segment_cherry_vanishes():
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
 
     c = 0.7
     path = np.array([[0.0, 0.0], [c, 0.0]], dtype=np.float64)
@@ -166,7 +166,7 @@ def test_branched_sig_to_log_sig_single_segment_cherry_vanishes():
 
 @pytest.mark.parametrize("d,N", [(2, 3), (3, 2)])
 def test_branched_log_sig_vs_kauri_hopf_log(d, N):
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     perm = compute_kauri_to_pysiglib_permutation(d, N)
 
     rng = np.random.default_rng(1234)
@@ -181,7 +181,7 @@ def test_branched_log_sig_vs_kauri_hopf_log(d, N):
 
 def test_branched_sig_to_log_sig_scalar_term_roundtrip():
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     path = np.array([[0.0, 0.0], [0.2, 0.5], [0.8, -0.1]], dtype=np.float64)
     bsig_scalar = pysiglib.branched_sig(path, N, scalar_term=True)
     bsig_tail = bsig_scalar[1:]
@@ -196,7 +196,8 @@ def test_branched_sig_to_log_sig_scalar_term_roundtrip():
 @pytest.mark.parametrize("time_aug,lead_lag", [(True, False), (False, True), (True, True)])
 def test_branched_sig_to_log_sig_uses_path_dimension_with_augmentation(time_aug, lead_lag):
     d, N = 2, 2
-    pysiglib.prepare_branched_log_sig(d, N, time_aug=time_aug, lead_lag=lead_lag)
+    pysiglib.prepare_branched_log_sig(
+        d, N, 0, time_aug=time_aug, lead_lag=lead_lag)
 
     rng = np.random.default_rng(9876)
     path = np.cumsum(rng.normal(scale=0.1, size=(5, d)), axis=0)
@@ -213,7 +214,7 @@ def test_branched_sig_to_log_sig_uses_path_dimension_with_augmentation(time_aug,
 
 def test_branched_sig_to_log_sig_backprop_finite_difference():
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     rng = np.random.default_rng(4321)
     path = np.cumsum(rng.normal(scale=0.2, size=(5, d)), axis=0)
     bsig = pysiglib.branched_sig(path, N, scalar_term=True)
@@ -236,7 +237,7 @@ def test_branched_sig_to_log_sig_backprop_finite_difference():
 
 def test_torch_branched_sig_to_log_sig_backward_matches_explicit_backprop():
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     path = np.array([[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]], dtype=np.float64)
     bsig_np = pysiglib.branched_sig(path, N, scalar_term=True)
     weights_np = np.linspace(-0.4, 0.7, bsig_np.shape[0])
@@ -252,7 +253,7 @@ def test_torch_branched_sig_to_log_sig_backward_matches_explicit_backprop():
 
 def test_torch_branched_log_sig_backward_runs():
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     path = torch.tensor(
         [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]],
         dtype=torch.float64,
@@ -268,7 +269,7 @@ def test_torch_branched_log_sig_backward_runs():
 
 def test_torch_branched_sig_to_log_sig_uses_path_dimension_with_augmentation():
     d, N = 2, 2
-    pysiglib.prepare_branched_log_sig(d, N, time_aug=True)
+    pysiglib.prepare_branched_log_sig(d, N, 0, time_aug=True)
     path = torch.tensor(
         [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]],
         dtype=torch.float64,
@@ -290,15 +291,17 @@ def test_torch_branched_sig_to_log_sig_uses_path_dimension_with_augmentation():
 @pytest.mark.parametrize("planar", [False, True])
 def test_branched_sig_to_log_sig_cuda_matches_cpu(scalar_term, planar):
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N, planar=planar)
+    pysiglib.prepare_branched_log_sig(d, N, 0, planar=planar)
     rng = np.random.default_rng(2468)
     path = np.cumsum(rng.normal(scale=0.1, size=(8, d)), axis=0)
 
     bsig_cpu = pysiglib.branched_sig(path, N, planar=planar, scalar_term=scalar_term)
-    expected = pysiglib.branched_sig_to_log_sig(bsig_cpu, d, N, planar=planar)
+    expected = pysiglib.branched_sig_to_log_sig(
+        bsig_cpu, d, N, planar=planar, method=0)
 
     bsig_cuda = torch.tensor(bsig_cpu, dtype=torch.float64, device="cuda")
-    actual = pysiglib.branched_sig_to_log_sig(bsig_cuda, d, N, planar=planar)
+    actual = pysiglib.branched_sig_to_log_sig(
+        bsig_cuda, d, N, planar=planar, method=0)
 
     check_close(expected, actual, double_atol=1e-12)
 
@@ -307,7 +310,7 @@ def test_branched_sig_to_log_sig_cuda_matches_cpu(scalar_term, planar):
 @pytest.mark.parametrize("scalar_term", [False, True])
 def test_branched_sig_to_log_sig_backprop_cuda_matches_cpu(scalar_term):
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     rng = np.random.default_rng(8642)
     path = np.cumsum(rng.normal(scale=0.1, size=(6, d)), axis=0)
 
@@ -325,7 +328,7 @@ def test_branched_sig_to_log_sig_backprop_cuda_matches_cpu(scalar_term):
 @skip_no_cuda
 def test_torch_branched_sig_to_log_sig_cuda_backward_matches_cpu():
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     rng = np.random.default_rng(9753)
     path_np = np.cumsum(rng.normal(scale=0.1, size=(5, d)), axis=0)
     bsig_np = pysiglib.branched_sig(path_np, N, scalar_term=True)
@@ -357,7 +360,7 @@ def test_jax_branched_sig_to_log_sig_cuda_value_and_grad_matches_cpu():
     import pysiglib.jax_api as jax_api
 
     d, N = 2, 3
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     rng = np.random.default_rng(3579)
     path_np = np.cumsum(rng.normal(scale=0.1, size=(6, d)), axis=0)
     bsig_np = pysiglib.branched_sig(path_np, N, scalar_term=True)
@@ -384,7 +387,7 @@ def test_jax_branched_sig_to_log_sig_value_and_grad():
     import pysiglib.jax_api as jax_api
 
     d, N = 2, 2
-    pysiglib.prepare_branched_log_sig(d, N)
+    pysiglib.prepare_branched_log_sig(d, N, 0)
     fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
     bsig = jnp.asarray(fixture["signature_scalar"], dtype=jnp.float64)
     expected = np.array(fixture["log_signature_scalar"], dtype=np.float64)
@@ -405,7 +408,7 @@ def test_jax_branched_sig_to_log_sig_uses_path_dimension_with_augmentation():
     import pysiglib.jax_api as jax_api
 
     d, N = 2, 2
-    pysiglib.prepare_branched_log_sig(d, N, lead_lag=True)
+    pysiglib.prepare_branched_log_sig(d, N, 0, lead_lag=True)
 
     path = jnp.asarray(
         [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]],

--- a/tests/test_cuda_grid_limits.py
+++ b/tests/test_cuda_grid_limits.py
@@ -77,7 +77,7 @@ def test_branched_cuda_batch_above_grid_y_limit():
     torch.testing.assert_close(d_bsig1, torch.ones_like(d_bsig1))
     torch.testing.assert_close(d_bsig2, torch.ones_like(d_bsig2))
 
-    pysiglib.prepare_branched_log_sig(1, 1, device="cuda")
+    pysiglib.prepare_branched_log_sig(1, 1, 0, device="cuda")
     blog_sig = pysiglib.branched_sig_to_log_sig(bsig, 1, 1)
     torch.testing.assert_close(blog_sig, torch.ones_like(blog_sig))
 


### PR DESCRIPTION
Stack layer 2 of 8. This layer adds the CPU MKW Lyndon branched log-signature implementation and exposes it consistently through the NumPy, Torch, JAX, and C interfaces. It also adds focused native and Python coverage. Validation: full Python unit suite, 2589 passed and 10 skipped.