### PR TITLE
Add BCH methods for MKW branched log signatures

### DIFF
--- a/benchmarks/bench_cpsig.cpp
+++ b/benchmarks/bench_cpsig.cpp
@@ -130,7 +130,7 @@ static void BM_prepare_branched_log_sig_planar(benchmark::State& state) {
     }
 }
 BENCHMARK(BM_prepare_branched_log_sig_planar)
-    ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
+    ->Arg(0)->Arg(1)->Arg(2)->Arg(3)->Unit(benchmark::kMicrosecond);
 
 // =========================================================================
 // Path transforms
@@ -849,6 +849,25 @@ static void BM_branched_sig_to_log_sig_planar(benchmark::State& state) {
 BENCHMARK(BM_branched_sig_to_log_sig_planar)
     ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
 
+static void BM_branched_log_sig_from_path_planar_method_3(
+        benchmark::State& state) {
+    check(::prepare_branched_log_sig(3, 4, 3, false, true),
+          "prepare_branched_log_sig");
+    const uint64_t out_len = ::branched_log_sig_length(3, 4, true);
+    auto path = random_data(64 * 32 * 3, 1);
+    std::vector<double> out(64 * out_len);
+    check(::branched_log_sig_from_path_d(
+        path.data(), out.data(), 64, 32, 3, 4, 1),
+        "branched_log_sig_from_path_d");
+    for (auto _ : state) {
+        ::branched_log_sig_from_path_d(
+            path.data(), out.data(), 64, 32, 3, 4, 1);
+        benchmark::DoNotOptimize(out.data());
+    }
+}
+BENCHMARK(BM_branched_log_sig_from_path_planar_method_3)
+    ->Unit(benchmark::kMicrosecond);
+
 static void BM_branched_sig_to_log_sig_backprop(benchmark::State& state) {
     check(::prepare_branched_log_sig(3, 4, 0, false, false),
           "prepare_branched_log_sig");
@@ -894,6 +913,28 @@ static void BM_branched_sig_to_log_sig_backprop_planar(
 }
 BENCHMARK(BM_branched_sig_to_log_sig_backprop_planar)
     ->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMicrosecond);
+
+static void BM_branched_log_sig_from_path_backprop_planar_method_3(
+        benchmark::State& state) {
+    check(::prepare_branched_log_sig(3, 4, 3, false, true),
+          "prepare_branched_log_sig");
+    const uint64_t out_len = ::branched_log_sig_length(3, 4, true);
+    auto path = random_data(64 * 32 * 3, 1);
+    auto derivs = random_data(64 * out_len, 2);
+    std::vector<double> path_derivs(64 * 32 * 3);
+    check(::branched_log_sig_from_path_backprop_d(
+        derivs.data(), path_derivs.data(), path.data(),
+        64, 32, 3, 4, 1),
+        "branched_log_sig_from_path_backprop_d");
+    for (auto _ : state) {
+        ::branched_log_sig_from_path_backprop_d(
+            derivs.data(), path_derivs.data(), path.data(),
+            64, 32, 3, 4, 1);
+        benchmark::DoNotOptimize(path_derivs.data());
+    }
+}
+BENCHMARK(BM_branched_log_sig_from_path_backprop_planar_method_3)
+    ->Unit(benchmark::kMicrosecond);
 
 static void BM_branched_sig_combine(benchmark::State& state) {
     check(::prepare_branched_sig(3, 4, false, false), "prepare_branched_sig");

--- a/pysiglib/branched_log_sig.py
+++ b/pysiglib/branched_log_sig.py
@@ -20,8 +20,17 @@ import torch
 
 from .param_checks import check_type, check_non_neg, check_n_jobs
 from .error_codes import err_msg
-from .dtypes import CPSIG_BRANCHED_SIG_TO_LOG_SIG, CUSIG_BRANCHED_SIG_TO_LOG_SIG_CUDA
-from .data_handlers import MultipleSigInputHandler, SigOutputHandler
+from .dtypes import (
+    CPSIG_BRANCHED_LOG_SIG_FROM_PATH,
+    CPSIG_BRANCHED_SIG_TO_LOG_SIG,
+    CUSIG_BRANCHED_SIG_TO_LOG_SIG_CUDA,
+)
+from .data_handlers import (
+    CorrectionInputHandler,
+    MultipleSigInputHandler,
+    PathInputHandler,
+    SigOutputHandler,
+)
 from .sig_length import aug_dim
 from .load_siglib import BUILT_WITH_CUDA, CPSIG, CUSIG
 from .branched_sig import (
@@ -29,6 +38,7 @@ from .branched_sig import (
     branched_sig,
     branched_sig_length,
 )
+from .transform_path import transform_path
 
 
 def prepare_branched_log_sig(
@@ -53,7 +63,7 @@ def prepare_branched_log_sig(
     :param degree: Maximum order (number of nodes).
     :type degree: int
     :param method: Method to prepare. Method 0 computes the expanded branched
-        log signature. Methods 1 and 2 compute compressed MKW log signatures
+        log signature. Methods 1, 2, and 3 compute compressed MKW log signatures
         and require ``planar=True``.
     :type method: int
     :param use_disk: If ``True``, load or save the branched-signature cache on disk.
@@ -107,14 +117,11 @@ def _resolve_branched_log_sig_method(method: Optional[int], planar: bool) -> int
     if method is None:
         return 1 if planar else 0
     check_type(method, "method", int)
-    if method == 3:
-        raise NotImplementedError(
-            "branched log signature method 3 is not implemented")
-    if method not in (0, 1, 2):
-        raise ValueError("method must be one of 0, 1 or 2. Got " + str(method) + " instead.")
+    if method not in (0, 1, 2, 3):
+        raise ValueError("method must be one of 0, 1, 2 or 3. Got " + str(method) + " instead.")
     if method and not planar:
         raise ValueError(
-            "branched log signature methods 1 and 2 require planar=True")
+            "branched log signature methods 1, 2 and 3 require planar=True")
     return method
 
 
@@ -175,7 +182,8 @@ def branched_sig_to_log_sig(
     :param method: Method to use. Method 0 returns the expanded branched log
         signature. Methods 1 and 2 return compressed MKW coordinates and
         require ``planar=True``. If omitted, method 0 is used for nonplanar
-        signatures and method 1 is used for planar signatures.
+        signatures and method 1 is used for planar signatures. Method 3 is not
+        available for conversion from a branched signature.
     :type method: int | None
     :param n_jobs: Number of threads to run in parallel.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
@@ -206,6 +214,10 @@ def branched_sig_to_log_sig(
     check_type(lead_lag, "lead_lag", bool)
     check_type(planar, "planar", bool)
     method = _resolve_branched_log_sig_method(method, planar)
+    if method == 3:
+        raise ValueError(
+            "method=3 is not supported in branched_sig_to_log_sig. "
+            "Use branched_log_sig(path, degree, method=3) instead.")
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
@@ -279,10 +291,11 @@ def branched_log_sig(
     :param scalar_term: If True, include the leading scalar coefficient, which is zero.
     :type scalar_term: bool
     :param method: Method to use. Method 0 returns the expanded branched log
-        signature. Methods 1 and 2 return compressed MKW coordinates and
-        require ``planar=True``. If omitted, method 0 is used for nonplanar
-        signatures and method 1 is used for planar signatures. ``scalar_term``
-        affects only method 0.
+        signature. Methods 1, 2, and 3 return compressed MKW coordinates and
+        require ``planar=True``. Method 3 uses direct sequential BCH updates
+        and does not support non-empty corrections. If omitted, method 0 is
+        used for nonplanar signatures and method 1 is used for planar
+        signatures. ``scalar_term`` affects only method 0.
     :type method: int | None
     :param correction: Optional per-segment correction of level
         :math:`\\geq 2` added to the path increment on each path
@@ -364,6 +377,41 @@ def branched_log_sig(
         print(ito_blogsig)
     """
     method = _resolve_branched_log_sig_method(method, planar)
+    if method == 3:
+        if correction is not None:
+            correction_data = CorrectionInputHandler(
+                correction,
+                PathInputHandler(path, time_aug, lead_lag, end_time, "path"),
+                degree,
+            )
+            if correction_data.length != 0:
+                raise ValueError(
+                    "correction is not supported with branched_log_sig method=3")
+        if isinstance(path, torch.Tensor) and path.device.type != "cpu":
+            raise NotImplementedError(
+                "MKW branched log signature method 3 is only supported on CPU")
+        if time_aug or lead_lag:
+            path = transform_path(
+                path, time_aug=time_aug, lead_lag=lead_lag,
+                end_time=end_time, n_jobs=n_jobs)
+        data = PathInputHandler(path, False, False, 1.0, "path")
+        if data.device != "cpu":
+            raise NotImplementedError(
+                "MKW branched log signature method 3 is only supported on CPU")
+        out_len = branched_log_sig_length(
+            data.data_dimension, degree, planar=True)
+        result = SigOutputHandler(data, out_len)
+        if data.batch_size == 0:
+            return result.data
+        err_code = CPSIG_BRANCHED_LOG_SIG_FROM_PATH[data.dtype](
+            data.data_ptr, result.data_ptr, data.batch_size, data.data_length,
+            data.data_dimension, degree, n_jobs)
+        if err_code:
+            raise Exception(
+                "Error in pysiglib.branched_log_sig (method=3): "
+                + err_msg(err_code))
+        return result.data
+
     if method and isinstance(path, torch.Tensor) and path.device.type != "cpu":
         raise NotImplementedError(
             "Compressed MKW branched log signatures are only supported on CPU")

--- a/pysiglib/branched_log_sig_backprop.py
+++ b/pysiglib/branched_log_sig_backprop.py
@@ -21,10 +21,11 @@ import torch
 from .param_checks import check_type, check_non_neg, check_n_jobs
 from .error_codes import err_msg
 from .dtypes import (
+    CPSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP,
     CPSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP,
     CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA,
 )
-from .data_handlers import SigInputHandler, SigOutputHandler
+from .data_handlers import PathInputHandler, PathOutputHandler, SigInputHandler, SigOutputHandler
 from .sig_length import aug_dim
 from .branched_sig import (
     _infer_branched_scalar_term,
@@ -110,6 +111,10 @@ def branched_sig_to_log_sig_backprop(
     check_type(lead_lag, "lead_lag", bool)
     check_type(planar, "planar", bool)
     method = _resolve_branched_log_sig_method(method, planar)
+    if method == 3:
+        raise ValueError(
+            "method=3 is not supported in branched_sig_to_log_sig_backprop. "
+            "Use the direct branched_log_sig path backward instead.")
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
@@ -163,4 +168,46 @@ def branched_sig_to_log_sig_backprop(
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_to_log_sig_backprop: " + err_msg(err_code))
 
+    return result.data
+
+
+def _branched_log_sig_from_path_backprop(
+        grad_output: Union[np.ndarray, torch.Tensor],
+        path: Union[np.ndarray, torch.Tensor],
+        degree: int,
+        *,
+        n_jobs: int = 1,
+) -> Union[np.ndarray, torch.Tensor]:
+    """Backpropagates through the MKW method=3 computation."""
+    check_type(degree, "degree", int)
+    check_non_neg(degree, "degree")
+    check_n_jobs(n_jobs)
+
+    data = PathInputHandler(path, False, False, 1.0, "path")
+    if data.device != "cpu":
+        raise NotImplementedError(
+            "MKW branched log signature method 3 is only supported on CPU")
+    out_len = branched_log_sig_length(
+        data.data_dimension, degree, planar=True)
+    derivs_data = SigInputHandler(grad_output, out_len, "grad_output")
+    if data.type_ != derivs_data.type_:
+        raise ValueError(
+            "grad_output and path must both be numpy arrays or both be torch tensors")
+    if data.dtype != derivs_data.dtype:
+        raise ValueError("grad_output and path must have the same dtype")
+    if data.batch_shape != derivs_data.batch_shape:
+        raise ValueError("grad_output and path have different batch shapes")
+    if data.device != derivs_data.device:
+        raise ValueError("grad_output and path must be on the same device")
+
+    result = PathOutputHandler(data.data_length, data.data_dimension, data)
+    if data.batch_size == 0:
+        return result.data
+    err_code = CPSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP[data.dtype](
+        derivs_data.data_ptr, result.data_ptr, data.data_ptr,
+        data.batch_size, data.data_length, data.data_dimension, degree, n_jobs)
+    if err_code:
+        raise Exception(
+            "Error in pysiglib.branched_log_sig_from_path_backprop: "
+            + err_msg(err_code))
     return result.data

--- a/pysiglib/dtypes.py
+++ b/pysiglib/dtypes.py
@@ -372,6 +372,16 @@ CPSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP = {
     "float64": CPSIG.branched_sig_to_log_sig_backprop_d
 }
 
+CPSIG_BRANCHED_LOG_SIG_FROM_PATH = {
+    "float32": CPSIG.branched_log_sig_from_path_f,
+    "float64": CPSIG.branched_log_sig_from_path_d
+}
+
+CPSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP = {
+    "float32": CPSIG.branched_log_sig_from_path_backprop_f,
+    "float64": CPSIG.branched_log_sig_from_path_backprop_d
+}
+
 CPSIG_BRANCHED_SIG_COMBINE_BACKPROP = {
     "float32": CPSIG.branched_sig_combine_backprop_f,
     "float64": CPSIG.branched_sig_combine_backprop_d

--- a/pysiglib/jax_api/_ffi.py
+++ b/pysiglib/jax_api/_ffi.py
@@ -183,6 +183,14 @@ _TARGETS = {
         "cpu": ("pysiglib_branched_sig_to_log_sig_backprop_cpu", "PySigLibBranchedSigToLogSigBackpropCpu"),
         "cuda": ("pysiglib_branched_sig_to_log_sig_backprop_cuda", "PySigLibBranchedSigToLogSigBackpropCuda"),
     },
+    "branched_log_sig_from_path": {
+        "cpu": ("pysiglib_branched_log_sig_from_path_cpu", "PySigLibBranchedLogSigFromPathCpu"),
+        "cuda": ("pysiglib_branched_log_sig_from_path_cuda", "PySigLibBranchedLogSigFromPathCuda"),
+    },
+    "branched_log_sig_from_path_backprop": {
+        "cpu": ("pysiglib_branched_log_sig_from_path_backprop_cpu", "PySigLibBranchedLogSigFromPathBackpropCpu"),
+        "cuda": ("pysiglib_branched_log_sig_from_path_backprop_cuda", "PySigLibBranchedLogSigFromPathBackpropCuda"),
+    },
 }
 
 
@@ -727,3 +735,29 @@ def branched_sig_to_log_sig_backprop_ffi_call(
                        method=np.int64(method), n_jobs=np.int64(n_jobs),
                        planar=np.bool_(planar))
     return _make_ffi_call("branched_sig_to_log_sig_backprop", (bsig, cotangent), out_type, call_kwargs)
+
+
+def branched_log_sig_from_path_ffi_call(
+        path, dimension, max_nodes, n_jobs):
+    _normalize_dtype(path.dtype)
+    out_len = branched_log_sig_length(
+        dimension, max_nodes, planar=True)
+    out_type = jax.ShapeDtypeStruct(
+        (*path.shape[:-2], out_len), path.dtype)
+    call_kwargs = dict(
+        dimension=np.int64(dimension), max_nodes=np.int64(max_nodes),
+        n_jobs=np.int64(n_jobs))
+    return _make_ffi_call(
+        "branched_log_sig_from_path", (path,), out_type, call_kwargs)
+
+
+def branched_log_sig_from_path_backprop_ffi_call(
+        cotangent, path, dimension, max_nodes, n_jobs):
+    _check_same_dtype(cotangent, path)
+    out_type = jax.ShapeDtypeStruct(path.shape, path.dtype)
+    call_kwargs = dict(
+        dimension=np.int64(dimension), max_nodes=np.int64(max_nodes),
+        n_jobs=np.int64(n_jobs))
+    return _make_ffi_call(
+        "branched_log_sig_from_path_backprop", (cotangent, path),
+        out_type, call_kwargs)

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -102,6 +102,8 @@ from ._ffi import (
     branched_sig_combine_backprop_ffi_call,
     branched_sig_to_log_sig_ffi_call,
     branched_sig_to_log_sig_backprop_ffi_call,
+    branched_log_sig_from_path_ffi_call,
+    branched_log_sig_from_path_backprop_ffi_call,
 )
 
 
@@ -1658,7 +1660,7 @@ def _check_branched_log_sig_device(arr, method: int) -> None:
         return
     if any(device.platform in ("cuda", "gpu") for device in devices()):
         raise NotImplementedError(
-            "MKW branched log signature methods 1 and 2 are only implemented on CPU."
+            "MKW branched log signature methods 1, 2 and 3 are only implemented on CPU."
         )
 
 
@@ -1687,6 +1689,10 @@ def branched_sig_to_log_sig(
     check_type(planar, "planar", bool)
     check_n_jobs(n_jobs)
     method = _resolve_branched_log_sig_method(method, planar)
+    if method == 3:
+        raise ValueError(
+            "method=3 is not supported in branched_sig_to_log_sig. "
+            "Use branched_log_sig(path, degree, method=3) instead.")
     _check_branched_log_sig_device(bsig, method)
 
     aug_dimension = _augmented_dim(dimension, time_aug, lead_lag)
@@ -1704,6 +1710,32 @@ def branched_sig_to_log_sig(
 branched_sig_to_log_sig.__doc__ = branched_sig_to_log_sig_forward.__doc__
 
 
+@partial(jax.custom_vjp, nondiff_argnums=(1, 2, 3))
+def _branched_log_sig_from_path(path, dimension, degree, n_jobs):
+    return branched_log_sig_from_path_ffi_call(
+        path, dimension, degree, n_jobs)
+
+
+def _branched_log_sig_from_path_fwd(path, dimension, degree, n_jobs):
+    result = branched_log_sig_from_path_ffi_call(
+        path, dimension, degree, n_jobs)
+    return result, (path,)
+
+
+def _branched_log_sig_from_path_bwd(
+        dimension, degree, n_jobs, residual, cotangent):
+    path, = residual
+    grad = branched_log_sig_from_path_backprop_ffi_call(
+        cotangent, path, dimension, degree, n_jobs)
+    return (grad,)
+
+
+_branched_log_sig_from_path.defvjp(
+    _branched_log_sig_from_path_fwd,
+    _branched_log_sig_from_path_bwd,
+)
+
+
 def branched_log_sig(
     path,
     degree: int,
@@ -1717,9 +1749,23 @@ def branched_log_sig(
     correction = None,
     n_jobs: int = 1,
 ):
+    ensure_registered()
     path = jnp.asarray(path)
+    _validate_shape(path)
     method = _resolve_branched_log_sig_method(method, planar)
     _check_branched_log_sig_device(path, method)
+    if method == 3:
+        correction = _prepare_correction_jax(
+            correction, path, degree, lead_lag)
+        if correction.shape[0] != 0:
+            raise ValueError(
+                "correction is not supported with branched_log_sig method=3")
+        if time_aug or lead_lag:
+            path = transform_path(
+                path, time_aug=time_aug, lead_lag=lead_lag,
+                end_time=end_time, n_jobs=n_jobs)
+        return _branched_log_sig_from_path(
+            path, path.shape[-1], degree, n_jobs)
     bsig = branched_sig(
         path, degree, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time,
         planar=planar, scalar_term=scalar_term, correction=correction, n_jobs=n_jobs)

--- a/pysiglib/load_siglib.py
+++ b/pysiglib/load_siglib.py
@@ -653,6 +653,18 @@ CPSIG.branched_sig_to_log_sig_backprop_f.restype = c_int
 CPSIG.branched_sig_to_log_sig_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_int, c_bool, c_bool)
 CPSIG.branched_sig_to_log_sig_backprop_d.restype = c_int
 
+CPSIG.branched_log_sig_from_path_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_log_sig_from_path_f.restype = c_int
+
+CPSIG.branched_log_sig_from_path_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_log_sig_from_path_d.restype = c_int
+
+CPSIG.branched_log_sig_from_path_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_log_sig_from_path_backprop_f.restype = c_int
+
+CPSIG.branched_log_sig_from_path_backprop_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_int)
+CPSIG.branched_log_sig_from_path_backprop_d.restype = c_int
+
 CPSIG.branched_sig_combine_backprop_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
 CPSIG.branched_sig_combine_backprop_f.restype = c_int
 

--- a/pysiglib/torch_api/torch_api.py
+++ b/pysiglib/torch_api/torch_api.py
@@ -786,7 +786,10 @@ from ..branched_log_sig import (
     branched_sig_to_log_sig as branched_sig_to_log_sig_forward,
     prepare_branched_log_sig,
 )
-from ..branched_log_sig_backprop import branched_sig_to_log_sig_backprop
+from ..branched_log_sig_backprop import (
+    _branched_log_sig_from_path_backprop,
+    branched_sig_to_log_sig_backprop,
+)
 
 class BranchedSigCoef(torch.autograd.Function):
     @staticmethod
@@ -951,11 +954,47 @@ def branched_sig_to_log_sig(
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
     method = _resolve_branched_log_sig_method(method, planar)
+    if method == 3:
+        raise ValueError(
+            "method=3 is not supported in branched_sig_to_log_sig. "
+            "Use branched_log_sig(path, degree, method=3) instead.")
     return BranchedSigToLogSig.apply(
         bsig, dimension, degree, time_aug, lead_lag, planar, method, n_jobs)
 
 
 branched_sig_to_log_sig.__doc__ = branched_sig_to_log_sig_forward.__doc__
+
+
+class BranchedLogSigFromPath(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, path, degree, time_aug, lead_lag, end_time, n_jobs):
+        if time_aug or lead_lag:
+            transformed = transform_path(
+                path, time_aug=time_aug, lead_lag=lead_lag,
+                end_time=end_time, n_jobs=n_jobs)
+        else:
+            transformed = path
+        result = branched_log_sig_forward(
+            transformed, degree, planar=True, method=3,
+            time_aug=False, lead_lag=False, n_jobs=n_jobs)
+        ctx.save_for_backward(transformed)
+        ctx.degree = degree
+        ctx.time_aug = time_aug
+        ctx.lead_lag = lead_lag
+        ctx.end_time = end_time
+        ctx.n_jobs = n_jobs
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        transformed, = ctx.saved_tensors
+        d_path = _branched_log_sig_from_path_backprop(
+            grad_output, transformed, ctx.degree, n_jobs=ctx.n_jobs)
+        if ctx.time_aug or ctx.lead_lag:
+            d_path = transform_path_backprop(
+                d_path, time_aug=ctx.time_aug, lead_lag=ctx.lead_lag,
+                end_time=ctx.end_time, n_jobs=ctx.n_jobs)
+        return d_path, None, None, None, None, None
 
 
 def branched_log_sig(
@@ -972,6 +1011,19 @@ def branched_log_sig(
         n_jobs: int = 1,
 ) -> Union[np.ndarray, torch.Tensor]:
     method = _resolve_branched_log_sig_method(method, planar)
+    if method == 3:
+        if not isinstance(path, torch.Tensor) or _has_non_empty_correction(correction):
+            return branched_log_sig_forward(
+                path, degree, time_aug=time_aug, lead_lag=lead_lag,
+                end_time=end_time, planar=planar, scalar_term=scalar_term,
+                method=method, correction=correction, n_jobs=n_jobs)
+        if path.requires_grad:
+            return BranchedLogSigFromPath.apply(
+                path, degree, time_aug, lead_lag, end_time, n_jobs)
+        return branched_log_sig_forward(
+            path, degree, time_aug=time_aug, lead_lag=lead_lag,
+            end_time=end_time, planar=planar, scalar_term=scalar_term,
+            method=method, n_jobs=n_jobs)
     if method and isinstance(path, torch.Tensor) and path.device.type != "cpu":
         raise NotImplementedError(
             "Compressed MKW branched log signatures are only supported on CPU")

--- a/siglib/cpsig/cp_bch.h
+++ b/siglib/cpsig/cp_bch.h
@@ -45,6 +45,8 @@ struct BchCache {
 	std::vector<int> comm_k_val;
 	std::vector<double> comm_k_val_d; // pre-cast to double
 	std::vector<uint32_t> comm_k_sparse_end; // per-output k: end index for entries with k_i < dim
+	std::vector<uint32_t> comm_k_sparse_ptr;
+	std::vector<uint32_t> comm_k_sparse_idx;
 
 	// Input-grouped commutator table (CSR format, grouped by input index a)
 	// For each input index a, stores (k, partner, signed_c) triples where
@@ -68,6 +70,10 @@ struct BchCache {
 	std::vector<std::pair<uint64_t, uint64_t>> linear_range;
 	std::vector<uint64_t> linear_pair_ptr;
 	std::vector<uint32_t> linear_pair_idx;
+	std::vector<uint64_t> coordinate_weights;
+	std::vector<uint32_t> linear_input_idx;
+	std::vector<uint8_t> linear_input_mask;
+	bool linear_input_prefix = true;
 	bool prune_linear_backprop = false;
 
 	// Standard factorization of each d-letter Lyndon word (as index pairs)
@@ -248,6 +254,119 @@ inline std::vector<word> compute_factorization_indices(
 	return lyndon_words;
 }
 
+inline void build_commutator_views(BchCache& cache) {
+	const uint64_t m = cache.m;
+	std::vector<uint32_t> counts(m, 0);
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			for (const auto& [k, c] : cache.commutator_table[i * m + j])
+				++counts[k];
+		}
+	}
+
+	cache.comm_k_ptr.resize(m + 1);
+	cache.comm_k_ptr[0] = 0;
+	for (uint64_t k = 0; k < m; ++k)
+		cache.comm_k_ptr[k + 1] = cache.comm_k_ptr[k] + counts[k];
+
+	const uint32_t nnz = cache.comm_k_ptr[m];
+	cache.comm_k_i.resize(nnz);
+	cache.comm_k_j.resize(nnz);
+	cache.comm_k_val.resize(nnz);
+	std::fill(counts.begin(), counts.end(), 0);
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
+				const uint32_t pos = cache.comm_k_ptr[k] + counts[k]++;
+				cache.comm_k_i[pos] = static_cast<uint32_t>(i);
+				cache.comm_k_j[pos] = static_cast<uint32_t>(j);
+				cache.comm_k_val[pos] = c;
+			}
+		}
+	}
+
+	cache.comm_k_val_d.resize(nnz);
+	for (uint32_t idx = 0; idx < nnz; ++idx)
+		cache.comm_k_val_d[idx] = static_cast<double>(cache.comm_k_val[idx]);
+
+	cache.comm_k_sparse_end.resize(m);
+	for (uint64_t k = 0; k < m; ++k) {
+		uint32_t sparse_end = cache.comm_k_ptr[k];
+		for (uint32_t idx = cache.comm_k_ptr[k]; idx < cache.comm_k_ptr[k + 1]; ++idx) {
+			if (cache.comm_k_i[idx] >= cache.dimension)
+				break;
+			sparse_end = idx + 1;
+		}
+		cache.comm_k_sparse_end[k] = sparse_end;
+	}
+
+	std::vector<uint32_t> a_counts(m, 0);
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
+				a_counts[i]++;
+				a_counts[j]++;
+			}
+		}
+	}
+	cache.comm_a_ptr.resize(m + 1);
+	cache.comm_a_ptr[0] = 0;
+	for (uint64_t a = 0; a < m; ++a)
+		cache.comm_a_ptr[a + 1] = cache.comm_a_ptr[a] + a_counts[a];
+
+	const uint32_t a_nnz = cache.comm_a_ptr[m];
+	cache.comm_a_k.resize(a_nnz);
+	cache.comm_a_partner.resize(a_nnz);
+	cache.comm_a_signed_c.resize(a_nnz);
+	std::fill(a_counts.begin(), a_counts.end(), 0);
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
+				const uint32_t pos_i = cache.comm_a_ptr[i] + a_counts[i]++;
+				cache.comm_a_k[pos_i] = static_cast<uint32_t>(k);
+				cache.comm_a_partner[pos_i] = static_cast<uint32_t>(j);
+				cache.comm_a_signed_c[pos_i] = c;
+
+				const uint32_t pos_j = cache.comm_a_ptr[j] + a_counts[j]++;
+				cache.comm_a_k[pos_j] = static_cast<uint32_t>(k);
+				cache.comm_a_partner[pos_j] = static_cast<uint32_t>(i);
+				cache.comm_a_signed_c[pos_j] = -c;
+			}
+		}
+	}
+
+	cache.n_pairs = 0;
+	for (uint64_t i = 0; i < m; ++i)
+		for (uint64_t j = i + 1; j < m; ++j)
+			if (!cache.commutator_table[i * m + j].empty())
+				cache.n_pairs++;
+
+	cache.comm_ij_i.resize(cache.n_pairs);
+	cache.comm_ij_j.resize(cache.n_pairs);
+	cache.comm_ij_ptr.resize(cache.n_pairs + 1);
+	cache.comm_ij_k.resize(nnz);
+	cache.comm_ij_c.resize(nnz);
+	uint32_t pair_idx = 0;
+	uint32_t entry_idx = 0;
+	cache.comm_ij_ptr[0] = 0;
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			const auto& entries = cache.commutator_table[i * m + j];
+			if (entries.empty())
+				continue;
+			cache.comm_ij_i[pair_idx] = static_cast<uint32_t>(i);
+			cache.comm_ij_j[pair_idx] = static_cast<uint32_t>(j);
+			for (const auto& [k, c] : entries) {
+				cache.comm_ij_k[entry_idx] = static_cast<uint32_t>(k);
+				cache.comm_ij_c[entry_idx] = static_cast<double>(c);
+				entry_idx++;
+			}
+			cache.comm_ij_ptr[pair_idx + 1] = entry_idx;
+			pair_idx++;
+		}
+	}
+}
+
 inline void build_commutator_table(BchCache& cache) {
 	uint64_t m = cache.m;
 	uint64_t dim = cache.dimension;
@@ -261,6 +380,7 @@ inline void build_commutator_table(BchCache& cache) {
 	std::vector<uint64_t> tensor_degs;
 	build_tensor_representations(lyndon_words, cache.left_factor, cache.right_factor,
 		dim, deg, tensor_reps, tensor_degs);
+	cache.coordinate_weights = tensor_degs;
 
 	// Get the Lyndon word tensor indices and P^{-1} matrix from BasisCache
 // (prepare_basis_cache has already been called before build_commutator_table)
@@ -323,141 +443,30 @@ inline void build_commutator_table(BchCache& cache) {
 		}
 	}
 
-	// Build transposed commutator table (CSR format, grouped by output k)
-	std::vector<uint32_t> counts(m, 0);
-	for (uint64_t i = 0; i < m; ++i) {
-		for (uint64_t j = i + 1; j < m; ++j) {
-			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
-				++counts[k];
-			}
-		}
-	}
-
-	cache.comm_k_ptr.resize(m + 1);
-	cache.comm_k_ptr[0] = 0;
-	for (uint64_t k = 0; k < m; ++k) {
-		cache.comm_k_ptr[k + 1] = cache.comm_k_ptr[k] + counts[k];
-	}
-
-	uint32_t nnz = cache.comm_k_ptr[m];
-	cache.comm_k_i.resize(nnz);
-	cache.comm_k_j.resize(nnz);
-	cache.comm_k_val.resize(nnz);
-
-	std::fill(counts.begin(), counts.end(), 0);
-	for (uint64_t i = 0; i < m; ++i) {
-		for (uint64_t j = i + 1; j < m; ++j) {
-			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
-				uint32_t pos = cache.comm_k_ptr[k] + counts[k]++;
-				cache.comm_k_i[pos] = static_cast<uint32_t>(i);
-				cache.comm_k_j[pos] = static_cast<uint32_t>(j);
-				cache.comm_k_val[pos] = c;
-			}
-		}
-	}
-
-	// Pre-cast k-grouped coefficients to double
-	cache.comm_k_val_d.resize(nnz);
-	for (uint32_t idx = 0; idx < nnz; ++idx) {
-		cache.comm_k_val_d[idx] = static_cast<double>(cache.comm_k_val[idx]);
-	}
-
-	// Sparse threshold: for each output k, find where k_i first reaches dimension.
-	// Entries within each k-group are ordered by (i, j) with i increasing,
-	// so entries with i < dimension come first.
-	cache.comm_k_sparse_end.resize(m);
-	for (uint64_t k = 0; k < m; ++k) {
-		uint32_t kend = cache.comm_k_ptr[k + 1];
-		uint32_t sparse_end = cache.comm_k_ptr[k];
-		for (uint32_t idx = cache.comm_k_ptr[k]; idx < kend; ++idx) {
-			if (cache.comm_k_i[idx] >= cache.dimension) break;
-			sparse_end = idx + 1;
-		}
-		cache.comm_k_sparse_end[k] = sparse_end;
-	}
-
-	// Build input-grouped commutator table (CSR format, grouped by input index a)
-	std::vector<uint32_t> a_counts(m, 0);
-	for (uint64_t i = 0; i < m; ++i) {
-		for (uint64_t j = i + 1; j < m; ++j) {
-			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
-				a_counts[i]++;
-				a_counts[j]++;
-			}
-		}
-	}
-
-	cache.comm_a_ptr.resize(m + 1);
-	cache.comm_a_ptr[0] = 0;
-	for (uint64_t a = 0; a < m; ++a) {
-		cache.comm_a_ptr[a + 1] = cache.comm_a_ptr[a] + a_counts[a];
-	}
-
-	uint32_t a_nnz = cache.comm_a_ptr[m];
-	cache.comm_a_k.resize(a_nnz);
-	cache.comm_a_partner.resize(a_nnz);
-	cache.comm_a_signed_c.resize(a_nnz);
-
-	std::fill(a_counts.begin(), a_counts.end(), 0);
-	for (uint64_t i = 0; i < m; ++i) {
-		for (uint64_t j = i + 1; j < m; ++j) {
-			for (const auto& [k, c] : cache.commutator_table[i * m + j]) {
-				uint32_t pos_i = cache.comm_a_ptr[i] + a_counts[i]++;
-				cache.comm_a_k[pos_i] = static_cast<uint32_t>(k);
-				cache.comm_a_partner[pos_i] = static_cast<uint32_t>(j);
-				cache.comm_a_signed_c[pos_i] = c;
-
-				uint32_t pos_j = cache.comm_a_ptr[j] + a_counts[j]++;
-				cache.comm_a_k[pos_j] = static_cast<uint32_t>(k);
-				cache.comm_a_partner[pos_j] = static_cast<uint32_t>(i);
-				cache.comm_a_signed_c[pos_j] = -c;
-			}
-		}
-	}
-
-	// Build pair-grouped commutator table (CSR format, grouped by (i,j) pair)
-	// Iterate non-empty pairs and flatten their (k, c) entries
-	cache.n_pairs = 0;
-	for (uint64_t i = 0; i < m; ++i) {
-		for (uint64_t j = i + 1; j < m; ++j) {
-			if (!cache.commutator_table[i * m + j].empty()) {
-				cache.n_pairs++;
-			}
-		}
-	}
-
-	cache.comm_ij_i.resize(cache.n_pairs);
-	cache.comm_ij_j.resize(cache.n_pairs);
-	cache.comm_ij_ptr.resize(cache.n_pairs + 1);
-	cache.comm_ij_k.resize(nnz);
-	cache.comm_ij_c.resize(nnz);
-
-	uint32_t pair_idx = 0;
-	uint32_t entry_idx = 0;
-	cache.comm_ij_ptr[0] = 0;
-	for (uint64_t i = 0; i < m; ++i) {
-		for (uint64_t j = i + 1; j < m; ++j) {
-			const auto& entries = cache.commutator_table[i * m + j];
-			if (entries.empty()) continue;
-			cache.comm_ij_i[pair_idx] = static_cast<uint32_t>(i);
-			cache.comm_ij_j[pair_idx] = static_cast<uint32_t>(j);
-			for (const auto& [k, c] : entries) {
-				cache.comm_ij_k[entry_idx] = static_cast<uint32_t>(k);
-				cache.comm_ij_c[entry_idx] = static_cast<double>(c);
-				entry_idx++;
-			}
-			cache.comm_ij_ptr[pair_idx + 1] = entry_idx;
-			pair_idx++;
-		}
-	}
+	build_commutator_views(cache);
 }
 
 inline void build_linear_bch_ranges(BchCache& cache) {
 	const uint64_t m2 = cache.bch_coefficients.size();
+	if (cache.coordinate_weights.size() != cache.m)
+		throw std::runtime_error("BCH coordinate weight count mismatch");
+	if (cache.linear_input_mask.size() != cache.m)
+		throw std::runtime_error("BCH linear input mask size mismatch");
 
 	std::vector<uint64_t> min_degree(m2, 1);
 	std::vector<uint64_t> max_degree(m2, cache.degree);
-	if (m2 > 1) max_degree[1] = 1;
+	if (m2 > 1) {
+		min_degree[1] = cache.degree + 1;
+		max_degree[1] = 0;
+		for (uint32_t index : cache.linear_input_idx) {
+			if (index >= cache.m)
+				throw std::out_of_range("BCH linear input index out of range");
+			min_degree[1] = std::min(min_degree[1], cache.coordinate_weights[index]);
+			max_degree[1] = std::max(max_degree[1], cache.coordinate_weights[index]);
+		}
+		if (cache.linear_input_idx.empty())
+			min_degree[1] = 1;
+	}
 	for (uint64_t w = 2; w < m2; ++w) {
 		const uint64_t lf = cache.bch_left_factor[w];
 		const uint64_t rf = cache.bch_right_factor[w];
@@ -466,20 +475,36 @@ inline void build_linear_bch_ranges(BchCache& cache) {
 	}
 	cache.linear_range.resize(m2);
 	for (uint64_t w = 0; w < m2; ++w) {
-		const uint64_t begin = min_degree[w] == 1
-			? 0 : ::log_sig_length(cache.dimension, min_degree[w] - 1);
-		cache.linear_range[w] = {begin, ::log_sig_length(cache.dimension, max_degree[w])};
+		const auto begin = std::lower_bound(
+			cache.coordinate_weights.begin(), cache.coordinate_weights.end(), min_degree[w]);
+		const auto end = std::upper_bound(
+			cache.coordinate_weights.begin(), cache.coordinate_weights.end(), max_degree[w]);
+		cache.linear_range[w] = {
+			static_cast<uint64_t>(begin - cache.coordinate_weights.begin()),
+			static_cast<uint64_t>(end - cache.coordinate_weights.begin())
+		};
 	}
 
 	cache.linear_pair_ptr.assign(m2 + 1, 0);
+	cache.linear_pair_idx.clear();
 	for (uint64_t w = 2; w < m2; ++w) {
 		const auto [lf_begin, lf_end] = cache.linear_range[cache.bch_left_factor[w]];
 		const auto [rf_begin, rf_end] = cache.linear_range[cache.bch_right_factor[w]];
 		for (uint32_t p = 0; p < cache.n_pairs; ++p) {
 			const uint32_t i = cache.comm_ij_i[p];
 			const uint32_t j = cache.comm_ij_j[p];
-			const bool forward_pair = i >= lf_begin && i < lf_end && j >= rf_begin && j < rf_end;
-			const bool reverse_pair = j >= lf_begin && j < lf_end && i >= rf_begin && i < rf_end;
+			const uint64_t lf = cache.bch_left_factor[w];
+			const uint64_t rf = cache.bch_right_factor[w];
+			const bool i_lf = lf == 1 ? cache.linear_input_mask[i]
+				: i >= lf_begin && i < lf_end;
+			const bool j_lf = lf == 1 ? cache.linear_input_mask[j]
+				: j >= lf_begin && j < lf_end;
+			const bool i_rf = rf == 1 ? cache.linear_input_mask[i]
+				: i >= rf_begin && i < rf_end;
+			const bool j_rf = rf == 1 ? cache.linear_input_mask[j]
+				: j >= rf_begin && j < rf_end;
+			const bool forward_pair = i_lf && j_rf;
+			const bool reverse_pair = j_lf && i_rf;
 			if (forward_pair || reverse_pair)
 				cache.linear_pair_idx.push_back(p);
 		}
@@ -490,9 +515,50 @@ inline void build_linear_bch_ranges(BchCache& cache) {
 		&& cache.linear_pair_idx.size() <= dense_pair_count - dense_pair_count / 3;
 }
 
+inline void configure_linear_bch_input(
+	BchCache& cache,
+	std::vector<uint32_t> input_indices,
+	bool prefix
+) {
+	cache.linear_input_idx = std::move(input_indices);
+	cache.linear_input_prefix = prefix;
+	cache.linear_input_mask.assign(cache.m, 0);
+	for (uint32_t index : cache.linear_input_idx) {
+		if (index >= cache.m)
+			throw std::out_of_range("BCH linear input index out of range");
+		cache.linear_input_mask[index] = 1;
+	}
+
+	cache.comm_k_sparse_ptr.assign(cache.m + 1, 0);
+	cache.comm_k_sparse_idx.clear();
+	for (uint64_t k = 0; k < cache.m; ++k) {
+		for (uint32_t idx = cache.comm_k_ptr[k]; idx < cache.comm_k_ptr[k + 1]; ++idx) {
+			if (cache.linear_input_mask[cache.comm_k_i[idx]]
+				|| cache.linear_input_mask[cache.comm_k_j[idx]])
+				cache.comm_k_sparse_idx.push_back(idx);
+		}
+		cache.comm_k_sparse_ptr[k + 1] = cache.comm_k_sparse_idx.size();
+	}
+	build_linear_bch_ranges(cache);
+}
+
 // ========================================================================
 // BCH cache management
 // ========================================================================
+
+inline void build_bch_formula_data(BchCache& cache, bool use_disk) {
+	const BchHardcodedData* hc = get_hardcoded_bch_data(cache.degree);
+	if (hc) {
+		cache.bch_coefficients.assign(hc->coefficients, hc->coefficients + hc->size);
+		cache.bch_left_factor.assign(hc->left_factor, hc->left_factor + hc->size);
+		cache.bch_right_factor.assign(hc->right_factor, hc->right_factor + hc->size);
+		return;
+	}
+	prepare_basis_cache(2, cache.degree, 2, use_disk);
+	cache.bch_coefficients = compute_bch_coefficients(cache.degree);
+	compute_factorization_indices(
+		2, cache.degree, cache.bch_left_factor, cache.bch_right_factor);
+}
 
 inline void prepare_bch_cache(
 	uint64_t dimension, uint64_t degree, bool use_disk = false
@@ -512,25 +578,17 @@ inline void prepare_bch_cache(
 	cache->degree = degree;
 	cache->m = ::log_sig_length(dimension, degree);
 
-	// Use hardcoded BCH data when available (degrees 1-12)
-	const BchHardcodedData* hc = get_hardcoded_bch_data(degree);
-	if (hc) {
-		cache->bch_coefficients.assign(hc->coefficients, hc->coefficients + hc->size);
-		cache->bch_left_factor.assign(hc->left_factor, hc->left_factor + hc->size);
-		cache->bch_right_factor.assign(hc->right_factor, hc->right_factor + hc->size);
-	}
-	else {
-		// Fallback for degree > 12: compute at runtime
-		// This requires a 2-letter basis cache for the Lyndon projection
-		if (dimension != 2)
-			prepare_basis_cache(2, degree, 2, use_disk);
-		cache->bch_coefficients = compute_bch_coefficients(degree);
-		compute_factorization_indices(2, degree, cache->bch_left_factor, cache->bch_right_factor);
-	}
+	build_bch_formula_data(*cache, use_disk);
 
 	// Build commutator table for d-letter Lyndon basis
 	build_commutator_table(*cache);
-	build_linear_bch_ranges(*cache);
+	const uint64_t linear_input_size = std::min(dimension, cache->m);
+	if (linear_input_size > UINT32_MAX)
+		throw std::overflow_error("BCH linear input is too large");
+	std::vector<uint32_t> linear_input_idx(linear_input_size);
+	for (uint64_t i = 0; i < linear_input_size; ++i)
+		linear_input_idx[i] = static_cast<uint32_t>(i);
+	configure_linear_bch_input(*cache, std::move(linear_input_idx), true);
 
 	std::unique_lock wlock(reg.mu);
 	reg.map.insert_or_assign(key, std::move(cache));
@@ -667,7 +725,14 @@ void bch_combine_linear_impl_(
 	uint64_t m2 = cache.bch_coefficients.size();
 
 	std::memcpy(out, ls1, m * sizeof(T));
-	for (uint64_t i = 0; i < dim; ++i) out[i] += ls2[i];
+	if (cache.linear_input_prefix) {
+		for (uint64_t i = 0; i < dim; ++i)
+			out[i] += ls2[i];
+	}
+	else {
+		for (uint32_t i : cache.linear_input_idx)
+			out[i] += ls2[i];
+	}
 
 	if (m2 <= 2) return;
 
@@ -679,7 +744,6 @@ void bch_combine_linear_impl_(
 	const uint32_t* k_i = cache.comm_k_i.data();
 	const uint32_t* k_j = cache.comm_k_j.data();
 	const double* k_val_d = cache.comm_k_val_d.data();
-	const uint32_t* k_sparse_end = cache.comm_k_sparse_end.data();
 
 	for (uint64_t w = 2; w < m2; ++w) {
 		const uint64_t lf = cache.bch_left_factor[w];
@@ -698,10 +762,24 @@ void bch_combine_linear_impl_(
 
 		for (uint64_t k = begin; k < end; ++k) {
 			T sum = T(0);
-			const uint32_t start = k_ptr[k];
-			const uint32_t end = sparse ? k_sparse_end[k] : k_ptr[k + 1];
-			for (uint32_t idx = start; idx < end; ++idx) {
-				sum += static_cast<T>(k_val_d[idx]) * (v1[k_i[idx]] * v2[k_j[idx]] - v1[k_j[idx]] * v2[k_i[idx]]);
+			if (sparse && !cache.linear_input_prefix) {
+				for (uint32_t q = cache.comm_k_sparse_ptr[k];
+					q < cache.comm_k_sparse_ptr[k + 1]; ++q) {
+					const uint32_t idx = cache.comm_k_sparse_idx[q];
+					sum += static_cast<T>(k_val_d[idx])
+						* (v1[k_i[idx]] * v2[k_j[idx]]
+							- v1[k_j[idx]] * v2[k_i[idx]]);
+				}
+			}
+			else {
+				const uint32_t start = k_ptr[k];
+				const uint32_t stop = sparse
+					? cache.comm_k_sparse_end[k] : k_ptr[k + 1];
+				for (uint32_t idx = start; idx < stop; ++idx) {
+					sum += static_cast<T>(k_val_d[idx])
+						* (v1[k_i[idx]] * v2[k_j[idx]]
+							- v1[k_j[idx]] * v2[k_i[idx]]);
+				}
 			}
 			result[k] = sum;
 			if (c_w != T(0)) out[k] += c_w * sum;

--- a/siglib/cpsig/cp_branched_log_signature.cpp
+++ b/siglib/cpsig/cp_branched_log_signature.cpp
@@ -17,6 +17,8 @@
 #include "cpsig.h"
 #include "cp_branched_log_signature.h"
 #include "cp_branched_cache.h"
+#include "cp_branched_signature.h"
+#include "cp_bch.h"
 #include "log_sig_cache.h"
 #include "words.h"
 #include "../shared/branched_log_cache.h"
@@ -40,6 +42,52 @@ BranchedLogBasisCacheRegistry_& branched_log_basis_cache_registry_() {
 	return registry;
 }
 
+struct MkwWordData_ {
+	std::vector<word> flat_words;
+	std::unordered_map<word, uint64_t, WordHash> flat_idx;
+	std::vector<word> lyndon_words;
+	std::vector<uint64_t> lyndon_idx;
+	std::vector<uint64_t> lyndon_weights;
+	std::vector<uint32_t> letter_log_idx;
+	std::vector<uint64_t> letter_basis_idx;
+};
+
+MkwWordData_ build_mkw_word_data_(const BranchedSigCache& cache) {
+	MkwWordData_ data;
+	const uint64_t lyndon_count = compute_branched_log_sig_length(
+		cache.dimension, cache.max_nodes, true);
+	data.flat_words.resize(cache.total_length);
+	data.flat_idx.reserve(cache.total_length);
+	data.lyndon_words.reserve(lyndon_count);
+	data.lyndon_idx.reserve(lyndon_count);
+	data.lyndon_weights.reserve(lyndon_count);
+	for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+		const uint64_t start = cache.basis_forest_offsets[basis_idx];
+		const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
+		word forest(
+			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
+			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
+		data.flat_words[basis_idx + 1] = forest;
+		if (is_lyndon(forest)) {
+			if (forest.size() == 1) {
+				data.letter_log_idx.push_back(
+					static_cast<uint32_t>(data.lyndon_words.size()));
+				data.letter_basis_idx.push_back(basis_idx);
+			}
+			data.lyndon_words.push_back(forest);
+			data.lyndon_idx.push_back(basis_idx + 1);
+			data.lyndon_weights.push_back(
+				cache.node_labels_offsets[basis_idx + 1]
+				- cache.node_labels_offsets[basis_idx]);
+		}
+	}
+	if (data.lyndon_idx.size() != lyndon_count)
+		throw std::runtime_error("MKW Lyndon cache length mismatch");
+	for (uint64_t i = 0; i < data.flat_words.size(); ++i)
+		data.flat_idx[data.flat_words[i]] = i;
+	return data;
+}
+
 void clear_branched_log_basis_cache_() {
 	auto& registry = branched_log_basis_cache_registry_();
 	std::unique_lock lock(registry.mu);
@@ -53,30 +101,26 @@ std::unique_ptr<BasisCache> build_branched_log_basis_cache_(
 	if (!cache.planar)
 		throw std::invalid_argument("compressed branched log signatures require planar=True");
 
-	std::vector<word> lyndon_words;
 	std::vector<uint64_t> lyndon_idx;
-	std::vector<word> flat_words;
 	const uint64_t lyndon_count = compute_branched_log_sig_length(
 		cache.dimension, cache.max_nodes, true);
 	lyndon_idx.reserve(lyndon_count);
-	if (method == 2) {
-		lyndon_words.reserve(lyndon_count);
-		flat_words.resize(cache.total_length);
-	}
-	for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
-		const uint64_t start = cache.basis_forest_offsets[basis_idx];
-		const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
-		word forest(
-			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
-			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
-		if (method == 2)
-			flat_words[basis_idx + 1] = forest;
-		if (is_lyndon(forest)) {
-			if (method == 2)
-				lyndon_words.push_back(forest);
-			lyndon_idx.push_back(basis_idx + 1);
+	MkwWordData_ word_data;
+	if (method == 2)
+		word_data = build_mkw_word_data_(cache);
+	else {
+		for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+			const uint64_t start = cache.basis_forest_offsets[basis_idx];
+			const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
+			word forest(
+				cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
+				cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
+			if (is_lyndon(forest))
+				lyndon_idx.push_back(basis_idx + 1);
 		}
 	}
+	if (method == 2)
+		lyndon_idx = word_data.lyndon_idx;
 
 	if (lyndon_idx.size() != lyndon_count)
 		throw std::runtime_error("MKW Lyndon cache length mismatch");
@@ -85,19 +129,16 @@ std::unique_ptr<BasisCache> build_branched_log_basis_cache_(
 	SparseIntMatrix inverse;
 	SparseIntMatrix inverse_transpose;
 	if (method == 2) {
-		std::unordered_map<word, uint64_t, WordHash> flat_idx;
-		flat_idx.reserve(flat_words.size());
-		for (uint64_t i = 0; i < flat_words.size(); ++i)
-			flat_idx[flat_words[i]] = i;
 		lyndon_proj_matrix_from_words(
 			projection,
-			lyndon_words,
+			word_data.lyndon_words,
 			cache.total_length,
-			[&flat_idx](const word& w) {
-				return flat_idx.at(w);
+			[&word_data](const word& w) {
+				return word_data.flat_idx.at(w);
 			},
-			[&flat_words, &flat_idx](uint64_t i, uint64_t j, uint64_t) {
-				return flat_idx.at(concatenate_words(flat_words.at(i), flat_words.at(j)));
+			[&word_data](uint64_t i, uint64_t j, uint64_t) {
+				return word_data.flat_idx.at(concatenate_words(
+					word_data.flat_words.at(i), word_data.flat_words.at(j)));
 			});
 		projection.inverse(inverse);
 		inverse.transpose(inverse_transpose);
@@ -117,17 +158,16 @@ void prepare_branched_log_basis_cache_(
 ) {
 	if (method < 1)
 		return;
-	if (method == 3)
-		throw std::invalid_argument("branched log signature method 3 is not implemented");
-	if (method > 2)
-		throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+	if (method > 3)
+		throw std::invalid_argument("branched log signature method must be 0, 1, 2, or 3");
+	const int basis_method = std::min(method, 2);
 
 	const std::pair<uint64_t, uint64_t> key(cache.dimension, cache.max_nodes);
 	auto& registry = branched_log_basis_cache_registry_();
 	{
 		std::shared_lock lock(registry.mu);
 		auto it = registry.map.find(key);
-		if (it != registry.map.end() && it->second->method >= method)
+		if (it != registry.map.end() && it->second->method >= basis_method)
 			return;
 	}
 
@@ -142,14 +182,14 @@ void prepare_branched_log_basis_cache_(
 	if (file && file->exists()) {
 		auto basis = std::make_unique<BasisCache>();
 		file->read(basis);
-		if (basis->method >= method) {
+		if (basis->method >= basis_method) {
 			std::unique_lock lock(registry.mu);
 			registry.map.insert_or_assign(key, std::move(basis));
 			return;
 		}
 	}
 
-	auto basis = build_branched_log_basis_cache_(cache, method);
+	auto basis = build_branched_log_basis_cache_(cache, basis_method);
 	if (file)
 		file->write(basis);
 
@@ -188,6 +228,242 @@ const BasisCache& get_branched_log_basis_cache_(
 	std::unique_lock lock(registry.mu);
 	auto inserted = registry.map.insert_or_assign(key, std::move(basis));
 	return *(inserted.first->second);
+}
+
+struct BranchedBchCache_ {
+	BchCache bch;
+	std::vector<double> linear_coefficients;
+	std::vector<uint64_t> linear_basis_idx;
+};
+
+template<std::floating_point T, bool ScalarTerm>
+void branched_sig_to_log_sig_compressed_(
+	const T* bsig,
+	T* out,
+	uint64_t batch_size,
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method,
+	int n_jobs
+);
+
+struct BranchedBchCacheRegistry_ {
+	std::unordered_map<
+		std::pair<uint64_t, uint64_t>,
+		std::unique_ptr<BranchedBchCache_>,
+		PairHash
+	> map;
+	std::shared_mutex mu;
+};
+
+BranchedBchCacheRegistry_& branched_bch_cache_registry_() {
+	static BranchedBchCacheRegistry_ registry;
+	return registry;
+}
+
+TensorElem mkw_tensor_product_(
+	const TensorElem& left,
+	const TensorElem& right,
+	const MkwWordData_& words
+) {
+	TensorElem result;
+	for (const auto& [left_idx, left_coefficient] : left) {
+		for (const auto& [right_idx, right_coefficient] : right) {
+			const word product = concatenate_words(
+				words.flat_words.at(left_idx), words.flat_words.at(right_idx));
+			const auto flat = words.flat_idx.find(product);
+			if (flat != words.flat_idx.end())
+				result[flat->second] += left_coefficient * right_coefficient;
+		}
+	}
+	remove_zero_entries(result);
+	return result;
+}
+
+using MkwInfinitesimalProduct_ = std::unordered_map<
+	std::pair<uint64_t, uint64_t>, TensorElem, PairHash>;
+
+MkwInfinitesimalProduct_ build_mkw_infinitesimal_product_(
+	const BranchedSigCache& cache
+) {
+	MkwInfinitesimalProduct_ product;
+	for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+		uint64_t pos = cache.coproduct_offsets[basis_idx];
+		const uint64_t end = cache.coproduct_offsets[basis_idx + 1];
+		while (pos < end) {
+			const uint64_t forest_size = cache.coproduct_data[pos++];
+			const uint64_t trunk = cache.coproduct_data[pos++];
+			if (forest_size == 1) {
+				const uint64_t branch = cache.coproduct_data[pos++];
+				product[{ branch, trunk }][basis_idx + 1] += 1;
+			} else {
+				pos += forest_size;
+			}
+		}
+	}
+	return product;
+}
+
+TensorElem mkw_infinitesimal_product_(
+	const TensorElem& left,
+	const TensorElem& right,
+	const MkwInfinitesimalProduct_& product
+) {
+	TensorElem result;
+	for (const auto& [left_idx, left_coefficient] : left) {
+		for (const auto& [right_idx, right_coefficient] : right) {
+			const auto found = product.find({ left_idx, right_idx });
+			if (found == product.end())
+				continue;
+			for (const auto& [out_idx, coefficient] : found->second) {
+				result[out_idx] += left_coefficient
+					* right_coefficient * coefficient;
+			}
+		}
+	}
+	remove_zero_entries(result);
+	return result;
+}
+
+std::unique_ptr<BranchedBchCache_> build_branched_bch_cache_(
+	const BranchedSigCache& branched_cache,
+	bool use_disk
+) {
+	const BasisCache& basis = get_branched_log_basis_cache_(
+		branched_cache.dimension, branched_cache.max_nodes, 2);
+	MkwWordData_ words = build_mkw_word_data_(branched_cache);
+	const uint64_t m = words.lyndon_words.size();
+	if (m > UINT32_MAX)
+		throw std::overflow_error("MKW BCH basis is too large");
+
+	auto result = std::make_unique<BranchedBchCache_>();
+	BchCache& bch = result->bch;
+	bch.dimension = branched_cache.dimension;
+	bch.degree = branched_cache.max_nodes;
+	bch.m = m;
+	bch.coordinate_weights = words.lyndon_weights;
+	result->linear_basis_idx.resize(m);
+	for (uint64_t i = 0; i < m; ++i)
+		result->linear_basis_idx[i] = basis.lyndon_idx[i] - 1;
+
+	std::unordered_set<word, WordHash> lyndon_set(
+		words.lyndon_words.begin(), words.lyndon_words.end());
+	std::unordered_map<word, uint64_t, WordHash> lyndon_map;
+	lyndon_map.reserve(m);
+	for (uint64_t i = 0; i < m; ++i)
+		lyndon_map[words.lyndon_words[i]] = i;
+	bch.left_factor.assign(m, UINT64_MAX);
+	bch.right_factor.assign(m, UINT64_MAX);
+	for (uint64_t i = 0; i < m; ++i) {
+		if (words.lyndon_words[i].size() <= 1)
+			continue;
+		auto [left, right] = standard_factorization(words.lyndon_words[i], lyndon_set);
+		bch.left_factor[i] = lyndon_map.at(left);
+		bch.right_factor[i] = lyndon_map.at(right);
+	}
+
+	std::vector<TensorElem> tensor_reps(m);
+	for (uint64_t i = 0; i < m; ++i) {
+		if (words.lyndon_words[i].size() == 1) {
+			tensor_reps[i] = { { words.flat_idx.at(words.lyndon_words[i]), 1 } };
+			continue;
+		}
+		TensorElem left_right = mkw_tensor_product_(
+			tensor_reps[bch.left_factor[i]], tensor_reps[bch.right_factor[i]], words);
+		TensorElem right_left = mkw_tensor_product_(
+			tensor_reps[bch.right_factor[i]], tensor_reps[bch.left_factor[i]], words);
+		for (const auto& [index, coefficient] : right_left)
+			left_right[index] -= coefficient;
+		remove_zero_entries(left_right);
+		tensor_reps[i] = std::move(left_right);
+	}
+
+	const MkwInfinitesimalProduct_ infinitesimal_product
+		= build_mkw_infinitesimal_product_(branched_cache);
+	bch.commutator_table.resize(m * m);
+	std::vector<double> coordinates(m, 0.0);
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			const uint64_t weight = bch.coordinate_weights[i] + bch.coordinate_weights[j];
+			if (weight > bch.degree)
+				continue;
+			TensorElem commutator = mkw_infinitesimal_product_(
+				tensor_reps[i], tensor_reps[j], infinitesimal_product);
+			TensorElem reverse = mkw_infinitesimal_product_(
+				tensor_reps[j], tensor_reps[i], infinitesimal_product);
+			for (const auto& [index, coefficient] : reverse)
+				commutator[index] -= coefficient;
+			std::fill(coordinates.begin(), coordinates.end(), 0.0);
+			for (uint64_t k = 0; k < m; ++k) {
+				if (bch.coordinate_weights[k] != weight)
+					continue;
+				const auto entry = commutator.find(basis.lyndon_idx[k]);
+				if (entry != commutator.end())
+					coordinates[k] = static_cast<double>(entry->second);
+			}
+			basis.inv_proj_mat.mul_vec_inplace_lower(coordinates.data());
+			SparseVec& entry = bch.commutator_table[i * m + j];
+			for (uint64_t k = 0; k < m; ++k) {
+				const int coefficient = static_cast<int>(std::round(coordinates[k]));
+				if (coefficient != 0)
+					entry.push_back({ k, coefficient });
+			}
+		}
+	}
+
+	build_commutator_views(bch);
+	build_bch_formula_data(bch, use_disk);
+
+	prepare_branched_log_sig_cache(branched_cache);
+	std::vector<double> unit_increment(branched_cache.dimension, 1.0);
+	std::vector<double> linear_sig(branched_cache.total_length);
+	result->linear_coefficients.resize(m);
+	linear_branched_sig_(
+		unit_increment.data(), linear_sig.data(), branched_cache);
+	branched_sig_to_log_sig_compressed_<double, true>(
+		linear_sig.data(), result->linear_coefficients.data(), 1,
+		branched_cache.dimension, branched_cache.max_nodes, 2, 1);
+	std::vector<uint32_t> linear_input_idx;
+	linear_input_idx.reserve(m);
+	for (uint64_t i = 0; i < m; ++i) {
+		if (result->linear_coefficients[i] != 0.0)
+			linear_input_idx.push_back(static_cast<uint32_t>(i));
+	}
+	configure_linear_bch_input(bch, std::move(linear_input_idx), false);
+	return result;
+}
+
+void prepare_branched_bch_cache_(const BranchedSigCache& cache, bool use_disk) {
+	const std::pair<uint64_t, uint64_t> key(cache.dimension, cache.max_nodes);
+	auto& registry = branched_bch_cache_registry_();
+	{
+		std::shared_lock lock(registry.mu);
+		if (registry.map.find(key) != registry.map.end())
+			return;
+	}
+	auto bch = build_branched_bch_cache_(cache, use_disk);
+	std::unique_lock lock(registry.mu);
+	registry.map.try_emplace(key, std::move(bch));
+}
+
+const BranchedBchCache_& get_branched_bch_cache_(
+	uint64_t dimension,
+	uint64_t max_nodes
+) {
+	const std::pair<uint64_t, uint64_t> key(dimension, max_nodes);
+	auto& registry = branched_bch_cache_registry_();
+	std::shared_lock lock(registry.mu);
+	const auto found = registry.map.find(key);
+	if (found == registry.map.end())
+		throw cache_not_found_error(
+			"MKW BCH cache not found - call prepare_branched_log_sig with method=3 first");
+	return *found->second;
+}
+
+void clear_branched_bch_cache_() {
+	auto& registry = branched_bch_cache_registry_();
+	std::unique_lock lock(registry.mu);
+	registry.map.clear();
 }
 
 std::unordered_map<
@@ -840,6 +1116,232 @@ void branched_sig_to_log_sig_backprop_compressed_(
 	}
 	spawn_batch_threads(batch_size, n_jobs, work_range);
 }
+
+template<std::floating_point T>
+void linear_mkw_log_sig_(
+	const T* increment,
+	T* out,
+	const BranchedSigCache& branched_cache,
+	const BranchedBchCache_& branched_bch
+) {
+	const BchCache& bch = branched_bch.bch;
+	std::fill(out, out + bch.m, T(0));
+	for (uint32_t coordinate : bch.linear_input_idx) {
+		const uint64_t basis_idx = branched_bch.linear_basis_idx[coordinate];
+		T value = static_cast<T>(
+			branched_bch.linear_coefficients[coordinate]);
+		for (uint64_t j = branched_cache.node_labels_offsets[basis_idx];
+			j < branched_cache.node_labels_offsets[basis_idx + 1]; ++j)
+			value *= increment[branched_cache.node_labels_data[j]];
+		out[coordinate] = value;
+	}
+}
+
+template<std::floating_point T>
+void linear_mkw_log_sig_backprop_(
+	const T* derivs,
+	const T* increment,
+	T* increment_derivs,
+	const BranchedSigCache& branched_cache,
+	const BranchedBchCache_& branched_bch
+) {
+	std::fill(
+		increment_derivs,
+		increment_derivs + branched_cache.dimension,
+		T(0));
+	for (uint32_t coordinate : branched_bch.bch.linear_input_idx) {
+		const uint64_t basis_idx = branched_bch.linear_basis_idx[coordinate];
+		const T base = derivs[coordinate]
+			* static_cast<T>(branched_bch.linear_coefficients[coordinate]);
+		const uint64_t start = branched_cache.node_labels_offsets[basis_idx];
+		const uint64_t end = branched_cache.node_labels_offsets[basis_idx + 1];
+		T prefix = T(1);
+		for (uint64_t j = start; j < end; ++j) {
+			T suffix = T(1);
+			for (uint64_t k = j + 1; k < end; ++k)
+				suffix *= increment[branched_cache.node_labels_data[k]];
+			increment_derivs[branched_cache.node_labels_data[j]]
+				+= base * prefix * suffix;
+			prefix *= increment[branched_cache.node_labels_data[j]];
+		}
+	}
+}
+
+template<std::floating_point T>
+void branched_log_sig_from_path_(
+	const T* path,
+	T* out,
+	uint64_t batch_size,
+	uint64_t length,
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int n_jobs
+) {
+	if (length == 0)
+		throw std::invalid_argument("branched_log_sig method 3 received an empty path");
+	const BranchedSigCache& branched_cache = get_branched_sig_cache(
+		dimension, max_nodes, true);
+	const BranchedBchCache_& branched_bch = get_branched_bch_cache_(
+		dimension, max_nodes);
+	const BchCache& bch = branched_bch.bch;
+	if (bch.m == 0)
+		return;
+	const uint64_t path_stride = length * dimension;
+	const uint64_t m2 = bch.bch_coefficients.size();
+
+	auto work_range = [&](uint64_t start, uint64_t end) {
+		std::vector<T> increment(dimension);
+		std::vector<T> segment(bch.m);
+		std::vector<T> temporary(bch.m);
+		std::vector<T> memo(m2 * bch.m);
+		for (uint64_t row = start; row < end; ++row) {
+			const T* path_row = path + row * path_stride;
+			T* out_row = out + row * bch.m;
+			if (length == 1) {
+				std::fill(out_row, out_row + bch.m, T(0));
+				continue;
+			}
+			for (uint64_t k = 0; k < dimension; ++k)
+				increment[k] = path_row[dimension + k] - path_row[k];
+			linear_mkw_log_sig_(
+				increment.data(), out_row, branched_cache, branched_bch);
+			T* accumulator = out_row;
+			T* target = temporary.data();
+			for (uint64_t segment_idx = 1; segment_idx + 1 < length; ++segment_idx) {
+				const T* left = path_row + segment_idx * dimension;
+				const T* right = left + dimension;
+				for (uint64_t k = 0; k < dimension; ++k)
+					increment[k] = right[k] - left[k];
+				linear_mkw_log_sig_(
+					increment.data(), segment.data(), branched_cache, branched_bch);
+				std::swap(accumulator, target);
+				bch_combine_linear_impl_<T>(
+					target, segment.data(), accumulator, bch, memo.data());
+			}
+			if (accumulator != out_row)
+				std::copy_n(accumulator, bch.m, out_row);
+		}
+	};
+	if (batch_size == 0 || n_jobs == 1 || batch_size == 1) {
+		work_range(0, batch_size);
+		return;
+	}
+	spawn_batch_threads(batch_size, n_jobs, work_range);
+}
+
+template<std::floating_point T>
+void branched_log_sig_from_path_backprop_(
+	const T* derivs,
+	T* path_derivs,
+	const T* path,
+	uint64_t batch_size,
+	uint64_t length,
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int n_jobs
+) {
+	if (length == 0)
+		throw std::invalid_argument("branched_log_sig method 3 received an empty path");
+	const BranchedSigCache& branched_cache = get_branched_sig_cache(
+		dimension, max_nodes, true);
+	const BranchedBchCache_& branched_bch = get_branched_bch_cache_(
+		dimension, max_nodes);
+	const BchCache& bch = branched_bch.bch;
+	const uint64_t path_stride = length * dimension;
+	if (bch.m == 0) {
+		std::fill(path_derivs, path_derivs + batch_size * path_stride, T(0));
+		return;
+	}
+	const uint64_t m2 = bch.bch_coefficients.size();
+	const uint64_t workspace_size = 7 * bch.m + 2 * m2 * bch.m;
+
+	auto work_range = [&](uint64_t start, uint64_t end) {
+		std::vector<T> workspace(workspace_size);
+		std::vector<T> increment(dimension);
+		std::vector<T> increment_derivs(dimension);
+		T* current = workspace.data();
+		T* previous = current + bch.m;
+		T* segment = previous + bch.m;
+		T* negative_segment = segment + bch.m;
+		T* bch_workspace = negative_segment + bch.m;
+		T* accumulated_derivs = bch_workspace + 2 * m2 * bch.m;
+		T* left_derivs = accumulated_derivs + bch.m;
+		T* segment_derivs = left_derivs + bch.m;
+		for (uint64_t row = start; row < end; ++row) {
+			const T* path_row = path + row * path_stride;
+			T* path_derivs_row = path_derivs + row * path_stride;
+			std::fill(path_derivs_row, path_derivs_row + path_stride, T(0));
+			if (length == 1)
+				continue;
+
+			for (uint64_t k = 0; k < dimension; ++k)
+				increment[k] = path_row[dimension + k] - path_row[k];
+			linear_mkw_log_sig_(
+				increment.data(), current, branched_cache, branched_bch);
+			const uint64_t num_segments = length - 1;
+			for (uint64_t segment_idx = 1; segment_idx < num_segments; ++segment_idx) {
+				const T* left = path_row + segment_idx * dimension;
+				const T* right = left + dimension;
+				for (uint64_t k = 0; k < dimension; ++k)
+					increment[k] = right[k] - left[k];
+				linear_mkw_log_sig_(
+					increment.data(), segment, branched_cache, branched_bch);
+				bch_combine_linear_impl_<T>(
+					current, segment, previous, bch, bch_workspace);
+				std::swap(current, previous);
+			}
+			std::copy_n(derivs + row * bch.m, bch.m, accumulated_derivs);
+
+			for (uint64_t segment_idx = num_segments - 1;
+				segment_idx >= 1; --segment_idx) {
+				const T* left = path_row + segment_idx * dimension;
+				const T* right = left + dimension;
+				for (uint64_t k = 0; k < dimension; ++k)
+					increment[k] = right[k] - left[k];
+				linear_mkw_log_sig_(
+					increment.data(), segment, branched_cache, branched_bch);
+				for (uint64_t k = 0; k < bch.m; ++k)
+					negative_segment[k] = -segment[k];
+				bch_combine_linear_impl_<T>(
+					current, negative_segment, previous, bch, bch_workspace);
+				if (bch.prune_linear_backprop)
+					bch_combine_backprop_impl_<T, true, true>(
+						accumulated_derivs, left_derivs, segment_derivs,
+						previous, segment, bch, bch_workspace);
+				else
+					bch_combine_backprop_impl_<T, true, false>(
+						accumulated_derivs, left_derivs, segment_derivs,
+						previous, segment, bch, bch_workspace);
+				linear_mkw_log_sig_backprop_(
+					segment_derivs, increment.data(), increment_derivs.data(),
+					branched_cache, branched_bch);
+				for (uint64_t k = 0; k < dimension; ++k) {
+					path_derivs_row[(segment_idx + 1) * dimension + k]
+						+= increment_derivs[k];
+					path_derivs_row[segment_idx * dimension + k]
+						-= increment_derivs[k];
+				}
+				std::copy_n(left_derivs, bch.m, accumulated_derivs);
+				std::swap(current, previous);
+			}
+
+			for (uint64_t k = 0; k < dimension; ++k)
+				increment[k] = path_row[dimension + k] - path_row[k];
+			linear_mkw_log_sig_backprop_(
+				accumulated_derivs, increment.data(), increment_derivs.data(),
+				branched_cache, branched_bch);
+			for (uint64_t k = 0; k < dimension; ++k) {
+				path_derivs_row[dimension + k] += increment_derivs[k];
+				path_derivs_row[k] -= increment_derivs[k];
+			}
+		}
+	};
+	if (batch_size == 0 || n_jobs == 1 || batch_size == 1) {
+		work_range(0, batch_size);
+		return;
+	}
+	spawn_batch_threads(batch_size, n_jobs, work_range);
+}
 }  // namespace
 
 
@@ -879,6 +1381,7 @@ void prepare_branched_log_sig_cache(const BranchedSigCache& cache) {
 
 
 void clear_branched_log_sig_cache() {
+	clear_branched_bch_cache_();
 	clear_branched_log_basis_cache_();
 	{
 		std::unique_lock lock(branched_log_forest_cache_mu_);
@@ -902,9 +1405,10 @@ void branched_sig_to_log_sig_(
 	bool scalar_term
 ) {
 	if (method == 3)
-		throw std::invalid_argument("branched log signature method 3 is not implemented");
+		throw std::invalid_argument(
+			"method=3 is not supported in branched_sig_to_log_sig; use branched_log_sig instead");
 	if (method < 0 || method > 2)
-		throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+		throw std::invalid_argument("branched log signature method must be 0, 1, 2, or 3");
 	if (method != 0 && !planar)
 		throw std::invalid_argument("compressed branched log signatures require planar=True");
 	if (method == 0) {
@@ -939,9 +1443,10 @@ void branched_sig_to_log_sig_backprop_(
 	bool scalar_term
 ) {
 	if (method == 3)
-		throw std::invalid_argument("branched log signature method 3 is not implemented");
+		throw std::invalid_argument(
+			"method=3 is not supported in branched_sig_to_log_sig_backprop");
 	if (method < 0 || method > 2)
-		throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+		throw std::invalid_argument("branched log signature method must be 0, 1, 2, or 3");
 	if (method != 0 && !planar)
 		throw std::invalid_argument("compressed branched log signatures require planar=True");
 	if (method == 0) {
@@ -969,16 +1474,18 @@ extern "C" {
 		uint64_t dimension, uint64_t max_nodes, int method, bool use_disk, bool planar
 	) noexcept {
 		SAFE_CALL(
-			if (method == 3)
-				throw std::invalid_argument("branched log signature method 3 is not implemented");
-			if (method < 0 || method > 2)
-				throw std::invalid_argument("branched log signature method must be 0, 1, or 2");
+			if (method < 0 || method > 3)
+				throw std::invalid_argument(
+					"branched log signature method must be 0, 1, 2, or 3");
 			if (method != 0 && !planar)
 				throw std::invalid_argument("compressed branched log signatures require planar=True");
 			prepare_branched_sig_cache(dimension, max_nodes, use_disk, planar);
 			const auto& cache = get_branched_sig_cache(dimension, max_nodes, planar);
-			prepare_branched_log_sig_cache(cache);
-			prepare_branched_log_basis_cache_(cache, method, use_disk)
+			if (method != 3)
+				prepare_branched_log_sig_cache(cache);
+			prepare_branched_log_basis_cache_(cache, method, use_disk);
+			if (method == 3)
+				prepare_branched_bch_cache_(cache, use_disk)
 		);
 	}
 
@@ -996,6 +1503,26 @@ extern "C" {
 
 	CPSIG_API int branched_sig_to_log_sig_backprop_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, int n_jobs, bool planar, bool scalar_term) noexcept {
 		SAFE_CALL(branched_sig_to_log_sig_backprop_<double>(bsig, derivs, out, batch_size, dimension, max_nodes, method, n_jobs, planar, scalar_term));
+	}
+
+	CPSIG_API int branched_log_sig_from_path_f(const float* path, float* out, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
+		SAFE_CALL(branched_log_sig_from_path_<float>(
+			path, out, batch_size, length, dimension, max_nodes, n_jobs));
+	}
+
+	CPSIG_API int branched_log_sig_from_path_d(const double* path, double* out, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
+		SAFE_CALL(branched_log_sig_from_path_<double>(
+			path, out, batch_size, length, dimension, max_nodes, n_jobs));
+	}
+
+	CPSIG_API int branched_log_sig_from_path_backprop_f(const float* derivs, float* path_derivs, const float* path, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
+		SAFE_CALL(branched_log_sig_from_path_backprop_<float>(
+			derivs, path_derivs, path, batch_size, length, dimension, max_nodes, n_jobs));
+	}
+
+	CPSIG_API int branched_log_sig_from_path_backprop_d(const double* derivs, double* path_derivs, const double* path, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs) noexcept {
+		SAFE_CALL(branched_log_sig_from_path_backprop_<double>(
+			derivs, path_derivs, path, batch_size, length, dimension, max_nodes, n_jobs));
 	}
 
 }

--- a/siglib/cpsig/cpsig.h
+++ b/siglib/cpsig/cpsig.h
@@ -701,7 +701,7 @@ extern "C" {
 	/** @addtogroup branched_sig_functions
 	* @{
 	*/
-	/** @brief Prepares the branched-signature and derived branched-log caches. */
+	/** @brief Prepares branched-log caches for methods 0, 1, 2, or 3. */
 	[[nodiscard]] CPSIG_API int prepare_branched_log_sig(uint64_t dimension, uint64_t max_nodes, int method, bool use_disk = false, bool planar = false) noexcept;
 
 	[[nodiscard]] CPSIG_API int branched_sig_combine_f(const float* bsig1, const float* bsig2, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
@@ -712,7 +712,8 @@ extern "C" {
 	*
 	* Method 0 returns the expanded decorated-tree or ordered-forest basis and
 	* preserves the scalar-term convention. Methods 1 and 2 return scalar-free
-	* compressed MKW coordinates and require planar=true.
+	* compressed MKW coordinates and require planar=true. Method 3 is available
+	* only through branched_log_sig_from_path_f and branched_log_sig_from_path_d.
 	*/
 	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	/** @brief */
@@ -727,6 +728,16 @@ extern "C" {
 	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_backprop_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	/** @brief */
 	[[nodiscard]] CPSIG_API int branched_sig_to_log_sig_backprop_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method = 0, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
+
+	/** @brief Computes method 3 for a planar MKW path directly using BCH. */
+	[[nodiscard]] CPSIG_API int branched_log_sig_from_path_f(const float* path, float* out, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
+	/** @copydoc branched_log_sig_from_path_f */
+	[[nodiscard]] CPSIG_API int branched_log_sig_from_path_d(const double* path, double* out, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
+
+	/** @brief Backpropagation through the direct planar MKW BCH computation. */
+	[[nodiscard]] CPSIG_API int branched_log_sig_from_path_backprop_f(const float* derivs, float* path_derivs, const float* path, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
+	/** @copydoc branched_log_sig_from_path_backprop_f */
+	[[nodiscard]] CPSIG_API int branched_log_sig_from_path_backprop_d(const double* derivs, double* path_derivs, const double* path, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1) noexcept;
 
 	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_f(const float* bsig1, const float* bsig2, const float* derivs, float* out1, float* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;
 	[[nodiscard]] CPSIG_API int branched_sig_combine_backprop_d(const double* bsig1, const double* bsig2, const double* derivs, double* out1, double* out2, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int n_jobs = 1, bool planar = false, bool scalar_term = true) noexcept;

--- a/siglib/cpsig_unit_testing/cp_test_branched.cpp
+++ b/siglib/cpsig_unit_testing/cp_test_branched.cpp
@@ -241,3 +241,64 @@
             EXPECT_NEAR(reconstructed, method_one[row], 1e-12);
         }
     }
+
+    TEST(branchedLogSigMethodsTest, BchForwardAndBackward) {
+        const uint64_t dimension = 2;
+        const uint64_t max_nodes = 3;
+        const uint64_t length = 4;
+        ASSERT_EQ(prepare_branched_log_sig(
+            dimension, max_nodes, 2, false, true), 0);
+        ASSERT_EQ(prepare_branched_log_sig(
+            dimension, max_nodes, 3, false, true), 0);
+
+        const uint64_t bsig_len = branched_sig_length(
+            dimension, max_nodes, true);
+        const uint64_t logsig_len = branched_log_sig_length(
+            dimension, max_nodes, true);
+        std::vector<double> path = {
+            0., 0., 0.2, -0.3, 0.7, 0.4, 0.5, 0.8
+        };
+        std::vector<double> bsig(bsig_len);
+        std::vector<double> expected(logsig_len);
+        std::vector<double> actual(logsig_len);
+        ASSERT_EQ(branched_sig_d(
+            path.data(), bsig.data(), 1, dimension, length, max_nodes,
+            1, false, false, 1., true, true), 0);
+        ASSERT_EQ(branched_sig_to_log_sig_d(
+            bsig.data(), expected.data(), 1, dimension, max_nodes,
+            2, 1, true, true), 0);
+        ASSERT_EQ(branched_log_sig_from_path_d(
+            path.data(), actual.data(), 1, length, dimension,
+            max_nodes, 1), 0);
+        for (uint64_t i = 0; i < logsig_len; ++i)
+            EXPECT_NEAR(actual[i], expected[i], 1e-12);
+
+        std::vector<double> cotangent(logsig_len);
+        for (uint64_t i = 0; i < logsig_len; ++i)
+            cotangent[i] = 0.1 + static_cast<double>(i) / logsig_len;
+        std::vector<double> path_derivs(path.size());
+        ASSERT_EQ(branched_log_sig_from_path_backprop_d(
+            cotangent.data(), path_derivs.data(), path.data(), 1,
+            length, dimension, max_nodes, 1), 0);
+
+        const double eps = 1e-6;
+        std::vector<double> plus(logsig_len);
+        std::vector<double> minus(logsig_len);
+        for (uint64_t i = 0; i < path.size(); ++i) {
+            path[i] += eps;
+            ASSERT_EQ(branched_log_sig_from_path_d(
+                path.data(), plus.data(), 1, length, dimension,
+                max_nodes, 1), 0);
+            path[i] -= 2. * eps;
+            ASSERT_EQ(branched_log_sig_from_path_d(
+                path.data(), minus.data(), 1, length, dimension,
+                max_nodes, 1), 0);
+            path[i] += eps;
+            double numerical = 0.;
+            for (uint64_t j = 0; j < logsig_len; ++j) {
+                numerical += cotangent[j]
+                    * (plus[j] - minus[j]) / (2. * eps);
+            }
+            EXPECT_NEAR(path_derivs[i], numerical, 1e-8);
+        }
+    }

--- a/siglib/cusig/cu_branched_signature.cu
+++ b/siglib/cusig/cu_branched_signature.cu
@@ -398,6 +398,22 @@ static void prepare_branched_sig_gpu_cache_(
 		*host_cache = std::move(c);
 }
 
+static void prepare_branched_log_sig_gpu_cache_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	bool planar,
+	bool use_disk
+) {
+	if (is_cuda_branched_log_sig_gpu_cache_prepared_(
+		dimension, max_nodes, planar))
+		return;
+
+	BranchedSigCache host_cache;
+	prepare_branched_sig_gpu_cache_(
+		dimension, max_nodes, planar, use_disk, &host_cache);
+	prepare_cuda_branched_log_sig_gpu_cache_(host_cache);
+}
+
 static const BranchedSigCacheGPU& get_gpu_cache(
 	uint64_t dimension,
 	uint64_t max_nodes,
@@ -2200,15 +2216,8 @@ extern "C" {
 	CUSIG_API int prepare_branched_log_sig_cuda(
 		uint64_t dimension, uint64_t max_nodes, bool planar, bool use_disk
 	) noexcept {
-		CUSIG_SAFE_CALL(
-			if (!is_cuda_branched_log_sig_gpu_cache_prepared_(
-				dimension, max_nodes, planar)) {
-				BranchedSigCache host_cache;
-				prepare_branched_sig_gpu_cache_(
-					dimension, max_nodes, planar, use_disk, &host_cache);
-				prepare_cuda_branched_log_sig_gpu_cache_(host_cache);
-			}
-		);
+		CUSIG_SAFE_CALL(prepare_branched_log_sig_gpu_cache_(
+			dimension, max_nodes, planar, use_disk));
 	}
 
 	CUSIG_API int prepare_branched_sig_coef_cuda(const uint64_t* tree_data, uint64_t tree_data_len, uint64_t data_dimension, uint64_t dimension, uint64_t max_nodes, bool planar, bool use_disk) noexcept {

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -332,6 +332,9 @@ struct CpuFns<float> {
     static constexpr auto bsig_to_log_sig = branched_sig_to_log_sig_f;
     static constexpr auto bsig_to_log_sig_backprop = branched_sig_to_log_sig_backprop_f;
 
+    static constexpr auto branched_log_sig_from_path = branched_log_sig_from_path_f;
+    static constexpr auto branched_log_sig_from_path_backprop = branched_log_sig_from_path_backprop_f;
+
     static constexpr auto log_sig_from_path = log_sig_from_path_f;
     static constexpr auto log_sig_from_path_backprop = log_sig_from_path_backprop_f;
 
@@ -375,6 +378,9 @@ struct CpuFns<double> {
 
     static constexpr auto bsig_to_log_sig = branched_sig_to_log_sig_d;
     static constexpr auto bsig_to_log_sig_backprop = branched_sig_to_log_sig_backprop_d;
+
+    static constexpr auto branched_log_sig_from_path = branched_log_sig_from_path_d;
+    static constexpr auto branched_log_sig_from_path_backprop = branched_log_sig_from_path_backprop_d;
 
     static constexpr auto log_sig_from_path = log_sig_from_path_d;
     static constexpr auto log_sig_from_path_backprop = log_sig_from_path_backprop_d;
@@ -2946,7 +2952,7 @@ ffi::Error BranchedSigToLogSigCuda(
     ffi::AnyBuffer bsig, ffi::Result<ffi::AnyBuffer> out) {
     if (method != 0) {
         return InvalidArgument(
-            "MKW branched log signature methods 1 and 2 are only implemented on CPU");
+            "MKW branched log signature methods 1, 2 and 3 are only implemented on CPU");
     }
     if (auto msg = ValidateFloatBuffer("bsig", bsig); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
@@ -2960,12 +2966,92 @@ ffi::Error BranchedSigToLogSigBackpropCuda(
     ffi::AnyBuffer bsig, ffi::AnyBuffer cotangent, ffi::Result<ffi::AnyBuffer> out) {
     if (method != 0) {
         return InvalidArgument(
-            "MKW branched log signature methods 1 and 2 are only implemented on CPU");
+            "MKW branched log signature methods 1, 2 and 3 are only implemented on CPU");
     }
     if (auto msg = ValidateSameFloatDtype("bsig", bsig, "cotangent", cotangent); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
         return BranchedSigToLogSigBackpropCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, bsig, cotangent, out);
     });
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// branched_log_sig_from_path (method=3)
+// ---------------------------------------------------------------------------
+
+template <typename T>
+ffi::Error BranchedLogSigFromPathCpuImpl(
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+    ffi::AnyBuffer& path, ffi::Result<ffi::AnyBuffer>& out
+) {
+    PathSpec spec;
+    if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
+    const std::uint64_t batch = spec.is_batch ? spec.batch_size : 1;
+    const int err_code = CpuFns<T>::branched_log_sig_from_path(
+        BufferData<T>(path), BufferData<T>(out), batch, spec.length,
+        static_cast<std::uint64_t>(dimension),
+        static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs));
+    if (err_code != 0) return NativeCallError("branched_log_sig_from_path", err_code);
+    return ffi::Error::Success();
+}
+
+template <typename T>
+ffi::Error BranchedLogSigFromPathBackpropCpuImpl(
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+    ffi::AnyBuffer& cotangent, ffi::AnyBuffer& path,
+    ffi::Result<ffi::AnyBuffer>& out
+) {
+    PathSpec spec;
+    if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
+    const std::uint64_t batch = spec.is_batch ? spec.batch_size : 1;
+    const int err_code = CpuFns<T>::branched_log_sig_from_path_backprop(
+        BufferData<T>(cotangent), BufferData<T>(out), BufferData<T>(path),
+        batch, spec.length, static_cast<std::uint64_t>(dimension),
+        static_cast<std::uint64_t>(max_nodes), static_cast<int>(n_jobs));
+    if (err_code != 0) return NativeCallError(
+        "branched_log_sig_from_path_backprop", err_code);
+    return ffi::Error::Success();
+}
+
+ffi::Error BranchedLogSigFromPathCpu(
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+    ffi::AnyBuffer path, ffi::Result<ffi::AnyBuffer> out
+) {
+    if (auto msg = ValidateFloatBuffer("path", path); !msg.empty()) return InvalidArgument(msg);
+    return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
+        return BranchedLogSigFromPathCpuImpl<T>(
+            dimension, max_nodes, n_jobs, path, out);
+    });
+}
+
+ffi::Error BranchedLogSigFromPathBackpropCpu(
+    std::int64_t dimension, std::int64_t max_nodes, std::int64_t n_jobs,
+    ffi::AnyBuffer cotangent, ffi::AnyBuffer path,
+    ffi::Result<ffi::AnyBuffer> out
+) {
+    if (auto msg = ValidateSameFloatDtype(
+        "cotangent", cotangent, "path", path); !msg.empty()) return InvalidArgument(msg);
+    return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
+        return BranchedLogSigFromPathBackpropCpuImpl<T>(
+            dimension, max_nodes, n_jobs, cotangent, path, out);
+    });
+}
+
+#ifdef PYSIGLIB_JAX_WITH_CUDA
+ffi::Error BranchedLogSigFromPathCuda(
+    cudaStream_t, std::int64_t, std::int64_t, std::int64_t,
+    ffi::AnyBuffer, ffi::Result<ffi::AnyBuffer>
+) {
+    return InvalidArgument(
+        "MKW branched log signature method 3 is only implemented on CPU");
+}
+
+ffi::Error BranchedLogSigFromPathBackpropCuda(
+    cudaStream_t, std::int64_t, std::int64_t, std::int64_t,
+    ffi::AnyBuffer, ffi::AnyBuffer, ffi::Result<ffi::AnyBuffer>
+) {
+    return InvalidArgument(
+        "MKW branched log signature method 3 is only implemented on CPU");
 }
 #endif
 
@@ -3207,6 +3293,30 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedSigToLogSigBackpropCuda, BranchedS
         .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
         .Attr<std::int64_t>("method").Attr<std::int64_t>("n_jobs").Attr<bool>("planar")
         .Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
+#endif
+
+// branched_log_sig_from_path (method=3)
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedLogSigFromPathCpu, BranchedLogSigFromPathCpu,
+    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("n_jobs").Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedLogSigFromPathBackpropCpu, BranchedLogSigFromPathBackpropCpu,
+    ffi::Ffi::Bind().Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("n_jobs").Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>()
+        .Ret<ffi::AnyBuffer>());
+
+#ifdef PYSIGLIB_JAX_WITH_CUDA
+XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedLogSigFromPathCuda, BranchedLogSigFromPathCuda,
+    ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
+        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("n_jobs").Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(PySigLibBranchedLogSigFromPathBackpropCuda, BranchedLogSigFromPathBackpropCuda,
+    ffi::Ffi::Bind().Ctx<ffi::PlatformStream<cudaStream_t>>()
+        .Attr<std::int64_t>("dimension").Attr<std::int64_t>("max_nodes")
+        .Attr<std::int64_t>("n_jobs").Arg<ffi::AnyBuffer>().Arg<ffi::AnyBuffer>()
+        .Ret<ffi::AnyBuffer>());
 #endif
 
 // log_sig_from_path (method=3)

--- a/siglib/test_app/dll_funcs.cpp
+++ b/siglib/test_app/dll_funcs.cpp
@@ -229,6 +229,8 @@ branched_sig_coef_cuda_d_fn branched_sig_coef_cuda_d = nullptr;
 branched_sig_coef_backprop_cuda_d_fn branched_sig_coef_backprop_cuda_d = nullptr;
 branched_sig_to_log_sig_d_fn branched_sig_to_log_sig_d = nullptr;
 branched_sig_to_log_sig_cuda_d_fn branched_sig_to_log_sig_cuda_d = nullptr;
+branched_log_sig_from_path_d_fn branched_log_sig_from_path_d = nullptr;
+branched_log_sig_from_path_backprop_d_fn branched_log_sig_from_path_backprop_d = nullptr;
 
 
 void get_cpsig_fn_ptrs()
@@ -262,6 +264,8 @@ void get_cpsig_fn_ptrs()
     GET_FN(branched_sig_length, cpsig);
     GET_FN(branched_sig_d, cpsig);
     GET_FN(branched_sig_to_log_sig_d, cpsig);
+    GET_FN(branched_log_sig_from_path_d, cpsig);
+    GET_FN(branched_log_sig_from_path_backprop_d, cpsig);
 }
 
 void get_cusig_fn_ptrs()

--- a/siglib/test_app/dll_funcs.h
+++ b/siglib/test_app/dll_funcs.h
@@ -186,6 +186,8 @@ using branched_sig_coef_cuda_d_fn = int(CDECL_*)(const double*, double*, const u
 using branched_sig_coef_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t, uint64_t, uint64_t);
 using branched_sig_to_log_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, int, int, bool, bool);
 using branched_sig_to_log_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, bool, bool);
+using branched_log_sig_from_path_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int);
+using branched_log_sig_from_path_backprop_d_fn = int(CDECL_*)(const double*, double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, int);
 
 extern prepare_branched_sig_fn prepare_branched_sig;
 extern prepare_branched_log_sig_fn prepare_branched_log_sig;
@@ -199,6 +201,8 @@ extern branched_sig_coef_cuda_d_fn branched_sig_coef_cuda_d;
 extern branched_sig_coef_backprop_cuda_d_fn branched_sig_coef_backprop_cuda_d;
 extern branched_sig_to_log_sig_d_fn branched_sig_to_log_sig_d;
 extern branched_sig_to_log_sig_cuda_d_fn branched_sig_to_log_sig_cuda_d;
+extern branched_log_sig_from_path_d_fn branched_log_sig_from_path_d;
+extern branched_log_sig_from_path_backprop_d_fn branched_log_sig_from_path_backprop_d;
 
 #if defined(_WIN32)
 #define GET_FN_PTR ::GetProcAddress

--- a/tests/test_branched_log_sig_methods.py
+++ b/tests/test_branched_log_sig_methods.py
@@ -1,0 +1,664 @@
+# Copyright 2026 Daniil Shmelev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========================================================================
+
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+import pysiglib
+import pysiglib.torch_api as torch_api
+from pysiglib.branched_log_sig_backprop import (
+    _branched_log_sig_from_path_backprop,
+)
+
+
+def _path():
+    return np.array(
+        [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4], [0.5, 0.8]],
+        dtype=np.float64,
+    )
+
+
+def _planar_forest_words(dimension, degree):
+    basis = pysiglib.trees(dimension, degree, planar=True)[1:]
+    letters = {
+        forest[0]: letter
+        for letter, forest in enumerate(
+            basis_element for basis_element in basis if len(basis_element) == 1
+        )
+    }
+    words = [tuple(letters[tree] for tree in forest) for forest in basis]
+    return basis, words
+
+
+def _lyndon_projection(words):
+    lyndon_words = [word for word in words if pysiglib.is_lyndon(word)]
+    basis_index = {word: idx for idx, word in enumerate(lyndon_words)}
+    expansions = []
+    for word in lyndon_words:
+        if len(word) == 1:
+            expansions.append({word: 1})
+            continue
+
+        suffix = next(
+            word[start:]
+            for start in range(1, len(word))
+            if word[start:] in basis_index
+        )
+        prefix = word[:-len(suffix)]
+        expansion = {}
+        for left, left_coeff in expansions[basis_index[prefix]].items():
+            for right, right_coeff in expansions[basis_index[suffix]].items():
+                coeff = left_coeff * right_coeff
+                expansion[left + right] = expansion.get(left + right, 0) + coeff
+                expansion[right + left] = expansion.get(right + left, 0) - coeff
+        expansions.append(expansion)
+
+    projection = np.zeros((len(lyndon_words), len(lyndon_words)), dtype=np.int64)
+    for col, expansion in enumerate(expansions):
+        for word, coeff in expansion.items():
+            row = basis_index.get(word)
+            if row is not None:
+                projection[row, col] += coeff
+    return lyndon_words, projection
+
+
+def test_branched_log_sig_length_matches_output_shapes():
+    dimension, degree = 2, 3
+    path = _path()
+
+    assert pysiglib.branched_log_sig_length(
+        dimension, degree) == pysiglib.branched_sig_length(dimension, degree)
+
+    expanded_len = pysiglib.branched_sig_length(
+        dimension, degree, planar=True)
+    compressed_len = pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True)
+    assert 0 < compressed_len < expanded_len
+
+    for method in (1, 2, 3):
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, method, planar=True, device="cpu")
+        out = pysiglib.branched_log_sig(
+            path, degree, planar=True, method=method)
+        assert out.shape == (compressed_len,)
+
+
+@pytest.mark.parametrize("dimension,degree", [(0, 3), (2, 0)])
+def test_compressed_zero_length_cases(dimension, degree):
+    assert pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True) == 0
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cpu")
+
+    bsig = np.ones(1, dtype=np.float64)
+    output = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=2)
+    gradient = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, np.empty(0, dtype=np.float64), dimension, degree,
+        planar=True, method=2)
+
+    assert output.shape == (0,)
+    np.testing.assert_array_equal(gradient, np.zeros_like(bsig))
+
+
+def test_branched_log_sig_length_reports_overflow():
+    with pytest.raises(ValueError, match="integer overflow"):
+        pysiglib.branched_log_sig_length(255, 7, planar=True)
+
+
+@pytest.mark.parametrize("planar", [False, True])
+def test_branched_log_sig_length_rejects_large_dimension_at_zero_degree(planar):
+    with pytest.raises(ValueError, match="dimension must be <= 255"):
+        pysiglib.branched_log_sig_length(256, 0, planar=planar)
+
+
+@pytest.mark.parametrize("dimension,degree", [(1, 1), (1, 3), (2, 3), (3, 2)])
+def test_planar_branched_log_sig_length_matches_explicit_lyndon_count(
+        dimension, degree):
+    _, words = _planar_forest_words(dimension, degree)
+    expected = sum(pysiglib.is_lyndon(word) for word in words)
+    assert pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True) == expected
+
+
+@pytest.mark.parametrize("scalar_term", [False, True])
+def test_method_one_is_expanded_lyndon_coordinate_slice(scalar_term):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 1, planar=True, device="cpu")
+    bsig = pysiglib.branched_sig(
+        _path(), degree, planar=True, scalar_term=scalar_term)
+    expanded = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=0)
+    compressed = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=1)
+
+    _, words = _planar_forest_words(dimension, degree)
+    offset = 1 if scalar_term else 0
+    expected = np.asarray([
+        expanded[idx + offset]
+        for idx, word in enumerate(words)
+        if pysiglib.is_lyndon(word)
+    ])
+    np.testing.assert_allclose(compressed, expected, atol=1e-13, rtol=1e-13)
+
+
+def test_method_two_uses_standard_lyndon_bracket_basis():
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cpu")
+    bsig = pysiglib.branched_sig(_path(), degree, planar=True)
+    method_one = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=1)
+    method_two = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=2)
+
+    _, words = _planar_forest_words(dimension, degree)
+    _, projection = _lyndon_projection(words)
+    np.testing.assert_allclose(
+        projection @ method_two, method_one, atol=1e-13, rtol=1e-13)
+
+
+def test_planar_default_is_method_one_and_is_scalar_free():
+    dimension, degree = 2, 3
+    path = _path()
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 1, planar=True, device="cpu")
+
+    expected = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=1)
+    default = pysiglib.branched_log_sig(path, degree, planar=True)
+    with_scalar_input = pysiglib.branched_log_sig(
+        path, degree, planar=True, scalar_term=True)
+
+    np.testing.assert_allclose(default, expected, atol=1e-14)
+    np.testing.assert_allclose(with_scalar_input, expected, atol=1e-14)
+    assert default.shape[-1] == pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True)
+
+
+def test_nonplanar_default_is_method_zero():
+    dimension, degree = 2, 3
+    path = _path()
+    pysiglib.prepare_branched_log_sig(dimension, degree, 0, device="cpu")
+
+    expected = pysiglib.branched_log_sig(path, degree, method=0)
+    actual = pysiglib.branched_log_sig(path, degree)
+    np.testing.assert_allclose(actual, expected, atol=1e-14)
+
+
+def test_compressed_cache_preparation_and_clearing():
+    dimension, degree = 2, 3
+    bsig = pysiglib.branched_sig(
+        _path(), degree, planar=True, scalar_term=True)
+    pysiglib.clear_cache()
+
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 1, planar=True, device="cpu")
+    pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=1)
+    with pytest.raises(Exception):
+        pysiglib.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=2)
+
+    pysiglib.clear_cache()
+    with pytest.raises(Exception):
+        pysiglib.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=1)
+
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cpu")
+    pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=1)
+    pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=2)
+
+
+def test_method_three_prepares_method_two_basis_and_clears_with_cache():
+    dimension, degree = 2, 3
+    path = _path()
+    bsig = pysiglib.branched_sig(
+        path, degree, planar=True, scalar_term=True)
+    pysiglib.clear_cache()
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cpu")
+
+    direct = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=3)
+    projected = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=2)
+    np.testing.assert_allclose(direct, projected, atol=2e-12, rtol=2e-12)
+
+    pysiglib.clear_cache()
+    with pytest.raises(Exception, match="cache"):
+        pysiglib.branched_log_sig(
+            path, degree, planar=True, method=3)
+
+
+def test_compressed_cache_disk_round_trip(tmp_path):
+    dimension, degree = 2, 3
+    pysiglib.set_cache_dir(str(tmp_path))
+    pysiglib.clear_cache(use_disk=True)
+    try:
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 2, planar=True, device="cpu", use_disk=True)
+        bsig = pysiglib.branched_sig(
+            _path(), degree, planar=True, scalar_term=True)
+        expected = [
+            pysiglib.branched_sig_to_log_sig(
+                bsig, dimension, degree, planar=True, method=method)
+            for method in (1, 2)
+        ]
+
+        pysiglib.clear_cache(use_disk=False)
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 2, planar=True, device="cpu", use_disk=True)
+        actual = [
+            pysiglib.branched_sig_to_log_sig(
+                bsig, dimension, degree, planar=True, method=method)
+            for method in (1, 2)
+        ]
+        for value, reference in zip(actual, expected):
+            np.testing.assert_allclose(value, reference, atol=1e-14, rtol=1e-14)
+    finally:
+        pysiglib.clear_cache(use_disk=True)
+
+
+def test_method_two_builds_from_legacy_method_zero_planar_disk_cache(tmp_path):
+    dimension, degree = 2, 3
+    pysiglib.set_cache_dir(str(tmp_path))
+    pysiglib.clear_cache(use_disk=True)
+    try:
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 0, planar=True, device="cpu", use_disk=True)
+        cache_dir = tmp_path / "pysiglib_cache"
+        cache_file, = cache_dir.glob("planar_branched_*.bin")
+        assert not list(cache_dir.glob("mkw_lyndon_*.bin"))
+
+        cache_bytes = cache_file.read_bytes()
+        offset = 4 * 8
+        for item_size in (8, 8, 1, 8, 8, 8, 8, 8):
+            count = int.from_bytes(
+                cache_bytes[offset:offset + 8], byteorder=sys.byteorder)
+            offset += 8 + count * item_size
+        cache_file.write_bytes(cache_bytes[:offset])
+
+        pysiglib.clear_cache(use_disk=False)
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 2, planar=True, device="cpu", use_disk=True)
+
+        output = pysiglib.branched_log_sig(
+            _path(), degree, planar=True, method=2)
+        assert output.shape == (
+            pysiglib.branched_log_sig_length(
+                dimension, degree, planar=True),)
+        assert list(cache_dir.glob("mkw_lyndon_*.bin"))
+    finally:
+        pysiglib.clear_cache(use_disk=True)
+
+
+def test_malformed_planar_forest_offsets_rebuild_disk_cache(tmp_path):
+    dimension, degree = 2, 3
+    pysiglib.set_cache_dir(str(tmp_path))
+    pysiglib.clear_cache(use_disk=True)
+    try:
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 0, planar=True, device="cpu", use_disk=True)
+        cache_dir = tmp_path / "pysiglib_cache"
+        cache_file, = cache_dir.glob("planar_branched_*.bin")
+
+        cache_bytes = bytearray(cache_file.read_bytes())
+        offset = 4 * 8
+        for item_size in (8, 8, 1, 8, 8, 8, 8, 8):
+            count = int.from_bytes(
+                cache_bytes[offset:offset + 8], byteorder=sys.byteorder)
+            offset += 8 + count * item_size
+        forest_data_count = int.from_bytes(
+            cache_bytes[offset:offset + 8], byteorder=sys.byteorder)
+        first_forest_offset = offset + 8 + forest_data_count * 8 + 8
+        cache_bytes[first_forest_offset:first_forest_offset + 8] = (
+            1).to_bytes(8, byteorder=sys.byteorder)
+        cache_file.write_bytes(cache_bytes)
+
+        pysiglib.clear_cache(use_disk=False)
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 2, planar=True, device="cpu", use_disk=True)
+
+        repaired_bytes = cache_file.read_bytes()
+        repaired_first_offset = int.from_bytes(
+            repaired_bytes[first_forest_offset:first_forest_offset + 8],
+            byteorder=sys.byteorder,
+        )
+        assert repaired_first_offset == 0
+        output = pysiglib.branched_log_sig(
+            _path(), degree, planar=True, method=2)
+        assert output.shape == (
+            pysiglib.branched_log_sig_length(
+                dimension, degree, planar=True),)
+    finally:
+        pysiglib.clear_cache(use_disk=True)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize(
+    "time_aug,lead_lag", [(True, False), (False, True), (True, True)])
+def test_compressed_augmentation_matches_conversion(method, time_aug, lead_lag):
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, device="cpu")
+    path = _path()
+    bsig = pysiglib.branched_sig(
+        path, degree, planar=True, time_aug=time_aug, lead_lag=lead_lag,
+        scalar_term=True)
+    expected = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, method=method)
+    actual = pysiglib.branched_log_sig(
+        path, degree, planar=True, time_aug=time_aug, lead_lag=lead_lag,
+        scalar_term=True, method=method)
+
+    effective_dimension = (
+        2 * dimension if lead_lag else dimension) + int(time_aug)
+    assert actual.shape == (pysiglib.branched_log_sig_length(
+        effective_dimension, degree, planar=True),)
+    np.testing.assert_allclose(actual, expected, atol=1e-13, rtol=1e-13)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+def test_compressed_correction_matches_conversion(method):
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu")
+    path = _path()
+    correction = np.zeros((path.shape[0] - 1, dimension * dimension))
+    correction[:, 0] = 0.03
+    correction[:, 3] = -0.02
+    bsig = pysiglib.branched_sig(
+        path, degree, planar=True, correction=correction, scalar_term=True)
+    expected = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+    actual = pysiglib.branched_log_sig(
+        path, degree, planar=True, correction=correction,
+        scalar_term=True, method=method)
+    np.testing.assert_allclose(actual, expected, atol=1e-13, rtol=1e-13)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_compressed_batch_dtype_and_empty_batch(method, dtype):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu")
+    paths = np.stack([_path(), 0.7 * _path()]).astype(dtype)
+
+    batch = pysiglib.branched_log_sig(
+        paths, degree, planar=True, method=method)
+    expected = np.stack([
+        pysiglib.branched_log_sig(
+            path.copy(), degree, planar=True, method=method)
+        for path in paths
+    ])
+    np.testing.assert_allclose(
+        batch, expected, atol=1e-5 if dtype == np.float32 else 1e-13)
+    assert batch.dtype == dtype
+
+    input_len = pysiglib.branched_sig_length(
+        dimension, degree, planar=True)
+    empty = np.empty((0, input_len), dtype=dtype)
+    empty_output = pysiglib.branched_sig_to_log_sig(
+        empty, dimension, degree, planar=True, method=method)
+    assert empty_output.shape == (
+        0, pysiglib.branched_log_sig_length(dimension, degree, planar=True))
+    assert empty_output.dtype == dtype
+
+
+@pytest.mark.parametrize("method", [1, 2])
+def test_compressed_backprop_shape_and_cotangent_unchanged(method):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu")
+    bsig = pysiglib.branched_sig(
+        _path(), degree, planar=True, scalar_term=True)
+    cotangent = np.linspace(
+        -0.4,
+        0.7,
+        pysiglib.branched_log_sig_length(dimension, degree, planar=True),
+    ).copy()
+    saved_cotangent = cotangent.copy()
+
+    grad = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, cotangent, dimension, degree, planar=True, method=method)
+
+    assert grad.shape == bsig.shape
+    np.testing.assert_array_equal(cotangent, saved_cotangent)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("scalar_term", [False, True])
+def test_compressed_backprop_matches_directional_finite_difference(
+        method, scalar_term):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu")
+    bsig = pysiglib.branched_sig(
+        _path(), degree, planar=True, scalar_term=scalar_term)
+    rng = np.random.default_rng(7391 + method + int(scalar_term))
+    cotangent = rng.normal(size=pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True))
+    direction = rng.normal(size=bsig.shape)
+    grad = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, cotangent, dimension, degree, planar=True, method=method)
+
+    def objective(value):
+        output = pysiglib.branched_sig_to_log_sig(
+            value, dimension, degree, planar=True, method=method)
+        return np.dot(output, cotangent)
+
+    eps = 1e-6
+    finite_difference = (
+        objective(bsig + eps * direction) - objective(bsig - eps * direction)
+    ) / (2 * eps)
+    np.testing.assert_allclose(
+        np.dot(grad, direction), finite_difference, atol=2e-8, rtol=2e-8)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+def test_torch_compressed_backward_matches_explicit_backprop(method):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu")
+    bsig_np = pysiglib.branched_sig(
+        _path(), degree, planar=True, scalar_term=True)
+    weights_np = np.linspace(
+        -0.4,
+        0.7,
+        pysiglib.branched_log_sig_length(dimension, degree, planar=True),
+    ).copy()
+
+    bsig = torch.tensor(bsig_np, dtype=torch.float64, requires_grad=True)
+    weights = torch.tensor(weights_np, dtype=torch.float64)
+    out = torch_api.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+    (out * weights).sum().backward()
+
+    expected = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig_np, weights_np, dimension, degree, planar=True, method=method)
+    torch.testing.assert_close(
+        bsig.grad, torch.tensor(expected, dtype=torch.float64),
+        atol=1e-10, rtol=1e-10)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+def test_torch_direct_compressed_backward_runs(method):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu")
+    path = torch.tensor(_path(), dtype=torch.float64, requires_grad=True)
+
+    out = torch_api.branched_log_sig(
+        path, degree, planar=True, method=method, scalar_term=True)
+    out.square().sum().backward()
+
+    assert out.shape == (
+        pysiglib.branched_log_sig_length(dimension, degree, planar=True),)
+    assert path.grad is not None
+    assert torch.all(torch.isfinite(path.grad))
+
+
+def test_branched_log_sig_method_validation():
+    path = _path()
+
+    with pytest.raises(TypeError, match="required positional argument"):
+        pysiglib.prepare_branched_log_sig(2, 2)
+    with pytest.raises(TypeError, match="method must be of type int"):
+        pysiglib.prepare_branched_log_sig(2, 2, None)
+    with pytest.raises(ValueError, match="not supported"):
+        pysiglib.branched_sig_to_log_sig(
+            np.ones(pysiglib.branched_sig_length(
+                2, 2, planar=True, scalar_term=True)),
+            2, 2, planar=True, method=3)
+    with pytest.raises(ValueError, match="require planar=True"):
+        pysiglib.branched_log_sig(path, 2, method=1)
+    with pytest.raises(ValueError, match="require planar=True"):
+        pysiglib.prepare_branched_log_sig(2, 2, 1)
+    with pytest.raises(ValueError, match="one of 0, 1, 2 or 3"):
+        pysiglib.branched_log_sig(path, 2, planar=True, method=4)
+    for method in (1, 2, 3):
+        with pytest.raises(NotImplementedError, match="only supported on CPU"):
+            pysiglib.prepare_branched_log_sig(
+                2, 2, method, planar=True, device="cuda")
+
+
+def test_prepare_compressed_device_both_prepares_cpu():
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 1, planar=True, device="both")
+    output = pysiglib.branched_log_sig(
+        _path(), degree, planar=True, method=1)
+    assert output.shape == (
+        pysiglib.branched_log_sig_length(dimension, degree, planar=True),)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("batch", [False, True])
+def test_method_three_matches_method_two(dtype, batch):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cpu")
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cpu")
+    path = _path().astype(dtype)
+    if batch:
+        path = np.stack([path, 0.7 * path])
+
+    expected = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=2)
+    actual = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=3, scalar_term=True)
+    tolerance = 2e-5 if dtype == np.float32 else 2e-12
+    np.testing.assert_allclose(
+        actual, expected, atol=tolerance, rtol=tolerance)
+
+
+@pytest.mark.parametrize(
+    "time_aug,lead_lag", [(True, False), (False, True), (True, True)])
+def test_method_three_augmentation_matches_method_two(time_aug, lead_lag):
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, device="cpu")
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, device="cpu")
+    expected = pysiglib.branched_log_sig(
+        _path(), degree, planar=True, method=2,
+        time_aug=time_aug, lead_lag=lead_lag)
+    actual = pysiglib.branched_log_sig(
+        _path(), degree, planar=True, method=3,
+        time_aug=time_aug, lead_lag=lead_lag)
+    np.testing.assert_allclose(actual, expected, atol=2e-12, rtol=2e-12)
+
+
+def test_method_three_backward_matches_finite_difference_and_preserves_cotangent():
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cpu")
+    path = _path()
+    rng = np.random.default_rng(9345)
+    cotangent = rng.normal(size=pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True))
+    saved_cotangent = cotangent.copy()
+    direction = rng.normal(size=path.shape)
+    gradient = _branched_log_sig_from_path_backprop(
+        cotangent, path, degree)
+
+    def objective(value):
+        result = pysiglib.branched_log_sig(
+            value, degree, planar=True, method=3)
+        return np.dot(result, cotangent)
+
+    eps = 1e-6
+    finite_difference = (
+        objective(path + eps * direction)
+        - objective(path - eps * direction)
+    ) / (2 * eps)
+    np.testing.assert_allclose(
+        np.sum(gradient * direction), finite_difference,
+        atol=2e-8, rtol=2e-8)
+    np.testing.assert_array_equal(cotangent, saved_cotangent)
+
+
+def test_torch_method_three_backward_matches_explicit_backprop():
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cpu")
+    path_np = _path()
+    weights_np = np.linspace(
+        -0.3, 0.8, pysiglib.branched_log_sig_length(
+            dimension, degree, planar=True))
+    path = torch.tensor(path_np, dtype=torch.float64, requires_grad=True)
+    weights = torch.tensor(weights_np, dtype=torch.float64)
+
+    output = torch_api.branched_log_sig(
+        path, degree, planar=True, method=3)
+    (output * weights).sum().backward()
+    expected = _branched_log_sig_from_path_backprop(
+        weights_np, path_np, degree)
+    torch.testing.assert_close(
+        path.grad, torch.tensor(expected), atol=1e-10, rtol=1e-10)
+
+
+def test_method_three_rejects_correction():
+    path = _path()
+    correction = np.zeros((path.shape[0] - 1, path.shape[-1] ** 2))
+    with pytest.raises(ValueError, match="correction is not supported"):
+        pysiglib.branched_log_sig(
+            path, 2, planar=True, method=3, correction=correction)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_compressed_method_rejects_cuda_tensor():
+    dimension, degree = 2, 2
+    length = pysiglib.branched_sig_length(
+        dimension, degree, planar=True, scalar_term=True)
+    bsig = torch.zeros(length, dtype=torch.float64, device="cuda")
+
+    with pytest.raises(NotImplementedError, match="only supported on CPU"):
+        pysiglib.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=1)

--- a/tests/test_branched_sig_coef.py
+++ b/tests/test_branched_sig_coef.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # =========================================================================
 
-import os
-import sys
-from pathlib import Path
-
 import numpy as np
 import pytest
 import torch
@@ -450,16 +446,10 @@ def test_branched_sig_dense_cuda_cache_is_per_device():
 
 
 @skip_no_cuda
-def test_branched_sig_dense_cuda_disk_cache():
-    if sys.platform == "win32":
-        cache_dir = Path(os.environ["LOCALAPPDATA"])
-    elif sys.platform == "darwin":
-        cache_dir = Path.home() / "Library" / "Caches"
-    else:
-        cache_dir = Path.home() / ".cache"
-
+def test_branched_sig_dense_cuda_disk_cache(tmp_path):
+    pysiglib.set_cache_dir(str(tmp_path))
     dimension, degree = 2, 3
-    cache_file = cache_dir / "pysiglib_cache" / "branched_2_3_v3.bin"
+    cache_file = tmp_path / "pysiglib_cache" / "branched_2_3_v3.bin"
     pysiglib.clear_cache(use_disk=True)
     try:
         pysiglib.prepare_branched_sig(
@@ -476,21 +466,15 @@ def test_branched_sig_dense_cuda_disk_cache():
 
 
 @skip_no_cuda
-def test_branched_sig_coef_cuda_disk_cache():
-    if sys.platform == "win32":
-        cache_dir = Path(os.environ["LOCALAPPDATA"])
-    elif sys.platform == "darwin":
-        cache_dir = Path.home() / "Library" / "Caches"
-    else:
-        cache_dir = Path.home() / ".cache"
-
+def test_branched_sig_coef_cuda_disk_cache(tmp_path):
+    pysiglib.set_cache_dir(str(tmp_path))
     dimension, degree = 2, 3
     trees = [pysiglib.trees(dimension, degree)[-1]]
     pysiglib.clear_cache(use_disk=True)
     try:
         pysiglib.prepare_branched_sig_coef(
             dimension, trees, device="cuda", use_disk=True)
-        cache_files = list((cache_dir / "pysiglib_cache").glob(
+        cache_files = list((tmp_path / "pysiglib_cache").glob(
             "branched_coef_*.bin"))
         assert len(cache_files) == 1
 
@@ -503,21 +487,15 @@ def test_branched_sig_coef_cuda_disk_cache():
         pysiglib.clear_cache(use_disk=True)
 
 
-def test_branched_sig_coef_cpu_disk_cache():
-    if sys.platform == "win32":
-        cache_dir = Path(os.environ["LOCALAPPDATA"])
-    elif sys.platform == "darwin":
-        cache_dir = Path.home() / "Library" / "Caches"
-    else:
-        cache_dir = Path.home() / ".cache"
-
+def test_branched_sig_coef_cpu_disk_cache(tmp_path):
+    pysiglib.set_cache_dir(str(tmp_path))
     dimension, degree = 2, 3
     trees = [pysiglib.trees(dimension, degree)[-1]]
     pysiglib.clear_cache(use_disk=True)
     try:
         pysiglib.prepare_branched_sig_coef(
             dimension, trees, device="cpu", use_disk=True)
-        cache_files = list((cache_dir / "pysiglib_cache").glob(
+        cache_files = list((tmp_path / "pysiglib_cache").glob(
             "branched_coef_*.bin"))
         assert len(cache_files) == 1
 

--- a/tests/test_jax_branched_log_sig_methods.py
+++ b/tests/test_jax_branched_log_sig_methods.py
@@ -1,0 +1,290 @@
+# Copyright 2026 Daniil Shmelev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========================================================================
+
+import numpy as np
+import pytest
+
+import pysiglib
+from pysiglib.branched_log_sig_backprop import (
+    _branched_log_sig_from_path_backprop,
+)
+
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+jnp = pytest.importorskip("jax.numpy")
+jax_api = pytest.importorskip("pysiglib.jax_api")
+
+
+pytestmark = pytest.mark.skipif(
+    not pysiglib.BUILT_WITH_JAX_FFI,
+    reason="JAX FFI not built",
+)
+
+
+def _planar_bsig(dimension, degree, *, batch=False, scalar_term=False):
+    rng = np.random.default_rng(20260815)
+    shape = (3, 7, dimension) if batch else (7, dimension)
+    path = np.cumsum(rng.normal(scale=0.2, size=shape), axis=-2)
+    return pysiglib.branched_sig(
+        path, degree, planar=True, scalar_term=scalar_term)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("scalar_term", [False, True])
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_compressed_branched_log_sig_matches_base(
+        method, scalar_term, jitted):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu", use_disk=False)
+    bsig = _planar_bsig(
+        dimension, degree, batch=True, scalar_term=scalar_term)
+    expected = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+
+    def convert(value):
+        return jax_api.branched_sig_to_log_sig(
+            value, dimension, degree, planar=True, method=method)
+
+    fn = jax.jit(convert) if jitted else convert
+    actual = fn(jnp.asarray(bsig, dtype=jnp.float64))
+
+    assert actual.shape == expected.shape
+    assert actual.shape[-1] == pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True)
+    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-10, rtol=1e-10)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("scalar_term", [False, True])
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_compressed_branched_log_sig_grad_matches_base(
+        method, scalar_term, jitted):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu", use_disk=False)
+    bsig = _planar_bsig(
+        dimension, degree, batch=True, scalar_term=scalar_term)
+    out = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+    weights = np.random.default_rng(12345).normal(size=out.shape)
+    expected = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, weights, dimension, degree, planar=True, method=method)
+    weights_jax = jnp.asarray(weights, dtype=jnp.float64)
+
+    def loss(value):
+        result = jax_api.branched_sig_to_log_sig(
+            value, dimension, degree, planar=True, method=method)
+        return jnp.sum(result * weights_jax)
+
+    grad_fn = jax.jit(jax.grad(loss)) if jitted else jax.grad(loss)
+    actual = grad_fn(jnp.asarray(bsig, dtype=jnp.float64))
+
+    assert actual.shape == bsig.shape
+    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-9, rtol=1e-9)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+def test_jax_direct_compressed_branched_log_sig_is_scalar_free(method):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu", use_disk=False)
+    path = np.array(
+        [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]], dtype=np.float64)
+
+    without_scalar = jax_api.branched_log_sig(
+        jnp.asarray(path), degree, planar=True, method=method,
+        scalar_term=False)
+    with_scalar = jax_api.branched_log_sig(
+        jnp.asarray(path), degree, planar=True, method=method,
+        scalar_term=True)
+
+    expected_length = jax_api.branched_log_sig_length(
+        dimension, degree, planar=True)
+    assert without_scalar.shape == (expected_length,)
+    assert with_scalar.shape == (expected_length,)
+    np.testing.assert_allclose(
+        np.asarray(without_scalar), np.asarray(with_scalar), atol=1e-12, rtol=1e-12)
+
+
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_direct_compressed_branched_log_sig_grad_matches_base(
+        method, jitted):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="cpu", use_disk=False)
+    path = np.array(
+        [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]], dtype=np.float64)
+    bsig = pysiglib.branched_sig(
+        path, degree, planar=True, scalar_term=True)
+    blog_sig = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+    weights = np.random.default_rng(6789).normal(size=blog_sig.shape)
+    bsig_grad = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, weights, dimension, degree, planar=True, method=method)
+    expected = pysiglib.branched_sig_backprop(
+        path, bsig, bsig_grad, degree, planar=True)
+    weights_jax = jnp.asarray(weights, dtype=jnp.float64)
+
+    def loss(value):
+        result = jax_api.branched_log_sig(
+            value, degree, planar=True, method=method, scalar_term=True)
+        return jnp.sum(result * weights_jax)
+
+    grad_fn = jax.jit(jax.grad(loss)) if jitted else jax.grad(loss)
+    actual = grad_fn(jnp.asarray(path, dtype=jnp.float64))
+
+    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-9, rtol=1e-9)
+
+
+def test_jax_planar_default_is_method_1():
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 1, planar=True, device="cpu", use_disk=False)
+    bsig = _planar_bsig(dimension, degree)
+    bsig_jax = jnp.asarray(bsig, dtype=jnp.float64)
+
+    default = jax_api.branched_sig_to_log_sig(
+        bsig_jax, dimension, degree, planar=True)
+    explicit = jax_api.branched_sig_to_log_sig(
+        bsig_jax, dimension, degree, planar=True, method=1)
+
+    np.testing.assert_allclose(
+        np.asarray(default), np.asarray(explicit), atol=1e-12, rtol=1e-12)
+
+
+def test_jax_branched_log_sig_method_validation():
+    dimension, degree = 1, 1
+    bsig = jnp.ones(
+        pysiglib.branched_sig_length(
+            dimension, degree, planar=True, scalar_term=True),
+        dtype=jnp.float64,
+    )
+
+    with pytest.raises(ValueError, match="not supported"):
+        jax_api.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=3)
+    with pytest.raises(ValueError, match="require planar=True"):
+        jax_api.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=False, method=1)
+    with pytest.raises(ValueError, match="method must be"):
+        jax_api.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=-1)
+
+
+def test_jax_compressed_branched_log_sig_rejects_gpu_array():
+    gpu_devices = [
+        device for device in jax.devices()
+        if device.platform in ("cuda", "gpu")
+    ]
+    if not gpu_devices:
+        pytest.skip("JAX GPU device unavailable")
+
+    dimension, degree = 1, 1
+    bsig = jax.device_put(
+        jnp.ones(
+            pysiglib.branched_sig_length(
+                dimension, degree, planar=True, scalar_term=True),
+            dtype=jnp.float64,
+        ),
+        gpu_devices[0],
+    )
+    with pytest.raises(NotImplementedError, match="only implemented on CPU"):
+        jax_api.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=1)
+
+
+@pytest.mark.parametrize("jitted", [False, True])
+@pytest.mark.parametrize("batch", [False, True])
+def test_jax_method_three_matches_method_two(jitted, batch):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cpu", use_disk=False)
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cpu", use_disk=False)
+    rng = np.random.default_rng(9124)
+    shape = (3, 5, dimension) if batch else (5, dimension)
+    path = np.cumsum(rng.normal(scale=0.2, size=shape), axis=-2)
+    expected = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=2)
+
+    def compute(value):
+        return jax_api.branched_log_sig(
+            value, degree, planar=True, method=3, scalar_term=True)
+
+    function = jax.jit(compute) if jitted else compute
+    actual = function(jnp.asarray(path, dtype=jnp.float64))
+    np.testing.assert_allclose(
+        np.asarray(actual), expected, atol=2e-10, rtol=2e-10)
+
+
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_method_three_gradient_matches_explicit_backward(jitted):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cpu", use_disk=False)
+    path = np.array(
+        [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]], dtype=np.float64)
+    weights = np.random.default_rng(31415).normal(
+        size=pysiglib.branched_log_sig_length(
+            dimension, degree, planar=True))
+    expected = _branched_log_sig_from_path_backprop(
+        weights, path, degree)
+    weights_jax = jnp.asarray(weights, dtype=jnp.float64)
+
+    def loss(value):
+        result = jax_api.branched_log_sig(
+            value, degree, planar=True, method=3)
+        return jnp.sum(result * weights_jax)
+
+    grad_function = jax.jit(jax.grad(loss)) if jitted else jax.grad(loss)
+    actual = grad_function(jnp.asarray(path, dtype=jnp.float64))
+    np.testing.assert_allclose(
+        np.asarray(actual), expected, atol=2e-10, rtol=2e-10)
+
+
+@pytest.mark.parametrize(
+    "time_aug,lead_lag", [(True, False), (False, True), (True, True)])
+def test_jax_method_three_augmentation_matches_method_two(
+        time_aug, lead_lag):
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, device="cpu", use_disk=False)
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, device="cpu", use_disk=False)
+    path = np.array(
+        [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]], dtype=np.float64)
+    expected = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=2,
+        time_aug=time_aug, lead_lag=lead_lag)
+    actual = jax.jit(lambda value: jax_api.branched_log_sig(
+        value, degree, planar=True, method=3,
+        time_aug=time_aug, lead_lag=lead_lag))(
+            jnp.asarray(path, dtype=jnp.float64))
+    np.testing.assert_allclose(
+        np.asarray(actual), expected, atol=2e-10, rtol=2e-10)
+
+
+def test_jax_method_three_rejects_correction():
+    path = jnp.asarray(
+        [[0.0, 0.0], [0.2, -0.3], [0.7, 0.4]], dtype=jnp.float64)
+    correction = jnp.zeros((path.shape[0] - 1, path.shape[-1] ** 2))
+    with pytest.raises(ValueError, match="correction is not supported"):
+        jax_api.branched_log_sig(
+            path, 2, planar=True, method=3, correction=correction)


### PR DESCRIPTION
Stack layer 3 of 8. This layer adds BCH evaluation methods for MKW branched log signatures, including forward, backpropagation, Torch, JAX, and coefficient behavior. It includes method-parity and differentiation tests. Validation: full Python unit suite, 2678 passed and 11 skipped.