### PR TITLE
Add CUDA MKW branched log signatures

### DIFF
--- a/pysiglib/branched_log_sig.py
+++ b/pysiglib/branched_log_sig.py
@@ -23,6 +23,7 @@ from .error_codes import err_msg
 from .dtypes import (
     CPSIG_BRANCHED_LOG_SIG_FROM_PATH,
     CPSIG_BRANCHED_SIG_TO_LOG_SIG,
+    CUSIG_BRANCHED_LOG_SIG_FROM_PATH_CUDA,
     CUSIG_BRANCHED_SIG_TO_LOG_SIG_CUDA,
 )
 from .data_handlers import (
@@ -91,10 +92,6 @@ def prepare_branched_log_sig(
     check_non_neg(degree, "degree")
     if device not in ("cpu", "cuda", "both"):
         raise ValueError("device must be 'cpu', 'cuda', or 'both'")
-    if method and device == "cuda":
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
-
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
     if device in ("cpu", "both"):
         err_code = CPSIG.prepare_branched_log_sig(
@@ -103,9 +100,13 @@ def prepare_branched_log_sig(
             raise Exception(
                 "Error in pysiglib.prepare_branched_log_sig: " + err_msg(err_code))
 
-    if method == 0 and BUILT_WITH_CUDA and device in ("cuda", "both"):
+    if (method == 3 and degree > 12 and BUILT_WITH_CUDA
+            and device in ("cuda", "both")):
+        raise NotImplementedError(
+            "CUDA MKW BCH method supports degree at most 12")
+    if BUILT_WITH_CUDA and device in ("cuda", "both"):
         err_code = CUSIG.prepare_branched_log_sig_cuda(
-            aug_dimension, degree, planar, use_disk)
+            aug_dimension, degree, method, planar, use_disk)
         if err_code:
             raise Exception(
                 "Error in pysiglib.prepare_branched_log_sig (CUDA): "
@@ -185,7 +186,8 @@ def branched_sig_to_log_sig(
         signatures and method 1 is used for planar signatures. Method 3 is not
         available for conversion from a branched signature.
     :type method: int | None
-    :param n_jobs: Number of threads to run in parallel.
+    :param n_jobs: Number of CPU threads to run in parallel. CUDA execution
+        ignores this value.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
         are used. For n_jobs below -1, (max_threads + 1 + n_jobs) threads are used. For example
         if n_jobs = -2, all threads but one are used.
@@ -221,10 +223,6 @@ def branched_sig_to_log_sig(
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
-    if method and isinstance(bsig, torch.Tensor) and bsig.device.type != "cpu":
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
-
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
     scalar_term = _infer_branched_scalar_term(bsig, aug_dimension, degree, planar=planar)
     bsig_len = branched_sig_length(aug_dimension, degree, planar=planar, scalar_term=scalar_term)
@@ -232,10 +230,6 @@ def branched_sig_to_log_sig(
     out_len = (bsig_len if method == 0 else
                branched_log_sig_length(aug_dimension, degree, planar=True))
     result = SigOutputHandler(data, out_len)
-
-    if method and data.device != "cpu":
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
 
     if data.batch_size == 0:
         return result.data
@@ -247,7 +241,7 @@ def branched_sig_to_log_sig(
     else:
         err_code = CUSIG_BRANCHED_SIG_TO_LOG_SIG_CUDA[data.dtype](
             data.sig_ptr[0], result.data_ptr, data.batch_size,
-            aug_dimension, degree, planar, scalar_term)
+            aug_dimension, degree, method, planar, scalar_term)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_to_log_sig: " + err_msg(err_code))
 
@@ -327,7 +321,8 @@ def branched_log_sig(
         appended time channel contributes no correction. Cannot be combined with
         ``lead_lag=True``.
     :type correction: numpy.ndarray | torch.Tensor | None
-    :param n_jobs: Number of threads to run in parallel.
+    :param n_jobs: Number of CPU threads to run in parallel. CUDA execution
+        ignores this value.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
         are used. For n_jobs below -1, (max_threads + 1 + n_jobs) threads are used. For example
         if n_jobs = -2, all threads but one are used.
@@ -378,43 +373,47 @@ def branched_log_sig(
     """
     method = _resolve_branched_log_sig_method(method, planar)
     if method == 3:
+        input_data = PathInputHandler(
+            path, time_aug, lead_lag, end_time, "path")
+        if input_data.data_length == 0:
+            raise ValueError(
+                "branched_log_sig method 3 received an empty path")
         if correction is not None:
             correction_data = CorrectionInputHandler(
-                correction,
-                PathInputHandler(path, time_aug, lead_lag, end_time, "path"),
-                degree,
+                correction, input_data, degree,
             )
             if correction_data.length != 0:
                 raise ValueError(
                     "correction is not supported with branched_log_sig method=3")
-        if isinstance(path, torch.Tensor) and path.device.type != "cpu":
-            raise NotImplementedError(
-                "MKW branched log signature method 3 is only supported on CPU")
         if time_aug or lead_lag:
             path = transform_path(
                 path, time_aug=time_aug, lead_lag=lead_lag,
                 end_time=end_time, n_jobs=n_jobs)
-        data = PathInputHandler(path, False, False, 1.0, "path")
-        if data.device != "cpu":
+            data = PathInputHandler(path, False, False, 1.0, "path")
+        else:
+            data = input_data
+        if data.device != "cpu" and degree > 12:
             raise NotImplementedError(
-                "MKW branched log signature method 3 is only supported on CPU")
+                "CUDA MKW BCH method supports degree at most 12")
         out_len = branched_log_sig_length(
             data.data_dimension, degree, planar=True)
         result = SigOutputHandler(data, out_len)
         if data.batch_size == 0:
             return result.data
-        err_code = CPSIG_BRANCHED_LOG_SIG_FROM_PATH[data.dtype](
-            data.data_ptr, result.data_ptr, data.batch_size, data.data_length,
-            data.data_dimension, degree, n_jobs)
+        if data.device == "cpu":
+            err_code = CPSIG_BRANCHED_LOG_SIG_FROM_PATH[data.dtype](
+                data.data_ptr, result.data_ptr, data.batch_size,
+                data.data_length, data.data_dimension, degree, n_jobs)
+        else:
+            err_code = CUSIG_BRANCHED_LOG_SIG_FROM_PATH_CUDA[data.dtype](
+                data.data_ptr, result.data_ptr, data.batch_size,
+                data.data_length, data.data_dimension, degree)
         if err_code:
             raise Exception(
                 "Error in pysiglib.branched_log_sig (method=3): "
                 + err_msg(err_code))
         return result.data
 
-    if method and isinstance(path, torch.Tensor) and path.device.type != "cpu":
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
     bsig = branched_sig(
         path, degree, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time,
         planar=planar, scalar_term=scalar_term, correction=correction, n_jobs=n_jobs)

--- a/pysiglib/branched_log_sig_backprop.py
+++ b/pysiglib/branched_log_sig_backprop.py
@@ -23,6 +23,7 @@ from .error_codes import err_msg
 from .dtypes import (
     CPSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP,
     CPSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP,
+    CUSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP_CUDA,
     CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA,
 )
 from .data_handlers import PathInputHandler, PathOutputHandler, SigInputHandler, SigOutputHandler
@@ -78,7 +79,8 @@ def branched_sig_to_log_sig_backprop(
         0 is used for nonplanar signatures and method 1 is used for planar
         signatures.
     :type method: int | None
-    :param n_jobs: Number of threads to run in parallel.
+    :param n_jobs: Number of CPU threads to run in parallel. CUDA execution
+        ignores this value.
         If n_jobs = 1, the computation is run serially. If set to -1, all available threads
         are used. For n_jobs below -1, (max_threads + 1 + n_jobs) threads are used. For example
         if n_jobs = -2, all threads but one are used.
@@ -118,14 +120,6 @@ def branched_sig_to_log_sig_backprop(
     check_non_neg(dimension, "dimension")
     check_non_neg(degree, "degree")
     check_n_jobs(n_jobs)
-    if method and (
-        isinstance(bsig, torch.Tensor) and bsig.device.type != "cpu"
-        or isinstance(blogsig_derivs, torch.Tensor)
-        and blogsig_derivs.device.type != "cpu"
-    ):
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
-
     aug_dimension = aug_dim(dimension, time_aug, lead_lag)
     scalar_term = _infer_branched_scalar_term(bsig, aug_dimension, degree, planar=planar)
     bsig_len = branched_sig_length(aug_dimension, degree, planar=planar, scalar_term=scalar_term)
@@ -150,10 +144,6 @@ def branched_sig_to_log_sig_backprop(
 
     result = SigOutputHandler(data, bsig_len)
 
-    if method and data.device != "cpu":
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
-
     if data.batch_size == 0:
         return result.data
 
@@ -164,7 +154,8 @@ def branched_sig_to_log_sig_backprop(
     else:
         err_code = CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA[data.dtype](
             data.data_ptr, derivs_data.data_ptr, result.data_ptr,
-            data.batch_size, aug_dimension, degree, planar, scalar_term)
+            data.batch_size, aug_dimension, degree, method, planar,
+            scalar_term)
     if err_code:
         raise Exception("Error in pysiglib.branched_sig_to_log_sig_backprop: " + err_msg(err_code))
 
@@ -184,9 +175,12 @@ def _branched_log_sig_from_path_backprop(
     check_n_jobs(n_jobs)
 
     data = PathInputHandler(path, False, False, 1.0, "path")
-    if data.device != "cpu":
+    if data.data_length == 0:
+        raise ValueError(
+            "branched_log_sig method 3 received an empty path")
+    if data.device != "cpu" and degree > 12:
         raise NotImplementedError(
-            "MKW branched log signature method 3 is only supported on CPU")
+            "CUDA MKW BCH method supports degree at most 12")
     out_len = branched_log_sig_length(
         data.data_dimension, degree, planar=True)
     derivs_data = SigInputHandler(grad_output, out_len, "grad_output")
@@ -203,9 +197,15 @@ def _branched_log_sig_from_path_backprop(
     result = PathOutputHandler(data.data_length, data.data_dimension, data)
     if data.batch_size == 0:
         return result.data
-    err_code = CPSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP[data.dtype](
-        derivs_data.data_ptr, result.data_ptr, data.data_ptr,
-        data.batch_size, data.data_length, data.data_dimension, degree, n_jobs)
+    if data.device == "cpu":
+        err_code = CPSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP[data.dtype](
+            derivs_data.data_ptr, result.data_ptr, data.data_ptr,
+            data.batch_size, data.data_length, data.data_dimension, degree,
+            n_jobs)
+    else:
+        err_code = CUSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP_CUDA[data.dtype](
+            derivs_data.data_ptr, result.data_ptr, data.data_ptr,
+            data.batch_size, data.data_length, data.data_dimension, degree)
     if err_code:
         raise Exception(
             "Error in pysiglib.branched_log_sig_from_path_backprop: "

--- a/pysiglib/dtypes.py
+++ b/pysiglib/dtypes.py
@@ -81,6 +81,8 @@ CUSIG_BRANCHED_SIG_COMBINE_BACKPROP_CUDA = None
 CUSIG_BRANCHED_SIG_BACKPROP_CUDA = None
 CUSIG_BRANCHED_SIG_TO_LOG_SIG_CUDA = None
 CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA = None
+CUSIG_BRANCHED_LOG_SIG_FROM_PATH_CUDA = None
+CUSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP_CUDA = None
 if BUILT_WITH_CUDA:
     CUSIG_TRANSFORM_PATH_CUDA = {
         "float32": CUSIG.transform_path_cuda_f,
@@ -430,4 +432,14 @@ if BUILT_WITH_CUDA:
     CUSIG_BRANCHED_SIG_TO_LOG_SIG_BACKPROP_CUDA = {
         "float32": CUSIG.branched_sig_to_log_sig_backprop_cuda_f,
         "float64": CUSIG.branched_sig_to_log_sig_backprop_cuda_d
+    }
+
+    CUSIG_BRANCHED_LOG_SIG_FROM_PATH_CUDA = {
+        "float32": CUSIG.branched_log_sig_from_path_cuda_f,
+        "float64": CUSIG.branched_log_sig_from_path_cuda_d
+    }
+
+    CUSIG_BRANCHED_LOG_SIG_FROM_PATH_BACKPROP_CUDA = {
+        "float32": CUSIG.branched_log_sig_from_path_backprop_cuda_f,
+        "float64": CUSIG.branched_log_sig_from_path_backprop_cuda_d
     }

--- a/pysiglib/jax_api/jax_api.py
+++ b/pysiglib/jax_api/jax_api.py
@@ -1652,18 +1652,6 @@ def _branched_sig_to_log_sig_bwd(
 _branched_sig_to_log_sig.defvjp(_branched_sig_to_log_sig_fwd, _branched_sig_to_log_sig_bwd)
 
 
-def _check_branched_log_sig_device(arr, method: int) -> None:
-    if method == 0 or isinstance(arr, jax.core.Tracer):
-        return
-    devices = getattr(arr, "devices", None)
-    if not callable(devices):
-        return
-    if any(device.platform in ("cuda", "gpu") for device in devices()):
-        raise NotImplementedError(
-            "MKW branched log signature methods 1, 2 and 3 are only implemented on CPU."
-        )
-
-
 def branched_sig_to_log_sig(
     bsig,
     dimension: int,
@@ -1693,8 +1681,6 @@ def branched_sig_to_log_sig(
         raise ValueError(
             "method=3 is not supported in branched_sig_to_log_sig. "
             "Use branched_log_sig(path, degree, method=3) instead.")
-    _check_branched_log_sig_device(bsig, method)
-
     aug_dimension = _augmented_dim(dimension, time_aug, lead_lag)
     scalar_term = _infer_branched_scalar_term_jax(bsig, aug_dimension, degree, planar=planar)
     if not scalar_term:
@@ -1753,8 +1739,10 @@ def branched_log_sig(
     path = jnp.asarray(path)
     _validate_shape(path)
     method = _resolve_branched_log_sig_method(method, planar)
-    _check_branched_log_sig_device(path, method)
     if method == 3:
+        if path.shape[-2] == 0:
+            raise ValueError(
+                "branched_log_sig method 3 received an empty path")
         correction = _prepare_correction_jax(
             correction, path, degree, lead_lag)
         if correction.shape[0] != 0:

--- a/pysiglib/load_siglib.py
+++ b/pysiglib/load_siglib.py
@@ -616,7 +616,7 @@ if BUILT_WITH_CUDA:
     CUSIG.prepare_branched_sig_cuda.argtypes = (c_uint64, c_uint64, c_bool, c_bool)
     CUSIG.prepare_branched_sig_cuda.restype = c_int
 
-    CUSIG.prepare_branched_log_sig_cuda.argtypes = (c_uint64, c_uint64, c_bool, c_bool)
+    CUSIG.prepare_branched_log_sig_cuda.argtypes = (c_uint64, c_uint64, c_int, c_bool, c_bool)
     CUSIG.prepare_branched_log_sig_cuda.restype = c_int
 
     CUSIG.prepare_branched_sig_coef_cuda.argtypes = (POINTER(c_uint64), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool)
@@ -702,17 +702,29 @@ if BUILT_WITH_CUDA:
     CUSIG.branched_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64, c_bool, c_bool, c_double, c_bool, c_bool, POINTER(c_double), c_uint64, c_uint64, c_uint64)
     CUSIG.branched_sig_backprop_cuda_d.restype = c_int
 
-    CUSIG.branched_sig_to_log_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_bool, c_bool)
+    CUSIG.branched_sig_to_log_sig_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
     CUSIG.branched_sig_to_log_sig_cuda_f.restype = c_int
 
-    CUSIG.branched_sig_to_log_sig_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_bool, c_bool)
+    CUSIG.branched_sig_to_log_sig_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
     CUSIG.branched_sig_to_log_sig_cuda_d.restype = c_int
 
-    CUSIG.branched_sig_to_log_sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_bool, c_bool)
+    CUSIG.branched_sig_to_log_sig_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
     CUSIG.branched_sig_to_log_sig_backprop_cuda_f.restype = c_int
 
-    CUSIG.branched_sig_to_log_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_bool, c_bool)
+    CUSIG.branched_sig_to_log_sig_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_int, c_bool, c_bool)
     CUSIG.branched_sig_to_log_sig_backprop_cuda_d.restype = c_int
+
+    CUSIG.branched_log_sig_from_path_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_log_sig_from_path_cuda_f.restype = c_int
+
+    CUSIG.branched_log_sig_from_path_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_log_sig_from_path_cuda_d.restype = c_int
+
+    CUSIG.branched_log_sig_from_path_backprop_cuda_f.argtypes = (POINTER(c_float), POINTER(c_float), POINTER(c_float), c_uint64, c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_log_sig_from_path_backprop_cuda_f.restype = c_int
+
+    CUSIG.branched_log_sig_from_path_backprop_cuda_d.argtypes = (POINTER(c_double), POINTER(c_double), POINTER(c_double), c_uint64, c_uint64, c_uint64, c_uint64)
+    CUSIG.branched_log_sig_from_path_backprop_cuda_d.restype = c_int
 
     ######################################################
     # logsig_to_sig_cuda

--- a/pysiglib/torch_api/torch_api.py
+++ b/pysiglib/torch_api/torch_api.py
@@ -1024,9 +1024,6 @@ def branched_log_sig(
             path, degree, time_aug=time_aug, lead_lag=lead_lag,
             end_time=end_time, planar=planar, scalar_term=scalar_term,
             method=method, n_jobs=n_jobs)
-    if method and isinstance(path, torch.Tensor) and path.device.type != "cpu":
-        raise NotImplementedError(
-            "Compressed MKW branched log signatures are only supported on CPU")
     bsig = branched_sig(
         path, degree, time_aug=time_aug, lead_lag=lead_lag, end_time=end_time,
         planar=planar, scalar_term=scalar_term, correction=correction, n_jobs=n_jobs)

--- a/siglib/cusig/CMakeLists.txt
+++ b/siglib/cusig/CMakeLists.txt
@@ -4,6 +4,7 @@ if(NOT DEFINED CUSIG_INSTALL_DESTINATION)
 endif()
 
 add_library(cusig SHARED
+	cu_branched_log_bch.cu
     cu_branched_log_signature.cu
     cu_branched_signature.cu
     cu_branched_sig_kernel.cu
@@ -23,8 +24,9 @@ add_library(cusig SHARED
 )
 
 set_target_properties(cusig PROPERTIES
-    CUDA_STANDARD 17
-    CXX_STANDARD  20
+    CUDA_STANDARD          20
+    CUDA_STANDARD_REQUIRED ON
+    CXX_STANDARD           20
     CUDA_SEPARABLE_COMPILATION ON
     CUDA_ARCHITECTURES         "${PYSIGLIB_CUDA_ARCH}"
 )

--- a/siglib/cusig/cu_branched_log_bch.cu
+++ b/siglib/cusig/cu_branched_log_bch.cu
@@ -1,0 +1,1456 @@
+/* Copyright 2026 Daniil Shmelev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================================= */
+
+#include "cupch.h"
+#include "cusig.h"
+#include "cu_branched_log_sig_cache.h"
+#include "cu_log_sig_combine.h"
+#include "cu_macros.h"
+#include "cu_utils.h"
+#include "../shared/branched_log_cache.h"
+
+#include <cmath>
+#include <limits>
+#include <unordered_set>
+
+namespace {
+
+using CuMkwTensorElem = std::unordered_map<uint64_t, int>;
+using CuMkwInfinitesimalProduct = std::unordered_map<
+	std::pair<uint64_t, uint64_t>, CuMkwTensorElem, CuPairHash>;
+
+struct CuMkwBchDeviceData {
+	const double* bch_coefficients = nullptr;
+	const uint64_t* bch_left_factor = nullptr;
+	const uint64_t* bch_right_factor = nullptr;
+	const uint32_t* comm_k_ptr = nullptr;
+	const uint32_t* comm_k_i = nullptr;
+	const uint32_t* comm_k_j = nullptr;
+	const int* comm_k_val = nullptr;
+	const uint32_t* comm_a_ptr = nullptr;
+	const uint32_t* comm_a_k = nullptr;
+	const uint32_t* comm_a_partner = nullptr;
+	const int* comm_a_signed_c = nullptr;
+	const uint64_t* linear_a_ptr = nullptr;
+	const uint32_t* linear_a_idx = nullptr;
+	const uint64_t* linear_output_ptr = nullptr;
+	const uint32_t* linear_output_idx = nullptr;
+	const uint64_t* linear_op_ptr = nullptr;
+	const uint32_t* linear_op_idx = nullptr;
+	const uint64_t* linear_reverse_ptr = nullptr;
+	const uint32_t* linear_reverse_idx = nullptr;
+	const uint32_t* segment_idx = nullptr;
+	const double* segment_coefficients = nullptr;
+	const uint32_t* segment_label_offsets = nullptr;
+	const uint8_t* segment_labels = nullptr;
+	uint64_t m = 0;
+	uint64_t m2 = 0;
+	uint64_t segment_count = 0;
+};
+
+struct CuMkwBchCache {
+	CUDABchCache bch;
+	uint64_t* d_linear_output_ptr = nullptr;
+	uint32_t* d_linear_output_idx = nullptr;
+	uint64_t* d_linear_op_ptr = nullptr;
+	uint32_t* d_linear_op_idx = nullptr;
+	uint64_t* d_linear_reverse_ptr = nullptr;
+	uint32_t* d_linear_reverse_idx = nullptr;
+	uint32_t* d_segment_idx = nullptr;
+	double* d_segment_coefficients = nullptr;
+	uint32_t* d_segment_label_offsets = nullptr;
+	uint8_t* d_segment_labels = nullptr;
+	uint64_t segment_count = 0;
+	uint64_t exact_forward_work = 0;
+	uint64_t exact_zero_work = 0;
+	bool prune_reverse = false;
+
+	CuMkwBchCache() = default;
+	CuMkwBchCache(const CuMkwBchCache&) = delete;
+	CuMkwBchCache& operator=(const CuMkwBchCache&) = delete;
+
+	~CuMkwBchCache() {
+		if (d_linear_output_ptr) cudaFree(d_linear_output_ptr);
+		if (d_linear_output_idx) cudaFree(d_linear_output_idx);
+		if (d_linear_op_ptr) cudaFree(d_linear_op_ptr);
+		if (d_linear_op_idx) cudaFree(d_linear_op_idx);
+		if (d_linear_reverse_ptr) cudaFree(d_linear_reverse_ptr);
+		if (d_linear_reverse_idx) cudaFree(d_linear_reverse_idx);
+		if (d_segment_idx) cudaFree(d_segment_idx);
+		if (d_segment_coefficients) cudaFree(d_segment_coefficients);
+		if (d_segment_label_offsets) cudaFree(d_segment_label_offsets);
+		if (d_segment_labels) cudaFree(d_segment_labels);
+	}
+
+	CuMkwBchDeviceData device_data() const noexcept {
+		return {
+			bch.d_bch_coefficients,
+			bch.d_bch_left_factor,
+			bch.d_bch_right_factor,
+			bch.d_comm_k_ptr,
+			bch.d_comm_k_i,
+			bch.d_comm_k_j,
+			bch.d_comm_k_val,
+			bch.d_comm_a_ptr,
+			bch.d_comm_a_k,
+			bch.d_comm_a_partner,
+			bch.d_comm_a_signed_c,
+			bch.d_linear_a_ptr,
+			bch.d_linear_a_idx,
+			d_linear_output_ptr,
+			d_linear_output_idx,
+			d_linear_op_ptr,
+			d_linear_op_idx,
+			d_linear_reverse_ptr,
+			d_linear_reverse_idx,
+			d_segment_idx,
+			d_segment_coefficients,
+			d_segment_label_offsets,
+			d_segment_labels,
+			bch.m,
+			bch.m2,
+			segment_count
+		};
+	}
+};
+
+std::unordered_map<
+	CuLogSigCacheKey,
+	std::unique_ptr<CuMkwBchCache>,
+	CuLogSigCacheKeyHash
+> s_mkw_bch_cache;
+std::mutex s_mkw_bch_cache_mu;
+
+template<typename T>
+void upload_mkw_vector_(T*& device, const std::vector<T>& host) {
+	if (host.empty())
+		return;
+	CudaBuf<T> buffer(host.size() * sizeof(T));
+	CUDA_CHECK(cudaMemcpy(
+		buffer.get(), host.data(), host.size() * sizeof(T),
+		cudaMemcpyHostToDevice));
+	device = buffer.release();
+}
+
+uint32_t narrow_mkw_u32_(uint64_t value, const char* message) {
+	if (value > UINT32_MAX)
+		throw std::overflow_error(message);
+	return static_cast<uint32_t>(value);
+}
+
+void add_mkw_coefficient_(int& target, int64_t value) {
+	const int64_t result = static_cast<int64_t>(target) + value;
+	if (result < std::numeric_limits<int>::min()
+		|| result > std::numeric_limits<int>::max())
+		throw std::overflow_error("MKW BCH integer coefficient overflow");
+	target = static_cast<int>(result);
+}
+
+void remove_mkw_zero_entries_(CuMkwTensorElem& element) {
+	for (auto it = element.begin(); it != element.end();) {
+		if (it->second == 0)
+			it = element.erase(it);
+		else
+			++it;
+	}
+}
+
+CuMkwTensorElem mkw_tensor_product_(
+	const CuMkwTensorElem& left,
+	const CuMkwTensorElem& right,
+	const CuMkwHostBasisData& basis
+) {
+	CuMkwTensorElem result;
+	for (const auto& [left_idx, left_coefficient] : left) {
+		for (const auto& [right_idx, right_coefficient] : right) {
+			cu_word word = basis.flat_words.at(left_idx);
+			const cu_word& suffix = basis.flat_words.at(right_idx);
+			word.insert(word.end(), suffix.begin(), suffix.end());
+			const auto flat = basis.flat_idx.find(word);
+			if (flat == basis.flat_idx.end())
+				continue;
+			add_mkw_coefficient_(
+				result[flat->second],
+				static_cast<int64_t>(left_coefficient) * right_coefficient);
+		}
+	}
+	remove_mkw_zero_entries_(result);
+	return result;
+}
+
+CuMkwInfinitesimalProduct build_mkw_infinitesimal_product_(
+	const BranchedSigCache& cache
+) {
+	CuMkwInfinitesimalProduct product;
+	for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+		uint64_t position = cache.coproduct_offsets[basis_idx];
+		const uint64_t end = cache.coproduct_offsets[basis_idx + 1];
+		while (position < end) {
+			const uint64_t forest_size = cache.coproduct_data[position++];
+			const uint64_t trunk = cache.coproduct_data[position++];
+			if (forest_size == 1) {
+				const uint64_t branch = cache.coproduct_data[position++];
+				add_mkw_coefficient_(
+					product[{ branch, trunk }][basis_idx + 1], 1);
+			}
+			else {
+				position += forest_size;
+			}
+		}
+	}
+	return product;
+}
+
+CuMkwTensorElem mkw_infinitesimal_product_(
+	const CuMkwTensorElem& left,
+	const CuMkwTensorElem& right,
+	const CuMkwInfinitesimalProduct& product
+) {
+	CuMkwTensorElem result;
+	for (const auto& [left_idx, left_coefficient] : left) {
+		for (const auto& [right_idx, right_coefficient] : right) {
+			const auto found = product.find({ left_idx, right_idx });
+			if (found == product.end())
+				continue;
+			for (const auto& [out_idx, coefficient] : found->second) {
+				add_mkw_coefficient_(
+					result[out_idx],
+					static_cast<int64_t>(left_coefficient)
+						* right_coefficient * coefficient);
+			}
+		}
+	}
+	remove_mkw_zero_entries_(result);
+	return result;
+}
+
+void apply_mkw_inverse_projection_(
+	const CuSparseIntMatrix& inverse,
+	std::vector<double>& coordinates
+) {
+	for (uint64_t offset = 0; offset < inverse.n; ++offset) {
+		const uint64_t row = inverse.n - offset - 1;
+		for (const CuEntry& entry : inverse.rows[row])
+			coordinates[row] += static_cast<double>(entry.val)
+				* coordinates[entry.col];
+	}
+}
+
+std::vector<double> build_unit_segment_coefficients_(
+	const BranchedSigCache& cache,
+	const CuMkwHostBasisData& basis
+) {
+	const BranchedLogForestCache forest = build_branched_log_forest_cache(cache);
+	const uint64_t num_forests = forest.forest_offsets.size() - 1;
+	std::vector<double> h(cache.total_length, 0.0);
+	std::vector<double> h_forest(num_forests, 0.0);
+	std::vector<double> power(num_forests, 0.0);
+	std::vector<double> next(num_forests, 0.0);
+	std::vector<double> expanded(cache.total_length, 0.0);
+
+	for (uint64_t flat = 1; flat < cache.total_length; ++flat)
+		h[flat] = cache.inv_tree_factorial[flat - 1];
+	for (uint64_t forest_idx = 1; forest_idx < num_forests; ++forest_idx) {
+		double value = 1.0;
+		for (uint64_t position = forest.forest_offsets[forest_idx];
+			position < forest.forest_offsets[forest_idx + 1]; ++position)
+			value *= h[forest.forest_trees[position]];
+		h_forest[forest_idx] = value;
+		power[forest_idx] = value;
+	}
+	for (uint64_t flat = 1; flat < cache.total_length; ++flat)
+		expanded[flat] = power[forest.single_tree_forest[flat]];
+
+	for (uint64_t order = 2; order <= cache.max_nodes; ++order) {
+		for (uint64_t forest_idx = 0; forest_idx < num_forests; ++forest_idx) {
+			double value = 0.0;
+			for (uint64_t position = forest.forest_coprod_offsets[forest_idx];
+				position < forest.forest_coprod_offsets[forest_idx + 1];
+				position += 2) {
+				value += power[forest.forest_coprod_data[position]]
+					* h_forest[forest.forest_coprod_data[position + 1]];
+			}
+			next[forest_idx] = value;
+		}
+		const double coefficient = order % 2 == 0
+			? -1.0 / static_cast<double>(order)
+			: 1.0 / static_cast<double>(order);
+		for (uint64_t flat = 1; flat < cache.total_length; ++flat)
+			expanded[flat] += coefficient
+				* next[forest.single_tree_forest[flat]];
+		power.swap(next);
+	}
+
+	std::vector<double> compact(basis.lyndon_idx.size(), 0.0);
+	for (uint64_t index = 0; index < compact.size(); ++index)
+		compact[index] = expanded[basis.lyndon_idx[index]];
+	apply_mkw_inverse_projection_(basis.inv_proj_mat, compact);
+	return compact;
+}
+
+struct HostMkwBchTables_ {
+	std::vector<uint32_t> k_ptr;
+	std::vector<uint32_t> k_i;
+	std::vector<uint32_t> k_j;
+	std::vector<int> k_val;
+	std::vector<uint32_t> a_ptr;
+	std::vector<uint32_t> a_k;
+	std::vector<uint32_t> a_partner;
+	std::vector<int> a_signed_c;
+};
+
+HostMkwBchTables_ build_mkw_commutator_tables_(
+	const BranchedSigCache& cache,
+	const CuMkwHostBasisData& basis
+) {
+	const uint64_t m = basis.lyndon_words.size();
+	std::vector<CuMkwTensorElem> tensor_representations(m);
+	for (uint64_t index = 0; index < m; ++index) {
+		if (basis.lyndon_words[index].size() == 1) {
+			tensor_representations[index] = {
+				{ basis.flat_idx.at(basis.lyndon_words[index]), 1 }
+			};
+			continue;
+		}
+		CuMkwTensorElem left_right = mkw_tensor_product_(
+			tensor_representations[basis.left_factor[index]],
+			tensor_representations[basis.right_factor[index]], basis);
+		const CuMkwTensorElem right_left = mkw_tensor_product_(
+			tensor_representations[basis.right_factor[index]],
+			tensor_representations[basis.left_factor[index]], basis);
+		for (const auto& [flat, coefficient] : right_left)
+			add_mkw_coefficient_(left_right[flat], -static_cast<int64_t>(coefficient));
+		remove_mkw_zero_entries_(left_right);
+		tensor_representations[index] = std::move(left_right);
+	}
+
+	struct KEntry_ {
+		uint32_t i;
+		uint32_t j;
+		int coefficient;
+	};
+	std::vector<std::vector<KEntry_>> by_output(m);
+	const CuMkwInfinitesimalProduct product
+		= build_mkw_infinitesimal_product_(cache);
+	std::vector<double> coordinates(m, 0.0);
+	for (uint64_t i = 0; i < m; ++i) {
+		for (uint64_t j = i + 1; j < m; ++j) {
+			const uint64_t weight = basis.lyndon_weights[i]
+				+ basis.lyndon_weights[j];
+			if (weight > cache.max_nodes)
+				continue;
+			CuMkwTensorElem commutator = mkw_infinitesimal_product_(
+				tensor_representations[i], tensor_representations[j], product);
+			const CuMkwTensorElem reverse = mkw_infinitesimal_product_(
+				tensor_representations[j], tensor_representations[i], product);
+			for (const auto& [flat, coefficient] : reverse)
+				add_mkw_coefficient_(commutator[flat], -static_cast<int64_t>(coefficient));
+			remove_mkw_zero_entries_(commutator);
+			std::fill(coordinates.begin(), coordinates.end(), 0.0);
+			for (uint64_t k = 0; k < m; ++k) {
+				if (basis.lyndon_weights[k] != weight)
+					continue;
+				const auto found = commutator.find(basis.lyndon_idx[k]);
+				if (found != commutator.end())
+					coordinates[k] = static_cast<double>(found->second);
+			}
+			apply_mkw_inverse_projection_(basis.inv_proj_mat, coordinates);
+			for (uint64_t k = 0; k < m; ++k) {
+				const double rounded = std::round(coordinates[k]);
+				if (rounded == 0.0)
+					continue;
+				if (rounded < std::numeric_limits<int>::min()
+					|| rounded > std::numeric_limits<int>::max())
+					throw std::overflow_error("MKW BCH commutator coefficient overflow");
+				by_output[k].push_back({
+					static_cast<uint32_t>(i),
+					static_cast<uint32_t>(j),
+					static_cast<int>(rounded)
+				});
+			}
+		}
+	}
+
+	HostMkwBchTables_ tables;
+	tables.k_ptr.resize(m + 1);
+	uint64_t offset = 0;
+	for (uint64_t k = 0; k < m; ++k) {
+		tables.k_ptr[k] = narrow_mkw_u32_(
+			offset, "MKW BCH commutator table exceeds uint32 range");
+		offset += by_output[k].size();
+	}
+	tables.k_ptr[m] = narrow_mkw_u32_(
+		offset, "MKW BCH commutator table exceeds uint32 range");
+	tables.k_i.reserve(offset);
+	tables.k_j.reserve(offset);
+	tables.k_val.reserve(offset);
+	for (const auto& entries : by_output) {
+		for (const KEntry_& entry : entries) {
+			tables.k_i.push_back(entry.i);
+			tables.k_j.push_back(entry.j);
+			tables.k_val.push_back(entry.coefficient);
+		}
+	}
+
+	struct AEntry_ {
+		uint32_t k;
+		uint32_t partner;
+		int signed_coefficient;
+	};
+	std::vector<std::vector<AEntry_>> by_input(m);
+	for (uint64_t k = 0; k < m; ++k) {
+		for (uint32_t index = tables.k_ptr[k]; index < tables.k_ptr[k + 1]; ++index) {
+			const uint32_t i = tables.k_i[index];
+			const uint32_t j = tables.k_j[index];
+			const int coefficient = tables.k_val[index];
+			by_input[i].push_back({ static_cast<uint32_t>(k), j, coefficient });
+			by_input[j].push_back({ static_cast<uint32_t>(k), i, -coefficient });
+		}
+	}
+	tables.a_ptr.resize(m + 1);
+	offset = 0;
+	for (uint64_t a = 0; a < m; ++a) {
+		tables.a_ptr[a] = narrow_mkw_u32_(
+			offset, "MKW BCH reverse table exceeds uint32 range");
+		offset += by_input[a].size();
+	}
+	tables.a_ptr[m] = narrow_mkw_u32_(
+		offset, "MKW BCH reverse table exceeds uint32 range");
+	if (offset > (UINT32_MAX >> 1))
+		throw std::overflow_error("MKW BCH reverse plan exceeds uint32 packing");
+	tables.a_k.reserve(offset);
+	tables.a_partner.reserve(offset);
+	tables.a_signed_c.reserve(offset);
+	for (const auto& entries : by_input) {
+		for (const AEntry_& entry : entries) {
+			tables.a_k.push_back(entry.k);
+			tables.a_partner.push_back(entry.partner);
+			tables.a_signed_c.push_back(entry.signed_coefficient);
+		}
+	}
+	return tables;
+}
+
+struct HostMkwPruning_ {
+	std::vector<uint64_t> range;
+	std::vector<uint64_t> output_ptr;
+	std::vector<uint32_t> output_idx;
+	std::vector<uint64_t> op_ptr{ 0 };
+	std::vector<uint32_t> op_idx;
+	std::vector<uint64_t> linear_a_ptr;
+	std::vector<uint32_t> linear_a_idx;
+	std::vector<uint64_t> reverse_ptr;
+	std::vector<uint32_t> reverse_idx;
+	uint64_t dense_forward_work = 0;
+	uint64_t exact_forward_work = 0;
+	uint64_t exact_zero_work = 0;
+	bool prune_reverse = false;
+};
+
+HostMkwPruning_ build_mkw_pruning_(
+	const BchHardcodedData& formula,
+	const HostMkwBchTables_& tables,
+	const std::vector<uint64_t>& weights,
+	const std::vector<uint32_t>& segment_idx
+) {
+	const uint64_t m = weights.size();
+	const uint64_t m2 = formula.size;
+	std::vector<uint8_t> input_mask(m, 0);
+	for (uint32_t index : segment_idx)
+		input_mask[index] = 1;
+
+	std::vector<uint64_t> min_weight(m2, 1);
+	std::vector<uint64_t> max_weight(m2, weights.empty() ? 0 : weights.back());
+	if (m2 > 1) {
+		min_weight[1] = weights.empty() ? 1 : weights.back() + 1;
+		max_weight[1] = 0;
+		for (uint32_t index : segment_idx) {
+			min_weight[1] = std::min(min_weight[1], weights[index]);
+			max_weight[1] = std::max(max_weight[1], weights[index]);
+		}
+		if (segment_idx.empty())
+			min_weight[1] = 1;
+	}
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t left = formula.left_factor[w];
+		const uint64_t right = formula.right_factor[w];
+		min_weight[w] = min_weight[left] + min_weight[right];
+		max_weight[w] = std::min(
+			weights.empty() ? uint64_t(0) : weights.back(),
+			max_weight[left] + max_weight[right]);
+	}
+
+	HostMkwPruning_ pruning;
+	pruning.range.resize(2 * m2);
+	for (uint64_t w = 0; w < m2; ++w) {
+		pruning.range[2 * w] = std::lower_bound(
+			weights.begin(), weights.end(), min_weight[w]) - weights.begin();
+		pruning.range[2 * w + 1] = std::upper_bound(
+			weights.begin(), weights.end(), max_weight[w]) - weights.begin();
+	}
+
+	std::vector<std::vector<uint8_t>> support(m2, std::vector<uint8_t>(m, 0));
+	if (m2 > 0)
+		std::fill(support[0].begin(), support[0].end(), uint8_t(1));
+	if (m2 > 1)
+		support[1] = input_mask;
+	pruning.output_ptr.assign(m2 + 1, 0);
+	for (uint64_t w = 2; w < m2; ++w) {
+		const auto& left_support = support[formula.left_factor[w]];
+		const auto& right_support = support[formula.right_factor[w]];
+		pruning.output_ptr[w] = pruning.output_idx.size();
+		for (uint64_t k = 0; k < m; ++k) {
+			const uint64_t before = pruning.op_idx.size();
+			for (uint32_t index = tables.k_ptr[k]; index < tables.k_ptr[k + 1]; ++index) {
+				const uint32_t i = tables.k_i[index];
+				const uint32_t j = tables.k_j[index];
+				if ((left_support[i] && right_support[j])
+					|| (left_support[j] && right_support[i]))
+					pruning.op_idx.push_back(index);
+			}
+			if (pruning.op_idx.size() != before) {
+				support[w][k] = 1;
+				pruning.output_idx.push_back(static_cast<uint32_t>(k));
+				pruning.op_ptr.push_back(pruning.op_idx.size());
+			}
+		}
+		pruning.output_ptr[w + 1] = pruning.output_idx.size();
+	}
+
+	pruning.linear_a_ptr.resize(m2 * m + 1, 0);
+	pruning.reverse_ptr.assign(m2 + 1, 0);
+	for (uint64_t w = 2; w < m2; ++w) {
+		const auto& left_support = support[formula.left_factor[w]];
+		const auto& right_support = support[formula.right_factor[w]];
+		pruning.reverse_ptr[w] = pruning.reverse_idx.size();
+		for (uint64_t a = 0; a < m; ++a) {
+			const uint64_t row = w * m + a;
+			pruning.linear_a_ptr[row] = pruning.linear_a_idx.size();
+			for (uint32_t index = tables.a_ptr[a]; index < tables.a_ptr[a + 1]; ++index) {
+				const uint32_t partner = tables.a_partner[index];
+				if (left_support[a] && right_support[partner])
+					pruning.linear_a_idx.push_back(index << 1);
+				if (right_support[a] && left_support[partner])
+					pruning.linear_a_idx.push_back((index << 1) | 1);
+			}
+			pruning.linear_a_ptr[row + 1] = pruning.linear_a_idx.size();
+			if (pruning.linear_a_ptr[row] != pruning.linear_a_ptr[row + 1])
+				pruning.reverse_idx.push_back(static_cast<uint32_t>(a));
+		}
+		pruning.reverse_ptr[w + 1] = pruning.reverse_idx.size();
+	}
+
+	const uint64_t node_count = m2 > 2 ? m2 - 2 : 0;
+	const uint64_t nnz = tables.k_i.size();
+	pruning.dense_forward_work = node_count * (m + nnz);
+	pruning.exact_forward_work = pruning.output_idx.size() + pruning.op_idx.size();
+	pruning.exact_zero_work = node_count * m;
+	const uint64_t dense_reverse_work = node_count
+		* (m + tables.a_k.size());
+	const uint64_t exact_reverse_work = pruning.reverse_idx.size()
+		+ pruning.linear_a_idx.size();
+	pruning.prune_reverse = dense_reverse_work > 0
+		&& exact_reverse_work <= dense_reverse_work - dense_reverse_work / 3;
+	return pruning;
+}
+
+std::unique_ptr<CuMkwBchCache> build_cuda_mkw_bch_cache_(
+	const BranchedSigCache& cache
+) {
+	if (!cache.planar)
+		throw std::invalid_argument("MKW BCH requires planar=True");
+	if (cache.max_nodes > BCH_MAX_HARDCODED_DEGREE)
+		throw std::runtime_error(
+			"CUDA MKW BCH method supports degree at most 12");
+
+	const CuMkwHostBasisData& basis = get_cuda_mkw_host_basis_data_(
+		cache.dimension, cache.max_nodes, 2);
+	const uint64_t m = basis.lyndon_words.size();
+	if (m > UINT32_MAX)
+		throw std::overflow_error("CUDA MKW BCH basis exceeds uint32 range");
+
+	auto result = std::make_unique<CuMkwBchCache>();
+	result->bch.m = m;
+	if (cache.max_nodes == 0)
+		return result;
+
+	const BchHardcodedData* formula = get_hardcoded_bch_data(cache.max_nodes);
+	if (formula == nullptr)
+		throw std::runtime_error(
+			"CUDA MKW BCH method supports degree at most 12");
+	result->bch.m2 = formula->size;
+
+	std::vector<double> segment_coefficients_full
+		= build_unit_segment_coefficients_(cache, basis);
+	std::vector<uint32_t> segment_idx;
+	std::vector<double> segment_coefficients;
+	std::vector<uint32_t> segment_label_offsets{ 0 };
+	std::vector<uint8_t> segment_labels;
+	for (uint64_t coordinate = 0; coordinate < m; ++coordinate) {
+		if (segment_coefficients_full[coordinate] == 0.0)
+			continue;
+		segment_idx.push_back(static_cast<uint32_t>(coordinate));
+		segment_coefficients.push_back(segment_coefficients_full[coordinate]);
+		const uint64_t basis_idx = basis.lyndon_idx[coordinate] - 1;
+		const uint64_t start = cache.node_labels_offsets[basis_idx];
+		const uint64_t end = cache.node_labels_offsets[basis_idx + 1];
+		segment_labels.insert(
+			segment_labels.end(),
+			cache.node_labels_data.begin() + static_cast<std::ptrdiff_t>(start),
+			cache.node_labels_data.begin() + static_cast<std::ptrdiff_t>(end));
+		segment_label_offsets.push_back(narrow_mkw_u32_(
+			segment_labels.size(), "MKW segment label plan exceeds uint32 range"));
+	}
+	result->segment_count = segment_idx.size();
+
+	const HostMkwBchTables_ tables = build_mkw_commutator_tables_(cache, basis);
+	const HostMkwPruning_ pruning = build_mkw_pruning_(
+		*formula, tables, basis.lyndon_weights, segment_idx);
+	result->bch.linear_dense_forward_work = pruning.dense_forward_work;
+	result->bch.linear_active_forward_work = pruning.exact_forward_work;
+	result->bch.linear_zero_work = pruning.exact_zero_work;
+	result->exact_forward_work = pruning.exact_forward_work;
+	result->exact_zero_work = pruning.exact_zero_work;
+	result->prune_reverse = pruning.prune_reverse;
+
+	std::vector<double> bch_coefficients(
+		formula->coefficients, formula->coefficients + formula->size);
+	std::vector<uint64_t> bch_left(
+		formula->left_factor, formula->left_factor + formula->size);
+	std::vector<uint64_t> bch_right(
+		formula->right_factor, formula->right_factor + formula->size);
+	upload_mkw_vector_(result->bch.d_bch_coefficients, bch_coefficients);
+	upload_mkw_vector_(result->bch.d_bch_left_factor, bch_left);
+	upload_mkw_vector_(result->bch.d_bch_right_factor, bch_right);
+	upload_mkw_vector_(result->bch.d_linear_range, pruning.range);
+	upload_mkw_vector_(result->bch.d_comm_k_ptr, tables.k_ptr);
+	upload_mkw_vector_(result->bch.d_comm_k_i, tables.k_i);
+	upload_mkw_vector_(result->bch.d_comm_k_j, tables.k_j);
+	upload_mkw_vector_(result->bch.d_comm_k_val, tables.k_val);
+	upload_mkw_vector_(result->bch.d_comm_a_ptr, tables.a_ptr);
+	upload_mkw_vector_(result->bch.d_comm_a_k, tables.a_k);
+	upload_mkw_vector_(result->bch.d_comm_a_partner, tables.a_partner);
+	upload_mkw_vector_(result->bch.d_comm_a_signed_c, tables.a_signed_c);
+	upload_mkw_vector_(result->bch.d_linear_a_ptr, pruning.linear_a_ptr);
+	upload_mkw_vector_(result->bch.d_linear_a_idx, pruning.linear_a_idx);
+	upload_mkw_vector_(result->d_linear_output_ptr, pruning.output_ptr);
+	upload_mkw_vector_(result->d_linear_output_idx, pruning.output_idx);
+	upload_mkw_vector_(result->d_linear_op_ptr, pruning.op_ptr);
+	upload_mkw_vector_(result->d_linear_op_idx, pruning.op_idx);
+	upload_mkw_vector_(result->d_linear_reverse_ptr, pruning.reverse_ptr);
+	upload_mkw_vector_(result->d_linear_reverse_idx, pruning.reverse_idx);
+	upload_mkw_vector_(result->d_segment_idx, segment_idx);
+	upload_mkw_vector_(result->d_segment_coefficients, segment_coefficients);
+	upload_mkw_vector_(result->d_segment_label_offsets, segment_label_offsets);
+	upload_mkw_vector_(result->d_segment_labels, segment_labels);
+	return result;
+}
+
+const CuMkwBchCache& get_cuda_mkw_bch_cache_(
+	uint64_t dimension,
+	uint64_t max_nodes
+) {
+	const CuLogSigCacheKey key = make_cuda_log_sig_cache_key_(
+		dimension, max_nodes);
+	std::lock_guard<std::mutex> lock(s_mkw_bch_cache_mu);
+	const auto found = s_mkw_bch_cache.find(key);
+	if (found == s_mkw_bch_cache.end())
+		throw cache_not_found_error(
+			"CUDA MKW BCH cache not found - call prepare_branched_log_sig with method=3 first");
+	return *found->second;
+}
+
+template<typename T>
+__device__ __forceinline__ void evaluate_mkw_segment_(
+	const T* left,
+	const T* right,
+	T* target,
+	T sign,
+	const CuMkwBchDeviceData& data
+) {
+	for (uint64_t q = threadIdx.x; q < data.segment_count; q += blockDim.x) {
+		T value = sign * static_cast<T>(data.segment_coefficients[q]);
+		for (uint32_t position = data.segment_label_offsets[q];
+			position < data.segment_label_offsets[q + 1]; ++position) {
+			const uint8_t label = data.segment_labels[position];
+			value *= right[label] - left[label];
+		}
+		target[data.segment_idx[q]] = value;
+	}
+}
+
+template<typename T, bool Sparse, bool Shared, bool Accumulate>
+__device__ __forceinline__ void evaluate_mkw_bch_nodes_(
+	T* memo,
+	T* out,
+	T* shared_left,
+	T* shared_right,
+	const CuMkwBchDeviceData& data
+) {
+	const uint64_t tid = threadIdx.x;
+	const uint64_t stride = blockDim.x;
+	for (uint64_t w = 2; w < data.m2; ++w) {
+		const T* left_global = memo + data.bch_left_factor[w] * data.m;
+		const T* right_global = memo + data.bch_right_factor[w] * data.m;
+		const T* left = left_global;
+		const T* right = right_global;
+		if constexpr (Shared) {
+			for (uint64_t k = tid; k < data.m; k += stride) {
+				shared_left[k] = left_global[k];
+				shared_right[k] = right_global[k];
+			}
+			__syncthreads();
+			left = shared_left;
+			right = shared_right;
+		}
+
+		T* result = memo + w * data.m;
+		if constexpr (Sparse) {
+			for (uint64_t q = data.linear_output_ptr[w] + tid;
+				q < data.linear_output_ptr[w + 1]; q += stride) {
+				const uint32_t k = data.linear_output_idx[q];
+				T value = T(0);
+				for (uint64_t position = data.linear_op_ptr[q];
+					position < data.linear_op_ptr[q + 1]; ++position) {
+					const uint32_t comm_index = data.linear_op_idx[position];
+					const uint32_t i = data.comm_k_i[comm_index];
+					const uint32_t j = data.comm_k_j[comm_index];
+					value += static_cast<T>(data.comm_k_val[comm_index])
+						* (left[i] * right[j] - left[j] * right[i]);
+				}
+				result[k] = value;
+				if constexpr (Accumulate) {
+					const T bch_coefficient = static_cast<T>(
+						data.bch_coefficients[w]);
+					if (bch_coefficient != T(0))
+						out[k] += bch_coefficient * value;
+				}
+			}
+		}
+		else {
+			for (uint64_t k = tid; k < data.m; k += stride) {
+				T value = T(0);
+				for (uint32_t position = data.comm_k_ptr[k];
+					position < data.comm_k_ptr[k + 1]; ++position) {
+					const uint32_t i = data.comm_k_i[position];
+					const uint32_t j = data.comm_k_j[position];
+					value += static_cast<T>(data.comm_k_val[position])
+						* (left[i] * right[j] - left[j] * right[i]);
+				}
+				result[k] = value;
+				if constexpr (Accumulate) {
+					const T bch_coefficient = static_cast<T>(
+						data.bch_coefficients[w]);
+					if (bch_coefficient != T(0))
+						out[k] += bch_coefficient * value;
+				}
+			}
+		}
+		__syncthreads();
+	}
+}
+
+template<typename T, bool Sparse, bool Shared>
+__global__ void branched_log_sig_from_path_kernel_(
+	const T* __restrict__ path,
+	T* __restrict__ out,
+	T* __restrict__ workspace,
+	uint64_t length,
+	uint64_t dimension,
+	CuMkwBchDeviceData data
+) {
+	const uint64_t batch_idx = blockIdx.x;
+	const uint64_t tid = threadIdx.x;
+	const uint64_t stride = blockDim.x;
+	const T* path_row = path + batch_idx * length * dimension;
+	T* out_row = out + batch_idx * data.m;
+	T* memo = workspace + batch_idx * data.m2 * data.m;
+
+	T* shared_left = nullptr;
+	T* shared_right = nullptr;
+	if constexpr (Shared) {
+		extern __shared__ char shared_bytes[];
+		shared_left = reinterpret_cast<T*>(shared_bytes);
+		shared_right = shared_left + data.m;
+	}
+
+	for (uint64_t k = tid; k < data.m; k += stride) {
+		out_row[k] = T(0);
+		memo[data.m + k] = T(0);
+	}
+	if constexpr (Sparse) {
+		for (uint64_t index = 2 * data.m + tid;
+			index < data.m2 * data.m; index += stride)
+			memo[index] = T(0);
+	}
+	__syncthreads();
+	if (length == 1)
+		return;
+
+	evaluate_mkw_segment_(
+		path_row, path_row + dimension, out_row, T(1), data);
+	__syncthreads();
+	for (uint64_t segment = 1; segment + 1 < length; ++segment) {
+		const T* left = path_row + segment * dimension;
+		const T* right = left + dimension;
+		for (uint64_t k = tid; k < data.m; k += stride)
+			memo[k] = out_row[k];
+		evaluate_mkw_segment_(left, right, memo + data.m, T(1), data);
+		__syncthreads();
+		for (uint64_t q = tid; q < data.segment_count; q += stride) {
+			const uint32_t coordinate = data.segment_idx[q];
+			out_row[coordinate] += memo[data.m + coordinate];
+		}
+		__syncthreads();
+		evaluate_mkw_bch_nodes_<T, Sparse, Shared, true>(
+			memo, out_row, shared_left, shared_right, data);
+	}
+}
+
+uint64_t checked_mkw_product_(
+	uint64_t left,
+	uint64_t right,
+	const char* message
+) {
+	if (right != 0 && left > UINT64_MAX / right)
+		throw std::overflow_error(message);
+	return left * right;
+}
+
+uint64_t checked_mkw_sum_(
+	uint64_t left,
+	uint64_t right,
+	const char* message
+) {
+	if (left > UINT64_MAX - right)
+		throw std::overflow_error(message);
+	return left + right;
+}
+
+template<typename T, bool Shared>
+void launch_mkw_forward_(
+	bool sparse,
+	const T* path,
+	T* out,
+	T* workspace,
+	uint64_t batch,
+	uint64_t length,
+	uint64_t dimension,
+	unsigned int threads,
+	size_t shared_size,
+	const CuMkwBchDeviceData& data
+) {
+	if (sparse) {
+		branched_log_sig_from_path_kernel_<T, true, Shared><<<
+			static_cast<unsigned int>(batch), threads, shared_size>>>(
+				path, out, workspace, length, dimension, data);
+	}
+	else {
+		branched_log_sig_from_path_kernel_<T, false, Shared><<<
+			static_cast<unsigned int>(batch), threads, shared_size>>>(
+				path, out, workspace, length, dimension, data);
+	}
+}
+
+template<typename T>
+void branched_log_sig_from_path_cuda_(
+	const T* path,
+	T* out,
+	uint64_t batch_size,
+	uint64_t length,
+	uint64_t dimension,
+	uint64_t max_nodes
+) {
+	if (length == 0)
+		throw std::invalid_argument(
+			"branched_log_sig method 3 received an empty path");
+	const CuMkwBchCache& cache = get_cuda_mkw_bch_cache_(
+		dimension, max_nodes);
+	const CuMkwBchDeviceData data = cache.device_data();
+	if (batch_size == 0 || data.m == 0)
+		return;
+	if (length == 1) {
+		const uint64_t output_elements = checked_mkw_product_(
+			batch_size, data.m, "MKW BCH output size overflow");
+		CUDA_CHECK(cudaMemset(
+			out, 0, checked_mkw_product_(output_elements, sizeof(T),
+				"MKW BCH output byte size overflow")));
+		check_cuda_kernel_launch();
+		return;
+	}
+
+	const uint64_t workspace_per_batch = checked_mkw_product_(
+		data.m2, data.m, "MKW BCH workspace size overflow");
+	size_t free_memory = 0;
+	size_t total_memory = 0;
+	CUDA_CHECK(cudaMemGetInfo(&free_memory, &total_memory));
+	const uint64_t workspace_bytes = checked_mkw_product_(
+		workspace_per_batch, sizeof(T), "MKW BCH workspace byte size overflow");
+	const uint64_t reservation_bytes = checked_mkw_product_(
+		2, workspace_bytes, "MKW BCH memory reservation overflow");
+	uint64_t chunk_size = workspace_bytes == 0
+		? batch_size
+		: free_memory / reservation_bytes;
+	chunk_size = std::max<uint64_t>(1, chunk_size);
+	chunk_size = std::min<uint64_t>(
+		std::min<uint64_t>(batch_size, chunk_size), CUDA_GRID_X_LIMIT);
+	CudaBuf<T> workspace(checked_mkw_product_(
+		chunk_size, workspace_bytes, "MKW BCH workspace allocation overflow"));
+
+	unsigned int threads = static_cast<unsigned int>(
+		std::min<uint64_t>(64, data.m));
+	threads = std::max(32U, ((threads + 31) / 32) * 32);
+	const size_t shared_size = checked_mkw_product_(
+		checked_mkw_product_(2, data.m, "MKW BCH shared size overflow"),
+		sizeof(T), "MKW BCH shared byte size overflow");
+	const bool shared = shared_size <= CUDA_BASE_DYNAMIC_SMEM;
+	const uint64_t passes = length > 2 ? length - 2 : 0;
+	const long double dense_work = static_cast<long double>(passes)
+		* cache.bch.linear_dense_forward_work;
+	const long double exact_work = static_cast<long double>(passes)
+		* cache.exact_forward_work + cache.exact_zero_work;
+	const bool sparse = data.m2 > 2 && exact_work < dense_work;
+	const uint64_t path_stride = checked_mkw_product_(
+		length, dimension, "MKW BCH path stride overflow");
+	checked_mkw_product_(
+		batch_size, path_stride, "MKW BCH path size overflow");
+	checked_mkw_product_(
+		batch_size, data.m, "MKW BCH output size overflow");
+
+	for (uint64_t offset = 0; offset < batch_size; offset += chunk_size) {
+		const uint64_t current_batch = std::min(
+			chunk_size, batch_size - offset);
+		if (shared) {
+			launch_mkw_forward_<T, true>(
+				sparse, path + offset * path_stride,
+				out + offset * data.m, workspace.get(), current_batch,
+				length, dimension, threads, shared_size, data);
+		}
+		else {
+			launch_mkw_forward_<T, false>(
+				sparse, path + offset * path_stride,
+				out + offset * data.m, workspace.get(), current_batch,
+				length, dimension, threads, 0, data);
+		}
+		check_cuda_kernel_launch();
+	}
+}
+
+template<typename T>
+__device__ __forceinline__ void add_mkw_segment_vjp_(
+	const T* left,
+	const T* right,
+	const T* accumulated_derivs,
+	const T* leaf_derivs,
+	T* left_derivs,
+	T* right_derivs,
+	uint64_t dimension,
+	const CuMkwBchDeviceData& data
+) {
+	for (uint64_t label = threadIdx.x; label < dimension; label += blockDim.x) {
+		T derivative = T(0);
+		for (uint64_t q = 0; q < data.segment_count; ++q) {
+			const uint32_t coordinate = data.segment_idx[q];
+			T base = accumulated_derivs[coordinate];
+			if (leaf_derivs != nullptr)
+				base += leaf_derivs[coordinate];
+			base *= static_cast<T>(data.segment_coefficients[q]);
+			const uint32_t start = data.segment_label_offsets[q];
+			const uint32_t end = data.segment_label_offsets[q + 1];
+			for (uint32_t position = start; position < end; ++position) {
+				if (data.segment_labels[position] != label)
+					continue;
+				T product = base;
+				for (uint32_t other = start; other < end; ++other) {
+					if (other == position)
+						continue;
+					const uint8_t other_label = data.segment_labels[other];
+					product *= right[other_label] - left[other_label];
+				}
+				derivative += product;
+			}
+		}
+		right_derivs[label] += derivative;
+		left_derivs[label] -= derivative;
+	}
+}
+
+template<typename T, bool Sparse, bool Shared>
+__device__ __forceinline__ void reverse_mkw_bch_nodes_(
+	const T* memo,
+	T* deriv_memo,
+	T* shared_left,
+	T* shared_right,
+	const CuMkwBchDeviceData& data
+) {
+	const uint64_t tid = threadIdx.x;
+	const uint64_t stride = blockDim.x;
+	for (uint64_t offset = 0; offset + 2 < data.m2; ++offset) {
+		const uint64_t w = data.m2 - offset - 1;
+		const uint64_t left_factor = data.bch_left_factor[w];
+		const uint64_t right_factor = data.bch_right_factor[w];
+		const T* left_global = memo + left_factor * data.m;
+		const T* right_global = memo + right_factor * data.m;
+		const T* left = left_global;
+		const T* right = right_global;
+		if constexpr (Shared) {
+			for (uint64_t k = tid; k < data.m; k += stride) {
+				shared_left[k] = left_global[k];
+				shared_right[k] = right_global[k];
+			}
+			__syncthreads();
+			left = shared_left;
+			right = shared_right;
+		}
+
+		const T* node_derivs = deriv_memo + w * data.m;
+		T* left_derivs = deriv_memo + left_factor * data.m;
+		T* right_derivs = deriv_memo + right_factor * data.m;
+		if constexpr (Sparse) {
+			for (uint64_t q = data.linear_reverse_ptr[w] + tid;
+				q < data.linear_reverse_ptr[w + 1]; q += stride) {
+				const uint32_t a = data.linear_reverse_idx[q];
+				T left_value = T(0);
+				T right_value = T(0);
+				const uint64_t row = w * data.m + a;
+				for (uint64_t position = data.linear_a_ptr[row];
+					position < data.linear_a_ptr[row + 1]; ++position) {
+					const uint32_t packed = data.linear_a_idx[position];
+					const uint32_t index = packed >> 1;
+					const uint32_t k = data.comm_a_k[index];
+					const uint32_t partner = data.comm_a_partner[index];
+					const T coefficient = static_cast<T>(
+						data.comm_a_signed_c[index]);
+					if (packed & 1)
+						right_value -= coefficient * left[partner] * node_derivs[k];
+					else
+						left_value += coefficient * right[partner] * node_derivs[k];
+				}
+				left_derivs[a] += left_value;
+				right_derivs[a] += right_value;
+			}
+		}
+		else {
+			for (uint64_t a = tid; a < data.m; a += stride) {
+				T left_value = T(0);
+				T right_value = T(0);
+				for (uint32_t index = data.comm_a_ptr[a];
+					index < data.comm_a_ptr[a + 1]; ++index) {
+					const uint32_t k = data.comm_a_k[index];
+					const uint32_t partner = data.comm_a_partner[index];
+					const T coefficient = static_cast<T>(
+						data.comm_a_signed_c[index]);
+					left_value += coefficient * right[partner] * node_derivs[k];
+					right_value -= coefficient * left[partner] * node_derivs[k];
+				}
+				left_derivs[a] += left_value;
+				right_derivs[a] += right_value;
+			}
+		}
+		__syncthreads();
+	}
+}
+
+template<typename T, bool SparseForward, bool SaveStates,
+	bool SparseReverse, bool Shared>
+__global__ void branched_log_sig_from_path_backprop_kernel_(
+	const T* __restrict__ out_derivs,
+	T* __restrict__ path_derivs,
+	const T* __restrict__ path,
+	T* __restrict__ workspace,
+	uint64_t length,
+	uint64_t dimension,
+	CuMkwBchDeviceData data
+) {
+	const uint64_t batch_idx = blockIdx.x;
+	const uint64_t tid = threadIdx.x;
+	const uint64_t stride = blockDim.x;
+	const uint64_t segment_count = length - 1;
+	const uint64_t state_count = SaveStates ? segment_count : 2;
+	const uint64_t workspace_per_batch = (state_count + 1) * data.m
+		+ 2 * data.m2 * data.m;
+	T* states = workspace + batch_idx * workspace_per_batch;
+	T* current = states;
+	T* previous = current + data.m;
+	T* memo = states + state_count * data.m;
+	T* deriv_memo = memo + data.m2 * data.m;
+	T* accumulated_derivs = deriv_memo + data.m2 * data.m;
+
+	const T* path_row = path + batch_idx * length * dimension;
+	T* path_derivs_row = path_derivs + batch_idx * length * dimension;
+	const T* out_derivs_row = out_derivs + batch_idx * data.m;
+	T* shared_left = nullptr;
+	T* shared_right = nullptr;
+	if constexpr (Shared) {
+		extern __shared__ char shared_bytes[];
+		shared_left = reinterpret_cast<T*>(shared_bytes);
+		shared_right = shared_left + data.m;
+	}
+
+	for (uint64_t index = tid; index < length * dimension; index += stride)
+		path_derivs_row[index] = T(0);
+	for (uint64_t k = tid; k < data.m; k += stride) {
+		current[k] = T(0);
+		memo[data.m + k] = T(0);
+	}
+	if constexpr (SparseForward) {
+		for (uint64_t index = 2 * data.m + tid;
+			index < data.m2 * data.m; index += stride)
+			memo[index] = T(0);
+	}
+	__syncthreads();
+
+	evaluate_mkw_segment_(
+		path_row, path_row + dimension, current, T(1), data);
+	__syncthreads();
+	for (uint64_t segment = 1; segment < segment_count; ++segment) {
+		const T* left = path_row + segment * dimension;
+		const T* right = left + dimension;
+		const T* accumulator = current;
+		T* next = previous;
+		if constexpr (SaveStates) {
+			accumulator = states + (segment - 1) * data.m;
+			next = states + segment * data.m;
+		}
+		for (uint64_t k = tid; k < data.m; k += stride) {
+			memo[k] = accumulator[k];
+			next[k] = accumulator[k];
+		}
+		evaluate_mkw_segment_(left, right, memo + data.m, T(1), data);
+		__syncthreads();
+		for (uint64_t q = tid; q < data.segment_count; q += stride) {
+			const uint32_t coordinate = data.segment_idx[q];
+			next[coordinate] += memo[data.m + coordinate];
+		}
+		__syncthreads();
+		evaluate_mkw_bch_nodes_<T, SparseForward, Shared, true>(
+			memo, next, shared_left, shared_right, data);
+		if constexpr (!SaveStates) {
+			T* temporary = current;
+			current = previous;
+			previous = temporary;
+		}
+	}
+
+	for (uint64_t k = tid; k < data.m; k += stride)
+		accumulated_derivs[k] = out_derivs_row[k];
+	__syncthreads();
+	for (uint64_t segment_offset = 0;
+		segment_offset + 1 < segment_count; ++segment_offset) {
+		const uint64_t segment = segment_count - segment_offset - 1;
+		const T* left = path_row + segment * dimension;
+		const T* right = left + dimension;
+		if constexpr (SaveStates) {
+			previous = states + (segment - 1) * data.m;
+		}
+		else {
+			for (uint64_t k = tid; k < data.m; k += stride) {
+				memo[k] = current[k];
+				previous[k] = current[k];
+			}
+			evaluate_mkw_segment_(left, right, memo + data.m, T(-1), data);
+			__syncthreads();
+			for (uint64_t q = tid; q < data.segment_count; q += stride) {
+				const uint32_t coordinate = data.segment_idx[q];
+				previous[coordinate] += memo[data.m + coordinate];
+			}
+			__syncthreads();
+			evaluate_mkw_bch_nodes_<T, SparseForward, Shared, true>(
+				memo, previous, shared_left, shared_right, data);
+		}
+
+		for (uint64_t k = tid; k < data.m; k += stride)
+			memo[k] = previous[k];
+		evaluate_mkw_segment_(left, right, memo + data.m, T(1), data);
+		__syncthreads();
+		evaluate_mkw_bch_nodes_<T, SparseForward, Shared, false>(
+			memo, nullptr, shared_left, shared_right, data);
+
+		for (uint64_t k = tid; k < data.m; k += stride) {
+			deriv_memo[k] = T(0);
+			deriv_memo[data.m + k] = T(0);
+		}
+		if constexpr (SparseForward && !SparseReverse) {
+			for (uint64_t index = 2 * data.m + tid;
+				index < data.m2 * data.m; index += stride)
+				deriv_memo[index] = T(0);
+		}
+		__syncthreads();
+		if constexpr (SparseForward) {
+			for (uint64_t w = 2; w < data.m2; ++w) {
+				const T coefficient = static_cast<T>(data.bch_coefficients[w]);
+				for (uint64_t q = data.linear_output_ptr[w] + tid;
+					q < data.linear_output_ptr[w + 1]; q += stride) {
+					const uint32_t k = data.linear_output_idx[q];
+					deriv_memo[w * data.m + k]
+						= coefficient * accumulated_derivs[k];
+				}
+			}
+		}
+		else {
+			for (uint64_t w = 2; w < data.m2; ++w) {
+				const T coefficient = static_cast<T>(data.bch_coefficients[w]);
+				for (uint64_t k = tid; k < data.m; k += stride)
+					deriv_memo[w * data.m + k]
+						= coefficient * accumulated_derivs[k];
+			}
+		}
+		__syncthreads();
+		reverse_mkw_bch_nodes_<T, SparseReverse, Shared>(
+			memo, deriv_memo, shared_left, shared_right, data);
+
+		add_mkw_segment_vjp_(
+			left, right, accumulated_derivs, deriv_memo + data.m,
+			path_derivs_row + segment * dimension,
+			path_derivs_row + (segment + 1) * dimension,
+			dimension, data);
+		__syncthreads();
+		for (uint64_t k = tid; k < data.m; k += stride)
+			accumulated_derivs[k] += deriv_memo[k];
+		__syncthreads();
+		if constexpr (!SaveStates) {
+			T* temporary = current;
+			current = previous;
+			previous = temporary;
+		}
+	}
+
+	add_mkw_segment_vjp_(
+		path_row, path_row + dimension, accumulated_derivs,
+		static_cast<const T*>(nullptr),
+		path_derivs_row, path_derivs_row + dimension, dimension, data);
+}
+
+template<typename T, bool SaveStates, bool Shared>
+void launch_mkw_backward_(
+	bool sparse_forward,
+	bool sparse_reverse,
+	const T* out_derivs,
+	T* path_derivs,
+	const T* path,
+	T* workspace,
+	uint64_t batch,
+	uint64_t length,
+	uint64_t dimension,
+	unsigned int threads,
+	size_t shared_size,
+	const CuMkwBchDeviceData& data
+) {
+	if (sparse_forward && sparse_reverse) {
+		branched_log_sig_from_path_backprop_kernel_<
+			T, true, SaveStates, true, Shared><<<
+				static_cast<unsigned int>(batch), threads, shared_size>>>(
+					out_derivs, path_derivs, path, workspace,
+					length, dimension, data);
+	}
+	else if (sparse_forward) {
+		branched_log_sig_from_path_backprop_kernel_<
+			T, true, SaveStates, false, Shared><<<
+				static_cast<unsigned int>(batch), threads, shared_size>>>(
+					out_derivs, path_derivs, path, workspace,
+					length, dimension, data);
+	}
+	else if (sparse_reverse) {
+		branched_log_sig_from_path_backprop_kernel_<
+			T, false, SaveStates, true, Shared><<<
+				static_cast<unsigned int>(batch), threads, shared_size>>>(
+					out_derivs, path_derivs, path, workspace,
+					length, dimension, data);
+	}
+	else {
+		branched_log_sig_from_path_backprop_kernel_<
+			T, false, SaveStates, false, Shared><<<
+				static_cast<unsigned int>(batch), threads, shared_size>>>(
+					out_derivs, path_derivs, path, workspace,
+					length, dimension, data);
+	}
+}
+
+template<typename T>
+void branched_log_sig_from_path_backprop_cuda_(
+	const T* out_derivs,
+	T* path_derivs,
+	const T* path,
+	uint64_t batch_size,
+	uint64_t length,
+	uint64_t dimension,
+	uint64_t max_nodes
+) {
+	if (length == 0)
+		throw std::invalid_argument(
+			"branched_log_sig method 3 received an empty path");
+	const CuMkwBchCache& cache = get_cuda_mkw_bch_cache_(
+		dimension, max_nodes);
+	const CuMkwBchDeviceData data = cache.device_data();
+	if (batch_size == 0)
+		return;
+	const uint64_t path_stride = checked_mkw_product_(
+		length, dimension, "MKW BCH path stride overflow");
+	const uint64_t path_elements = checked_mkw_product_(
+		batch_size, path_stride, "MKW BCH path gradient size overflow");
+	checked_mkw_product_(
+		batch_size, data.m, "MKW BCH output derivative size overflow");
+	if (length == 1 || data.m == 0) {
+		if (path_elements != 0) {
+			CUDA_CHECK(cudaMemset(path_derivs, 0, checked_mkw_product_(
+				path_elements, sizeof(T),
+				"MKW BCH path gradient byte size overflow")));
+			check_cuda_kernel_launch();
+		}
+		return;
+	}
+
+	const uint64_t segment_count = length - 1;
+	const bool save_states = length > 2 && segment_count <= 2 * data.m2;
+	const uint64_t state_count = save_states ? segment_count : 2;
+	const uint64_t memo_size = checked_mkw_product_(
+		data.m2, data.m, "MKW BCH backward memo size overflow");
+	const uint64_t workspace_per_batch = checked_mkw_sum_(
+		checked_mkw_product_(state_count + 1, data.m,
+			"MKW BCH backward state size overflow"),
+		checked_mkw_product_(2, memo_size,
+			"MKW BCH backward workspace size overflow"),
+		"MKW BCH backward workspace size overflow");
+	const uint64_t workspace_bytes = checked_mkw_product_(
+		workspace_per_batch, sizeof(T),
+		"MKW BCH backward workspace byte size overflow");
+	size_t free_memory = 0;
+	size_t total_memory = 0;
+	CUDA_CHECK(cudaMemGetInfo(&free_memory, &total_memory));
+	const uint64_t reservation_bytes = checked_mkw_product_(
+		2, workspace_bytes,
+		"MKW BCH backward memory reservation overflow");
+	uint64_t chunk_size = workspace_bytes == 0
+		? batch_size
+		: free_memory / reservation_bytes;
+	chunk_size = std::max<uint64_t>(1, chunk_size);
+	chunk_size = std::min<uint64_t>(
+		std::min<uint64_t>(batch_size, chunk_size), CUDA_GRID_X_LIMIT);
+	CudaBuf<T> workspace(checked_mkw_product_(
+		chunk_size, workspace_bytes,
+		"MKW BCH backward workspace allocation overflow"));
+
+	unsigned int threads = static_cast<unsigned int>(
+		std::min<uint64_t>(64, data.m));
+	threads = std::max(32U, ((threads + 31) / 32) * 32);
+	const size_t shared_size = checked_mkw_product_(
+		checked_mkw_product_(2, data.m,
+			"MKW BCH backward shared size overflow"),
+		sizeof(T), "MKW BCH backward shared byte size overflow");
+	const bool shared = shared_size <= CUDA_BASE_DYNAMIC_SMEM;
+	const uint64_t combine_count = length > 2 ? length - 2 : 0;
+	const long double passes = static_cast<long double>(combine_count)
+		* (save_states ? 2 : 3);
+	const long double dense_work = passes
+		* cache.bch.linear_dense_forward_work;
+	const long double exact_work = passes
+		* cache.exact_forward_work + cache.exact_zero_work;
+	const bool sparse_forward = data.m2 > 2 && exact_work < dense_work;
+	const bool sparse_reverse = data.m2 > 2 && cache.prune_reverse;
+
+	for (uint64_t offset = 0; offset < batch_size; offset += chunk_size) {
+		const uint64_t current_batch = std::min(
+			chunk_size, batch_size - offset);
+		const T* chunk_out_derivs = out_derivs + offset * data.m;
+		T* chunk_path_derivs = path_derivs + offset * path_stride;
+		const T* chunk_path = path + offset * path_stride;
+		if (save_states && shared) {
+			launch_mkw_backward_<T, true, true>(
+				sparse_forward, sparse_reverse, chunk_out_derivs,
+				chunk_path_derivs, chunk_path, workspace.get(), current_batch,
+				length, dimension, threads, shared_size, data);
+		}
+		else if (save_states) {
+			launch_mkw_backward_<T, true, false>(
+				sparse_forward, sparse_reverse, chunk_out_derivs,
+				chunk_path_derivs, chunk_path, workspace.get(), current_batch,
+				length, dimension, threads, 0, data);
+		}
+		else if (shared) {
+			launch_mkw_backward_<T, false, true>(
+				sparse_forward, sparse_reverse, chunk_out_derivs,
+				chunk_path_derivs, chunk_path, workspace.get(), current_batch,
+				length, dimension, threads, shared_size, data);
+		}
+		else {
+			launch_mkw_backward_<T, false, false>(
+				sparse_forward, sparse_reverse, chunk_out_derivs,
+				chunk_path_derivs, chunk_path, workspace.get(), current_batch,
+				length, dimension, threads, 0, data);
+		}
+		check_cuda_kernel_launch();
+	}
+}
+
+}  // namespace
+
+void prepare_cuda_branched_bch_cache_(
+	const BranchedSigCache& cache,
+	bool
+) {
+	const CuLogSigCacheKey key = make_cuda_log_sig_cache_key_(
+		cache.dimension, cache.max_nodes);
+	{
+		std::lock_guard<std::mutex> lock(s_mkw_bch_cache_mu);
+		if (s_mkw_bch_cache.find(key) != s_mkw_bch_cache.end())
+			return;
+	}
+	auto built = build_cuda_mkw_bch_cache_(cache);
+	std::lock_guard<std::mutex> lock(s_mkw_bch_cache_mu);
+	s_mkw_bch_cache.try_emplace(key, std::move(built));
+}
+
+void clear_cuda_branched_bch_cache_() {
+	std::lock_guard<std::mutex> lock(s_mkw_bch_cache_mu);
+	s_mkw_bch_cache.clear();
+}
+
+extern "C" {
+
+	CUSIG_API int branched_log_sig_from_path_cuda_f(
+		const float* path, float* out, uint64_t batch_size, uint64_t length,
+		uint64_t dimension, uint64_t max_nodes
+	) noexcept {
+		CUSIG_SAFE_CALL(branched_log_sig_from_path_cuda_<float>(
+			path, out, batch_size, length, dimension, max_nodes));
+	}
+
+	CUSIG_API int branched_log_sig_from_path_cuda_d(
+		const double* path, double* out, uint64_t batch_size, uint64_t length,
+		uint64_t dimension, uint64_t max_nodes
+	) noexcept {
+		CUSIG_SAFE_CALL(branched_log_sig_from_path_cuda_<double>(
+			path, out, batch_size, length, dimension, max_nodes));
+	}
+
+	CUSIG_API int branched_log_sig_from_path_backprop_cuda_f(
+		const float* derivs, float* path_derivs, const float* path,
+		uint64_t batch_size, uint64_t length, uint64_t dimension,
+		uint64_t max_nodes
+	) noexcept {
+		CUSIG_SAFE_CALL(branched_log_sig_from_path_backprop_cuda_<float>(
+			derivs, path_derivs, path, batch_size, length, dimension, max_nodes));
+	}
+
+	CUSIG_API int branched_log_sig_from_path_backprop_cuda_d(
+		const double* derivs, double* path_derivs, const double* path,
+		uint64_t batch_size, uint64_t length, uint64_t dimension,
+		uint64_t max_nodes
+	) noexcept {
+		CUSIG_SAFE_CALL(branched_log_sig_from_path_backprop_cuda_<double>(
+			derivs, path_derivs, path, batch_size, length, dimension, max_nodes));
+	}
+
+}

--- a/siglib/cusig/cu_branched_log_sig_cache.h
+++ b/siglib/cusig/cu_branched_log_sig_cache.h
@@ -1,0 +1,84 @@
+/* Copyright 2026 Daniil Shmelev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================================= */
+
+#pragma once
+
+#include "cu_log_sig_cache.h"
+#include "../shared/branched_cache.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+struct CuMkwHostBasisData {
+	int method = 0;
+	std::vector<cu_word> flat_words;
+	std::unordered_map<cu_word, uint64_t, CuWordHash> flat_idx;
+	std::vector<cu_word> lyndon_words;
+	std::vector<uint64_t> lyndon_idx;
+	std::vector<uint64_t> lyndon_weights;
+	std::vector<uint32_t> letter_log_idx;
+	std::vector<uint64_t> letter_basis_idx;
+	std::vector<uint64_t> left_factor;
+	std::vector<uint64_t> right_factor;
+	CuSparseIntMatrix inv_proj_mat;
+	CuSparseIntMatrix inv_proj_mat_t;
+};
+
+struct CuMkwBasisGpuCache {
+	uint32_t* d_lyndon_idx = nullptr;
+	int* d_sparse_vals = nullptr;
+	uint32_t* d_sparse_cols = nullptr;
+	uint32_t* d_sparse_row_ptr = nullptr;
+	int* d_sparse_vals_t = nullptr;
+	uint32_t* d_sparse_cols_t = nullptr;
+	uint32_t* d_sparse_row_ptr_t = nullptr;
+	uint32_t compact_length = 0;
+	int method = 0;
+
+	CuMkwBasisGpuCache() = default;
+	CuMkwBasisGpuCache(const CuMkwBasisGpuCache&) = delete;
+	CuMkwBasisGpuCache& operator=(const CuMkwBasisGpuCache&) = delete;
+	~CuMkwBasisGpuCache();
+};
+
+void prepare_cuda_branched_log_sig_gpu_cache_(
+	const BranchedSigCache& cache);
+
+bool is_cuda_branched_log_sig_gpu_cache_prepared_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	bool planar);
+
+void prepare_cuda_mkw_basis_cache_(
+	const BranchedSigCache& cache,
+	int method,
+	bool use_disk);
+
+const CuMkwHostBasisData& get_cuda_mkw_host_basis_data_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method);
+
+const CuMkwBasisGpuCache& get_cuda_mkw_basis_gpu_cache_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method);
+
+void prepare_cuda_branched_bch_cache_(
+	const BranchedSigCache& cache,
+	bool use_disk);
+
+void clear_cuda_branched_bch_cache_();

--- a/siglib/cusig/cu_branched_log_signature.cu
+++ b/siglib/cusig/cu_branched_log_signature.cu
@@ -16,6 +16,7 @@
 #include "cupch.h"
 #include "cusig.h"
 #include "cu_atomic.h"
+#include "cu_branched_log_sig_cache.h"
 #include "cu_log_sig_cache.h"
 #include "cu_macros.h"
 #include "cu_utils.h"
@@ -104,9 +105,357 @@ static std::unordered_map<
 > s_branched_log_gpu_cache_map;
 static std::mutex s_branched_log_gpu_cache_mu;
 
+static constexpr const char* cu_mkw_basis_cache_prefix_ = "mkw_lyndon_";
+
+static std::unordered_map<
+	std::pair<uint64_t, uint64_t>,
+	std::unique_ptr<CuMkwHostBasisData>,
+	CuPairHash
+> s_mkw_host_basis_cache_map;
+static std::mutex s_mkw_host_basis_cache_mu;
+
+static std::unordered_map<
+	CuBranchedLogCacheKey,
+	std::unique_ptr<CuMkwBasisGpuCache>,
+	CuBranchedLogCacheKeyHash
+> s_mkw_gpu_basis_cache_map;
+static std::mutex s_mkw_gpu_basis_cache_mu;
+
+template<typename T>
+static void upload_branched_log(T*& d_ptr, const T* h_data, size_t count);
+
+CuMkwBasisGpuCache::~CuMkwBasisGpuCache() {
+	if (d_lyndon_idx) cudaFree(d_lyndon_idx);
+	if (d_sparse_vals) cudaFree(d_sparse_vals);
+	if (d_sparse_cols) cudaFree(d_sparse_cols);
+	if (d_sparse_row_ptr) cudaFree(d_sparse_row_ptr);
+	if (d_sparse_vals_t) cudaFree(d_sparse_vals_t);
+	if (d_sparse_cols_t) cudaFree(d_sparse_cols_t);
+	if (d_sparse_row_ptr_t) cudaFree(d_sparse_row_ptr_t);
+}
+
+static std::unique_ptr<CuMkwHostBasisData> build_mkw_word_data_(
+	const BranchedSigCache& cache
+) {
+	auto data = std::make_unique<CuMkwHostBasisData>();
+	const uint64_t lyndon_count = compute_branched_log_sig_length(
+		cache.dimension, cache.max_nodes, true);
+	data->flat_words.resize(cache.total_length);
+	data->flat_idx.reserve(cache.total_length);
+	data->lyndon_words.reserve(lyndon_count);
+	data->lyndon_idx.reserve(lyndon_count);
+	data->lyndon_weights.reserve(lyndon_count);
+	for (uint64_t basis_idx = 0; basis_idx + 1 < cache.total_length; ++basis_idx) {
+		const uint64_t start = cache.basis_forest_offsets[basis_idx];
+		const uint64_t end = cache.basis_forest_offsets[basis_idx + 1];
+		cu_word forest(
+			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(start),
+			cache.basis_forest_data.begin() + static_cast<std::ptrdiff_t>(end));
+		data->flat_words[basis_idx + 1] = forest;
+		if (cu_is_lyndon(forest)) {
+			if (forest.size() == 1) {
+				if (data->lyndon_words.size() > UINT32_MAX)
+					throw std::overflow_error("MKW Lyndon letter index exceeds uint32 range");
+				data->letter_log_idx.push_back(
+					static_cast<uint32_t>(data->lyndon_words.size()));
+				data->letter_basis_idx.push_back(basis_idx);
+			}
+			data->lyndon_words.push_back(forest);
+			data->lyndon_idx.push_back(basis_idx + 1);
+			data->lyndon_weights.push_back(
+				cache.node_labels_offsets[basis_idx + 1]
+				- cache.node_labels_offsets[basis_idx]);
+		}
+	}
+	if (data->lyndon_idx.size() != lyndon_count)
+		throw std::runtime_error("MKW Lyndon cache length mismatch");
+	for (uint64_t i = 0; i < data->flat_words.size(); ++i)
+		data->flat_idx[data->flat_words[i]] = i;
+
+	std::unordered_set<cu_word, CuWordHash> lyndon_set(
+		data->lyndon_words.begin(), data->lyndon_words.end());
+	std::unordered_map<cu_word, uint64_t, CuWordHash> lyndon_map;
+	lyndon_map.reserve(lyndon_count);
+	for (uint64_t i = 0; i < lyndon_count; ++i)
+		lyndon_map[data->lyndon_words[i]] = i;
+	data->left_factor.assign(lyndon_count, UINT64_MAX);
+	data->right_factor.assign(lyndon_count, UINT64_MAX);
+	for (uint64_t i = 0; i < lyndon_count; ++i) {
+		const cu_word& w = data->lyndon_words[i];
+		if (w.size() == 1)
+			continue;
+		const cu_word right = cu_longest_lyndon_suffix_(w, lyndon_set);
+		const cu_word left(w.begin(), w.end() - right.size());
+		data->left_factor[i] = lyndon_map.at(left);
+		data->right_factor[i] = lyndon_map.at(right);
+	}
+	return data;
+}
+
+static void build_mkw_projection_(
+	CuMkwHostBasisData& data,
+	uint64_t flat_word_count
+) {
+	CuSparseIntMatrix projection;
+	cu_lyndon_proj_matrix_from_words(
+		projection,
+		data.lyndon_words,
+		flat_word_count,
+		[&data](const cu_word& w) {
+			return data.flat_idx.at(w);
+		},
+		[&data](uint64_t i, uint64_t j, uint64_t) {
+			cu_word product = data.flat_words.at(i);
+			const cu_word& right = data.flat_words.at(j);
+			product.insert(product.end(), right.begin(), right.end());
+			return data.flat_idx.at(product);
+		});
+	projection.inverse(data.inv_proj_mat);
+	data.inv_proj_mat.transpose(data.inv_proj_mat_t);
+}
+
+static void prepare_cuda_mkw_host_basis_cache_(
+	const BranchedSigCache& cache,
+	int method,
+	bool use_disk
+) {
+	const int basis_method = std::min(method, 2);
+	const std::pair<uint64_t, uint64_t> key(cache.dimension, cache.max_nodes);
+	{
+		std::lock_guard<std::mutex> lock(s_mkw_host_basis_cache_mu);
+		auto found = s_mkw_host_basis_cache_map.find(key);
+		if (found != s_mkw_host_basis_cache_map.end()
+			&& found->second->method >= basis_method)
+			return;
+	}
+
+	auto data = build_mkw_word_data_(cache);
+	bool loaded = false;
+	std::unique_ptr<CuCacheFile> file;
+	if (use_disk) {
+		ensure_cuda_cache_dir_();
+		file = std::make_unique<CuCacheFile>(
+			cache.dimension, cache.max_nodes, cu_mkw_basis_cache_prefix_);
+	}
+	if (file && file->exists()) {
+		int disk_method = 0;
+		std::vector<uint64_t> disk_lyndon_idx;
+		CuSparseIntMatrix disk_inverse;
+		CuSparseIntMatrix disk_inverse_t;
+		file->read(
+			disk_method, disk_lyndon_idx, disk_inverse, disk_inverse_t);
+		if (disk_lyndon_idx != data->lyndon_idx)
+			throw corrupted_cache_error(
+				"MKW Lyndon cache indices do not match the branched basis");
+		if (disk_method >= basis_method) {
+			if (disk_method >= 2
+				&& (disk_inverse.n != data->lyndon_idx.size()
+					|| disk_inverse.m != data->lyndon_idx.size()
+					|| disk_inverse_t.n != data->lyndon_idx.size()
+					|| disk_inverse_t.m != data->lyndon_idx.size()))
+				throw corrupted_cache_error(
+					"MKW Lyndon cache matrix has an invalid shape");
+			data->method = std::min(disk_method, 2);
+			data->inv_proj_mat = std::move(disk_inverse);
+			data->inv_proj_mat_t = std::move(disk_inverse_t);
+			loaded = true;
+		}
+	}
+	if (!loaded) {
+		data->method = basis_method;
+		if (basis_method == 2)
+			build_mkw_projection_(*data, cache.total_length);
+		if (file)
+			file->write(
+				data->method, data->lyndon_idx,
+				data->inv_proj_mat, data->inv_proj_mat_t);
+	}
+
+	std::lock_guard<std::mutex> lock(s_mkw_host_basis_cache_mu);
+	auto found = s_mkw_host_basis_cache_map.find(key);
+	if (found == s_mkw_host_basis_cache_map.end()
+		|| found->second->method < data->method)
+		s_mkw_host_basis_cache_map.insert_or_assign(key, std::move(data));
+}
+
+const CuMkwHostBasisData& get_cuda_mkw_host_basis_data_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method
+) {
+	const int basis_method = std::min(method, 2);
+	const std::pair<uint64_t, uint64_t> key(dimension, max_nodes);
+	std::lock_guard<std::mutex> lock(s_mkw_host_basis_cache_mu);
+	auto found = s_mkw_host_basis_cache_map.find(key);
+	if (found == s_mkw_host_basis_cache_map.end()
+		|| found->second->method < basis_method)
+		throw cache_not_found_error(
+			"CUDA MKW basis cache not found - call prepare_branched_log_sig first");
+	return *found->second;
+}
+
+static uint32_t narrow_mkw_u32_(uint64_t value, const char* label) {
+	if (value > UINT32_MAX)
+		throw std::overflow_error(std::string(label) + " exceeds uint32 range");
+	return static_cast<uint32_t>(value);
+}
+
+static void upload_mkw_csr_(
+	const CuSparseIntMatrix& matrix,
+	int*& d_values,
+	uint32_t*& d_columns,
+	uint32_t*& d_row_offsets
+) {
+	const uint32_t row_count = narrow_mkw_u32_(matrix.n, "MKW matrix row count");
+	uint64_t nnz64 = 0;
+	for (const auto& row : matrix.rows) {
+		if (row.size() > UINT32_MAX
+			|| nnz64 > UINT32_MAX - static_cast<uint64_t>(row.size()))
+			throw std::overflow_error("MKW matrix entry count exceeds uint32 range");
+		nnz64 += row.size();
+	}
+	const uint32_t nnz = static_cast<uint32_t>(nnz64);
+	std::vector<int> values(nnz);
+	std::vector<uint32_t> columns(nnz);
+	std::vector<uint32_t> row_offsets(static_cast<uint64_t>(row_count) + 1);
+	uint32_t entry = 0;
+	for (uint32_t row = 0; row < row_count; ++row) {
+		row_offsets[row] = entry;
+		for (const CuEntry& item : matrix.rows[row]) {
+			values[entry] = item.val;
+			columns[entry] = narrow_mkw_u32_(
+				item.col, "MKW matrix column index");
+			++entry;
+		}
+	}
+	row_offsets[row_count] = entry;
+
+	CudaBuf<int> value_buffer;
+	CudaBuf<uint32_t> column_buffer;
+	if (nnz != 0) {
+		value_buffer = CudaBuf<int>(static_cast<size_t>(nnz) * sizeof(int));
+		column_buffer = CudaBuf<uint32_t>(
+			static_cast<size_t>(nnz) * sizeof(uint32_t));
+		CUDA_CHECK(cudaMemcpy(
+			value_buffer.get(), values.data(),
+			static_cast<size_t>(nnz) * sizeof(int), cudaMemcpyHostToDevice));
+		CUDA_CHECK(cudaMemcpy(
+			column_buffer.get(), columns.data(),
+			static_cast<size_t>(nnz) * sizeof(uint32_t), cudaMemcpyHostToDevice));
+	}
+	CudaBuf<uint32_t> row_buffer(
+		(static_cast<size_t>(row_count) + 1) * sizeof(uint32_t));
+	CUDA_CHECK(cudaMemcpy(
+		row_buffer.get(), row_offsets.data(),
+		(static_cast<size_t>(row_count) + 1) * sizeof(uint32_t),
+		cudaMemcpyHostToDevice));
+	d_values = value_buffer.release();
+	d_columns = column_buffer.release();
+	d_row_offsets = row_buffer.release();
+}
+
+static void upload_mkw_projection_(
+	CuMkwBasisGpuCache& gpu,
+	const CuMkwHostBasisData& host
+) {
+	int* values = nullptr;
+	uint32_t* columns = nullptr;
+	uint32_t* row_offsets = nullptr;
+	int* values_t = nullptr;
+	uint32_t* columns_t = nullptr;
+	uint32_t* row_offsets_t = nullptr;
+	try {
+		upload_mkw_csr_(
+			host.inv_proj_mat, values, columns, row_offsets);
+		upload_mkw_csr_(
+			host.inv_proj_mat_t, values_t, columns_t, row_offsets_t);
+	} catch (...) {
+		if (values) cudaFree(values);
+		if (columns) cudaFree(columns);
+		if (row_offsets) cudaFree(row_offsets);
+		if (values_t) cudaFree(values_t);
+		if (columns_t) cudaFree(columns_t);
+		if (row_offsets_t) cudaFree(row_offsets_t);
+		throw;
+	}
+	gpu.d_sparse_vals = values;
+	gpu.d_sparse_cols = columns;
+	gpu.d_sparse_row_ptr = row_offsets;
+	gpu.d_sparse_vals_t = values_t;
+	gpu.d_sparse_cols_t = columns_t;
+	gpu.d_sparse_row_ptr_t = row_offsets_t;
+	gpu.method = 2;
+}
+
+void prepare_cuda_mkw_basis_cache_(
+	const BranchedSigCache& cache,
+	int method,
+	bool use_disk
+) {
+	if (method < 1 || method > 3)
+		throw std::invalid_argument(
+			"branched log signature method must be 0, 1, 2, or 3");
+	if (!cache.planar)
+		throw std::invalid_argument(
+			"compressed branched log signatures require planar=True");
+	const int basis_method = std::min(method, 2);
+	prepare_cuda_mkw_host_basis_cache_(cache, basis_method, use_disk);
+	const CuMkwHostBasisData& host = get_cuda_mkw_host_basis_data_(
+		cache.dimension, cache.max_nodes, basis_method);
+	const auto key = make_cu_branched_log_key(
+		cache.dimension, cache.max_nodes, true);
+	std::lock_guard<std::mutex> lock(s_mkw_gpu_basis_cache_mu);
+	auto found = s_mkw_gpu_basis_cache_map.find(key);
+	if (found != s_mkw_gpu_basis_cache_map.end()) {
+		if (host.method >= 2 && found->second->method < 2)
+			upload_mkw_projection_(*found->second, host);
+		return;
+	}
+
+	auto gpu = std::make_unique<CuMkwBasisGpuCache>();
+	gpu->compact_length = narrow_mkw_u32_(
+		host.lyndon_idx.size(), "MKW basis length");
+	if (gpu->compact_length != 0) {
+		std::vector<uint32_t> indices(gpu->compact_length);
+		for (uint32_t i = 0; i < gpu->compact_length; ++i)
+			indices[i] = narrow_mkw_u32_(
+				host.lyndon_idx[i], "MKW Lyndon flat index");
+		upload_branched_log(
+			gpu->d_lyndon_idx, indices.data(), indices.size());
+	}
+	gpu->method = 1;
+	if (host.method >= 2)
+		upload_mkw_projection_(*gpu, host);
+	s_mkw_gpu_basis_cache_map.try_emplace(key, std::move(gpu));
+}
+
+const CuMkwBasisGpuCache& get_cuda_mkw_basis_gpu_cache_(
+	uint64_t dimension,
+	uint64_t max_nodes,
+	int method
+) {
+	const int basis_method = std::min(method, 2);
+	const auto key = make_cu_branched_log_key(dimension, max_nodes, true);
+	std::lock_guard<std::mutex> lock(s_mkw_gpu_basis_cache_mu);
+	auto found = s_mkw_gpu_basis_cache_map.find(key);
+	if (found == s_mkw_gpu_basis_cache_map.end()
+		|| found->second->method < basis_method)
+		throw cache_not_found_error(
+			"CUDA MKW basis cache not found - call prepare_branched_log_sig first");
+	return *found->second;
+}
+
 void release_branched_log_sig_gpu_state() {
-	std::lock_guard<std::mutex> lock(s_branched_log_gpu_cache_mu);
-	s_branched_log_gpu_cache_map.clear();
+	{
+		std::lock_guard<std::mutex> lock(s_branched_log_gpu_cache_mu);
+		s_branched_log_gpu_cache_map.clear();
+	}
+	{
+		std::lock_guard<std::mutex> lock(s_mkw_gpu_basis_cache_mu);
+		s_mkw_gpu_basis_cache_map.clear();
+	}
+	std::lock_guard<std::mutex> lock(s_mkw_host_basis_cache_mu);
+	s_mkw_host_basis_cache_map.clear();
 }
 
 void clear_cuda_branched_log_sig_gpu_cache_() {
@@ -202,7 +551,7 @@ static const BranchedLogSigCacheGPU& get_branched_log_gpu_cache(
 		"CUDA branched log sig cache not found - call prepare_branched_log_sig with device='cuda' first");
 }
 
-template<typename T>
+template<typename T, int Method>
 __global__ __launch_bounds__(1024)
 void branched_sig_to_log_sig_ker(
 	const T* __restrict__ bsig,
@@ -214,10 +563,13 @@ void branched_sig_to_log_sig_ker(
 	const uint32_t* __restrict__ g_forest_coprod_offsets,
 	const uint32_t* __restrict__ g_forest_coprod_data,
 	const uint32_t* __restrict__ g_single_tree_forest,
-	uint32_t forest_trees_len,
-	uint32_t forest_coprod_data_len,
 	int max_nodes,
 	bool scalar_term,
+	const uint32_t* __restrict__ g_lyndon_idx,
+	uint32_t compact_len,
+	const int* __restrict__ g_sparse_vals,
+	const uint32_t* __restrict__ g_sparse_cols,
+	const uint32_t* __restrict__ g_sparse_row_ptr,
 	uint64_t batch_offset,
 	uint64_t batch_chunk_size
 ) {
@@ -226,7 +578,8 @@ void branched_sig_to_log_sig_ker(
 	const uint64_t batch_idx = batch_offset + local_batch_idx;
 	const uint32_t tid = threadIdx.x;
 	const uint32_t num_trees = total_len - 1;
-	const uint64_t stride = scalar_term ? total_len : total_len - 1;
+	const uint64_t input_stride = scalar_term ? total_len : total_len - 1;
+	const uint64_t output_stride = Method == 0 ? input_stride : compact_len;
 
 	extern __shared__ char smem[];
 	T* h = reinterpret_cast<T*>(smem);
@@ -234,22 +587,6 @@ void branched_sig_to_log_sig_ker(
 	T* power = h_forest + num_forests;
 	T* next_power = power + num_forests;
 	T* full_out = next_power + num_forests;
-	uint32_t* s_forest_offsets = reinterpret_cast<uint32_t*>(full_out + total_len);
-	uint32_t* s_forest_trees = s_forest_offsets + num_forests + 1;
-	uint32_t* s_forest_coprod_offsets = s_forest_trees + forest_trees_len;
-	uint32_t* s_forest_coprod_data = s_forest_coprod_offsets + num_forests + 1;
-	uint32_t* s_single_tree_forest = s_forest_coprod_data + forest_coprod_data_len;
-
-	for (uint32_t i = tid; i < num_forests + 1; i += blockDim.x) {
-		s_forest_offsets[i] = g_forest_offsets[i];
-		s_forest_coprod_offsets[i] = g_forest_coprod_offsets[i];
-	}
-	for (uint32_t i = tid; i < forest_trees_len; i += blockDim.x)
-		s_forest_trees[i] = g_forest_trees[i];
-	for (uint32_t i = tid; i < forest_coprod_data_len; i += blockDim.x)
-		s_forest_coprod_data[i] = g_forest_coprod_data[i];
-	for (uint32_t i = tid; i < total_len; i += blockDim.x)
-		s_single_tree_forest[i] = g_single_tree_forest[i];
 	for (uint32_t i = tid; i < total_len; i += blockDim.x) {
 		h[i] = T(0);
 		full_out[i] = T(0);
@@ -261,8 +598,8 @@ void branched_sig_to_log_sig_ker(
 	}
 	__syncthreads();
 
-	const T* src = bsig + static_cast<uint64_t>(batch_idx) * stride;
-	T* dst = out + static_cast<uint64_t>(batch_idx) * stride;
+	const T* src = bsig + static_cast<uint64_t>(batch_idx) * input_stride;
+	T* dst = out + static_cast<uint64_t>(batch_idx) * output_stride;
 	for (uint32_t i = tid; i < num_trees; i += blockDim.x) {
 		const T v = scalar_term ? src[i + 1] : src[i];
 		h[i + 1] = v;
@@ -271,17 +608,17 @@ void branched_sig_to_log_sig_ker(
 
 	for (uint32_t forest_idx = tid + 1; forest_idx < num_forests; forest_idx += blockDim.x) {
 		T val = T(1);
-		const uint32_t start = s_forest_offsets[forest_idx];
-		const uint32_t end = s_forest_offsets[forest_idx + 1];
+		const uint32_t start = g_forest_offsets[forest_idx];
+		const uint32_t end = g_forest_offsets[forest_idx + 1];
 		for (uint32_t pos = start; pos < end; ++pos)
-			val *= h[s_forest_trees[pos]];
+			val *= h[g_forest_trees[pos]];
 		h_forest[forest_idx] = val;
 		power[forest_idx] = val;
 	}
 	__syncthreads();
 
 	for (uint32_t i = tid + 1; i < total_len; i += blockDim.x)
-		full_out[i] = power[s_single_tree_forest[i]];
+		full_out[i] = power[g_single_tree_forest[i]];
 	__syncthreads();
 
 	T* cur = power;
@@ -289,11 +626,11 @@ void branched_sig_to_log_sig_ker(
 	for (int k = 2; k <= max_nodes; ++k) {
 		for (uint32_t forest_idx = tid; forest_idx < num_forests; forest_idx += blockDim.x) {
 			T val = T(0);
-			const uint32_t start = s_forest_coprod_offsets[forest_idx];
-			const uint32_t end = s_forest_coprod_offsets[forest_idx + 1];
+			const uint32_t start = g_forest_coprod_offsets[forest_idx];
+			const uint32_t end = g_forest_coprod_offsets[forest_idx + 1];
 			for (uint32_t pos = start; pos < end; pos += 2) {
-				const uint32_t left = s_forest_coprod_data[pos];
-				const uint32_t right = s_forest_coprod_data[pos + 1];
+				const uint32_t left = g_forest_coprod_data[pos];
+				const uint32_t right = g_forest_coprod_data[pos + 1];
 				val += cur[left] * h_forest[right];
 			}
 			next[forest_idx] = val;
@@ -302,7 +639,7 @@ void branched_sig_to_log_sig_ker(
 
 		const T coeff = (k % 2 == 0) ? T(-1) / T(k) : T(1) / T(k);
 		for (uint32_t i = tid + 1; i < total_len; i += blockDim.x)
-			full_out[i] += coeff * next[s_single_tree_forest[i]];
+			full_out[i] += coeff * next[g_single_tree_forest[i]];
 		__syncthreads();
 
 		T* tmp = cur;
@@ -310,16 +647,34 @@ void branched_sig_to_log_sig_ker(
 		next = tmp;
 	}
 
-	if (scalar_term) {
-		for (uint32_t i = tid; i < total_len; i += blockDim.x)
-			dst[i] = (i == 0) ? T(0) : full_out[i];
+	if constexpr (Method == 0) {
+		if (scalar_term) {
+			for (uint32_t i = tid; i < total_len; i += blockDim.x)
+				dst[i] = (i == 0) ? T(0) : full_out[i];
+		} else {
+			for (uint32_t i = tid; i < num_trees; i += blockDim.x)
+				dst[i] = full_out[i + 1];
+		}
+	} else if constexpr (Method == 1) {
+		for (uint32_t i = tid; i < compact_len; i += blockDim.x)
+			dst[i] = full_out[g_lyndon_idx[i]];
 	} else {
-		for (uint32_t i = tid; i < num_trees; i += blockDim.x)
-			dst[i] = full_out[i + 1];
+		for (uint32_t i = tid; i < compact_len; i += blockDim.x)
+			h[i] = full_out[g_lyndon_idx[i]];
+		__syncthreads();
+		for (uint32_t i = tid; i < compact_len; i += blockDim.x) {
+			T value = h[i];
+			const uint32_t start = g_sparse_row_ptr[i];
+			const uint32_t end = g_sparse_row_ptr[i + 1];
+			for (uint32_t pos = start; pos < end; ++pos)
+				value += static_cast<T>(g_sparse_vals[pos])
+					* h[g_sparse_cols[pos]];
+			dst[i] = value;
+		}
 	}
 }
 
-template<typename T>
+template<typename T, int Method>
 __global__ __launch_bounds__(1024)
 void branched_sig_to_log_sig_backprop_ker(
 	const T* __restrict__ bsig,
@@ -332,10 +687,14 @@ void branched_sig_to_log_sig_backprop_ker(
 	const uint32_t* __restrict__ g_forest_coprod_offsets,
 	const uint32_t* __restrict__ g_forest_coprod_data,
 	const uint32_t* __restrict__ g_single_tree_forest,
-	uint32_t forest_trees_len,
-	uint32_t forest_coprod_data_len,
+	T* __restrict__ workspace,
 	int max_nodes,
 	bool scalar_term,
+	const uint32_t* __restrict__ g_lyndon_idx,
+	uint32_t compact_len,
+	const int* __restrict__ g_sparse_vals_t,
+	const uint32_t* __restrict__ g_sparse_cols_t,
+	const uint32_t* __restrict__ g_sparse_row_ptr_t,
 	uint64_t batch_offset,
 	uint64_t batch_chunk_size
 ) {
@@ -345,24 +704,20 @@ void branched_sig_to_log_sig_backprop_ker(
 	const uint32_t tid = threadIdx.x;
 	const uint32_t num_trees = total_len - 1;
 	const uint32_t levels = static_cast<uint32_t>(max_nodes + 1);
-	const uint64_t stride = scalar_term ? total_len : total_len - 1;
+	const uint64_t input_stride = scalar_term ? total_len : total_len - 1;
+	const uint64_t deriv_stride = Method == 0 ? input_stride : compact_len;
 
 	extern __shared__ char smem[];
-	T* powers = reinterpret_cast<T*>(smem);
-	T* d_powers = powers + static_cast<uint64_t>(levels) * num_forests;
-	T* h = d_powers + static_cast<uint64_t>(levels) * num_forests;
+	const uint64_t powers_size = static_cast<uint64_t>(levels) * num_forests;
+	T* powers = workspace + local_batch_idx * 2 * powers_size;
+	T* d_powers = powers + powers_size;
+	T* h = reinterpret_cast<T*>(smem);
 	T* h_forest = h + total_len;
 	T* d_h_forest = h_forest + num_forests;
 	T* d_h_tree = d_h_forest + num_forests;
 	T* full_derivs = d_h_tree + total_len;
-	uint32_t* s_forest_offsets = reinterpret_cast<uint32_t*>(full_derivs + total_len);
-	uint32_t* s_forest_trees = s_forest_offsets + num_forests + 1;
-	uint32_t* s_forest_coprod_offsets = s_forest_trees + forest_trees_len;
-	uint32_t* s_forest_coprod_data = s_forest_coprod_offsets + num_forests + 1;
-	uint32_t* s_single_tree_forest = s_forest_coprod_data + forest_coprod_data_len;
 
-	const uint64_t level_size = static_cast<uint64_t>(levels) * num_forests;
-	for (uint64_t i = tid; i < level_size; i += blockDim.x) {
+	for (uint64_t i = tid; i < powers_size; i += blockDim.x) {
 		powers[i] = T(0);
 		d_powers[i] = T(0);
 	}
@@ -375,37 +730,42 @@ void branched_sig_to_log_sig_backprop_ker(
 		h_forest[i] = T(0);
 		d_h_forest[i] = T(0);
 	}
-	for (uint32_t i = tid; i < num_forests + 1; i += blockDim.x) {
-		s_forest_offsets[i] = g_forest_offsets[i];
-		s_forest_coprod_offsets[i] = g_forest_coprod_offsets[i];
-	}
-	for (uint32_t i = tid; i < forest_trees_len; i += blockDim.x)
-		s_forest_trees[i] = g_forest_trees[i];
-	for (uint32_t i = tid; i < forest_coprod_data_len; i += blockDim.x)
-		s_forest_coprod_data[i] = g_forest_coprod_data[i];
-	for (uint32_t i = tid; i < total_len; i += blockDim.x)
-		s_single_tree_forest[i] = g_single_tree_forest[i];
 	__syncthreads();
 
-	const T* src = bsig + static_cast<uint64_t>(batch_idx) * stride;
-	const T* dsrc = derivs + static_cast<uint64_t>(batch_idx) * stride;
-	T* dst = out + static_cast<uint64_t>(batch_idx) * stride;
+	const T* src = bsig + static_cast<uint64_t>(batch_idx) * input_stride;
+	const T* dsrc = derivs + static_cast<uint64_t>(batch_idx) * deriv_stride;
+	T* dst = out + static_cast<uint64_t>(batch_idx) * input_stride;
 
 	for (uint32_t i = tid; i < num_trees; i += blockDim.x) {
 		const T v = scalar_term ? src[i + 1] : src[i];
-		const T d = scalar_term ? dsrc[i + 1] : dsrc[i];
 		h[i + 1] = v;
-		full_derivs[i + 1] = d;
+	}
+	if constexpr (Method == 0) {
+		for (uint32_t i = tid; i < num_trees; i += blockDim.x)
+			full_derivs[i + 1] = scalar_term ? dsrc[i + 1] : dsrc[i];
+	} else if constexpr (Method == 1) {
+		for (uint32_t i = tid; i < compact_len; i += blockDim.x)
+			full_derivs[g_lyndon_idx[i]] = dsrc[i];
+	} else {
+		for (uint32_t i = tid; i < compact_len; i += blockDim.x) {
+			T value = dsrc[i];
+			const uint32_t start = g_sparse_row_ptr_t[i];
+			const uint32_t end = g_sparse_row_ptr_t[i + 1];
+			for (uint32_t pos = start; pos < end; ++pos)
+				value += static_cast<T>(g_sparse_vals_t[pos])
+					* dsrc[g_sparse_cols_t[pos]];
+			full_derivs[g_lyndon_idx[i]] = value;
+		}
 	}
 	__syncthreads();
 
 	T* p1 = powers + num_forests;
 	for (uint32_t forest_idx = tid + 1; forest_idx < num_forests; forest_idx += blockDim.x) {
 		T val = T(1);
-		const uint32_t start = s_forest_offsets[forest_idx];
-		const uint32_t end = s_forest_offsets[forest_idx + 1];
+		const uint32_t start = g_forest_offsets[forest_idx];
+		const uint32_t end = g_forest_offsets[forest_idx + 1];
 		for (uint32_t pos = start; pos < end; ++pos)
-			val *= h[s_forest_trees[pos]];
+			val *= h[g_forest_trees[pos]];
 		h_forest[forest_idx] = val;
 		p1[forest_idx] = val;
 	}
@@ -416,11 +776,11 @@ void branched_sig_to_log_sig_backprop_ker(
 		T* next = powers + static_cast<uint64_t>(k) * num_forests;
 		for (uint32_t forest_idx = tid; forest_idx < num_forests; forest_idx += blockDim.x) {
 			T val = T(0);
-			const uint32_t start = s_forest_coprod_offsets[forest_idx];
-			const uint32_t end = s_forest_coprod_offsets[forest_idx + 1];
+			const uint32_t start = g_forest_coprod_offsets[forest_idx];
+			const uint32_t end = g_forest_coprod_offsets[forest_idx + 1];
 			for (uint32_t pos = start; pos < end; pos += 2) {
-				const uint32_t left = s_forest_coprod_data[pos];
-				const uint32_t right = s_forest_coprod_data[pos + 1];
+				const uint32_t left = g_forest_coprod_data[pos];
+				const uint32_t right = g_forest_coprod_data[pos + 1];
 				val += prev[left] * h_forest[right];
 			}
 			next[forest_idx] = val;
@@ -432,7 +792,7 @@ void branched_sig_to_log_sig_backprop_ker(
 		const T coeff = (k == 1) ? T(1) : ((k % 2 == 0) ? T(-1) / T(k) : T(1) / T(k));
 		T* dk = d_powers + static_cast<uint64_t>(k) * num_forests;
 		for (uint32_t i = tid + 1; i < total_len; i += blockDim.x)
-			dk[s_single_tree_forest[i]] += coeff * full_derivs[i];
+			dk[g_single_tree_forest[i]] += coeff * full_derivs[i];
 	}
 	__syncthreads();
 
@@ -444,11 +804,11 @@ void branched_sig_to_log_sig_backprop_ker(
 			const T d = d_cur[forest_idx];
 			if (d == T(0))
 				continue;
-			const uint32_t start = s_forest_coprod_offsets[forest_idx];
-			const uint32_t end = s_forest_coprod_offsets[forest_idx + 1];
+			const uint32_t start = g_forest_coprod_offsets[forest_idx];
+			const uint32_t end = g_forest_coprod_offsets[forest_idx + 1];
 			for (uint32_t pos = start; pos < end; pos += 2) {
-				const uint32_t left = s_forest_coprod_data[pos];
-				const uint32_t right = s_forest_coprod_data[pos + 1];
+				const uint32_t left = g_forest_coprod_data[pos];
+				const uint32_t right = g_forest_coprod_data[pos + 1];
 				myAtomicAdd(&d_prev[left], d * h_forest[right]);
 				myAtomicAdd(&d_h_forest[right], d * prev[left]);
 			}
@@ -465,15 +825,15 @@ void branched_sig_to_log_sig_backprop_ker(
 		const T d = d_h_forest[forest_idx];
 		if (d == T(0))
 			continue;
-		const uint32_t start = s_forest_offsets[forest_idx];
-		const uint32_t end = s_forest_offsets[forest_idx + 1];
+		const uint32_t start = g_forest_offsets[forest_idx];
+		const uint32_t end = g_forest_offsets[forest_idx + 1];
 		for (uint32_t pos = start; pos < end; ++pos) {
 			T partial = d;
 			for (uint32_t other = start; other < end; ++other) {
 				if (other != pos)
-					partial *= h[s_forest_trees[other]];
+					partial *= h[g_forest_trees[other]];
 			}
-			myAtomicAdd(&d_h_tree[s_forest_trees[pos]], partial);
+			myAtomicAdd(&d_h_tree[g_forest_trees[pos]], partial);
 		}
 	}
 	__syncthreads();
@@ -489,6 +849,49 @@ void branched_sig_to_log_sig_backprop_ker(
 	}
 }
 
+template<typename T, int Method>
+static void branched_sig_to_log_sig_cuda_method_(
+	const T* bsig,
+	T* out,
+	uint64_t batch_size,
+	const BranchedLogSigCacheGPU& gc,
+	const CuMkwBasisGpuCache* basis,
+	bool scalar_term
+) {
+	const uint32_t compact_len = basis == nullptr ? 0 : basis->compact_length;
+	if (batch_size == 0 || (Method != 0 && compact_len == 0))
+		return;
+	const uint32_t work_items = std::max(
+		std::max(gc.num_trees, gc.num_forests), compact_len);
+	unsigned int block = static_cast<unsigned int>((work_items + 31u) & ~31u);
+	if (block < 32) block = 32;
+	if (block > 1024) block = 1024;
+
+	size_t smem = (2 * static_cast<uint64_t>(gc.total_length)
+		+ 3 * static_cast<uint64_t>(gc.num_forests)) * sizeof(T);
+	configure_dynamic_smem(
+		branched_sig_to_log_sig_ker<T, Method>, smem, "CUDA branched log sig");
+	for (uint64_t batch_offset = 0; batch_offset < batch_size;) {
+		const auto batch_chunk = make_cuda_batch_grid_chunk(
+			1, batch_size, batch_offset);
+		branched_sig_to_log_sig_ker<T, Method><<<batch_chunk.grid, block, smem>>>(
+			bsig, out, gc.total_length, gc.num_forests,
+			gc.d_forest_offsets32, gc.d_forest_trees32,
+			gc.d_forest_coprod_offsets32, gc.d_forest_coprod_data32,
+			gc.d_single_tree_forest32,
+			gc.max_nodes, scalar_term,
+			basis == nullptr ? nullptr : basis->d_lyndon_idx,
+			compact_len,
+			basis == nullptr ? nullptr : basis->d_sparse_vals,
+			basis == nullptr ? nullptr : basis->d_sparse_cols,
+			basis == nullptr ? nullptr : basis->d_sparse_row_ptr,
+			batch_chunk.offset, batch_chunk.size);
+		batch_offset += batch_chunk.size;
+	}
+	cudaDeviceSynchronize();
+	check_cuda_error();
+}
+
 template<typename T>
 void branched_sig_to_log_sig_cuda_(
 	const T* bsig,
@@ -496,33 +899,115 @@ void branched_sig_to_log_sig_cuda_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	bool planar,
 	bool scalar_term
 ) {
-	const auto& gc = get_branched_log_gpu_cache(dimension, max_nodes, planar);
-	const uint32_t work_items = std::max(gc.num_trees, gc.num_forests);
+	if (method == 3)
+		throw std::invalid_argument(
+			"method=3 is not supported in branched_sig_to_log_sig; use branched_log_sig instead");
+	if (method < 0 || method > 2)
+		throw std::invalid_argument(
+			"branched log signature method must be 0, 1, 2, or 3");
+	if (method != 0 && !planar)
+		throw std::invalid_argument(
+			"compressed branched log signatures require planar=True");
+	const auto& gc = get_branched_log_gpu_cache(
+		dimension, max_nodes, planar);
+	if (method == 0) {
+		branched_sig_to_log_sig_cuda_method_<T, 0>(
+			bsig, out, batch_size, gc, nullptr, scalar_term);
+		return;
+	}
+	const auto& basis = get_cuda_mkw_basis_gpu_cache_(
+		dimension, max_nodes, method);
+	if (method == 1)
+		branched_sig_to_log_sig_cuda_method_<T, 1>(
+			bsig, out, batch_size, gc, &basis, scalar_term);
+	else
+		branched_sig_to_log_sig_cuda_method_<T, 2>(
+			bsig, out, batch_size, gc, &basis, scalar_term);
+}
+
+template<typename T, int Method>
+static void branched_sig_to_log_sig_backprop_cuda_method_(
+	const T* bsig,
+	const T* derivs,
+	T* out,
+	uint64_t batch_size,
+	const BranchedLogSigCacheGPU& gc,
+	const CuMkwBasisGpuCache* basis,
+	bool scalar_term
+) {
+	const uint32_t compact_len = basis == nullptr ? 0 : basis->compact_length;
+	if (batch_size == 0)
+		return;
+	if (Method != 0 && compact_len == 0) {
+		const uint64_t input_stride = scalar_term
+			? gc.total_length : gc.total_length - 1;
+		if (input_stride != 0) {
+			CUDA_CHECK(cudaMemset(
+				out, 0, batch_size * input_stride * sizeof(T)));
+			check_cuda_kernel_launch();
+		}
+		return;
+	}
+	const uint32_t work_items = std::max(
+		std::max(gc.num_trees, gc.num_forests), compact_len);
 	unsigned int block = static_cast<unsigned int>((work_items + 31u) & ~31u);
 	if (block < 32) block = 32;
 	if (block > 1024) block = 1024;
 
-	size_t smem = (2 * static_cast<uint64_t>(gc.total_length) + 3 * static_cast<uint64_t>(gc.num_forests)) * sizeof(T)
-		+ (2 * (static_cast<uint64_t>(gc.num_forests) + 1)
-			+ static_cast<uint64_t>(gc.forest_trees_len)
-			+ static_cast<uint64_t>(gc.forest_coprod_data_len)
-			+ static_cast<uint64_t>(gc.total_length)) * sizeof(uint32_t);
+	const uint64_t levels = static_cast<uint64_t>(gc.max_nodes + 1);
+	const uint64_t power_elements = checked_branched_mul_(
+		checked_branched_mul_(2, levels,
+			"CUDA branched log sig backprop workspace size overflow"),
+		gc.num_forests,
+		"CUDA branched log sig backprop workspace size overflow");
+	const uint64_t workspace_bytes = checked_branched_mul_(
+		power_elements, sizeof(T),
+		"CUDA branched log sig backprop workspace byte size overflow");
+	size_t free_memory = 0;
+	size_t total_memory = 0;
+	CUDA_CHECK(cudaMemGetInfo(&free_memory, &total_memory));
+	const uint64_t reservation_bytes = checked_branched_mul_(
+		2, workspace_bytes,
+		"CUDA branched log sig backprop memory reservation overflow");
+	uint64_t workspace_chunk_size = workspace_bytes == 0
+		? batch_size
+		: free_memory / reservation_bytes;
+	workspace_chunk_size = std::max<uint64_t>(1, workspace_chunk_size);
+	workspace_chunk_size = std::min<uint64_t>(
+		std::min<uint64_t>(batch_size, workspace_chunk_size),
+		CUDA_BATCH_GRID_CAPACITY);
+	CudaBuf<T> workspace(checked_branched_mul_(
+		workspace_chunk_size, workspace_bytes,
+		"CUDA branched log sig backprop workspace allocation overflow"));
+
+	size_t smem = (2 * static_cast<uint64_t>(gc.num_forests)
+		+ 3 * static_cast<uint64_t>(gc.total_length)) * sizeof(T);
 	configure_dynamic_smem(
-		branched_sig_to_log_sig_ker<T>, smem, "CUDA branched log sig");
-	for (uint64_t batch_offset = 0; batch_offset < batch_size;) {
+		branched_sig_to_log_sig_backprop_ker<T, Method>, smem,
+		"CUDA branched log sig backprop");
+	for (uint64_t batch_offset = 0; batch_offset < batch_size;
+		batch_offset += workspace_chunk_size) {
+		const uint64_t current_batch = std::min<uint64_t>(
+			workspace_chunk_size, batch_size - batch_offset);
 		const auto batch_chunk = make_cuda_batch_grid_chunk(
-			1, batch_size, batch_offset);
-		branched_sig_to_log_sig_ker<T><<<batch_chunk.grid, block, smem>>>(
-			bsig, out, gc.total_length, gc.num_forests,
+			1, current_batch, 0);
+		branched_sig_to_log_sig_backprop_ker<T, Method><<<batch_chunk.grid, block, smem>>>(
+			bsig, derivs, out, gc.total_length, gc.num_forests,
 			gc.d_forest_offsets32, gc.d_forest_trees32,
 			gc.d_forest_coprod_offsets32, gc.d_forest_coprod_data32,
 			gc.d_single_tree_forest32,
-			gc.forest_trees_len, gc.forest_coprod_data_len,
-			gc.max_nodes, scalar_term, batch_chunk.offset, batch_chunk.size);
-		batch_offset += batch_chunk.size;
+			workspace.get(),
+			gc.max_nodes, scalar_term,
+			basis == nullptr ? nullptr : basis->d_lyndon_idx,
+			compact_len,
+			basis == nullptr ? nullptr : basis->d_sparse_vals_t,
+			basis == nullptr ? nullptr : basis->d_sparse_cols_t,
+			basis == nullptr ? nullptr : basis->d_sparse_row_ptr_t,
+			batch_offset, current_batch);
 	}
 	cudaDeviceSynchronize();
 	check_cuda_error();
@@ -536,57 +1021,52 @@ void branched_sig_to_log_sig_backprop_cuda_(
 	uint64_t batch_size,
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	bool planar,
 	bool scalar_term
 ) {
-	const auto& gc = get_branched_log_gpu_cache(dimension, max_nodes, planar);
-	const uint32_t work_items = std::max(gc.num_trees, gc.num_forests);
-	unsigned int block = static_cast<unsigned int>((work_items + 31u) & ~31u);
-	if (block < 32) block = 32;
-	if (block > 1024) block = 1024;
-
-	const uint64_t levels = static_cast<uint64_t>(gc.max_nodes + 1);
-	size_t smem = (2 * levels * static_cast<uint64_t>(gc.num_forests)
-			+ 2 * static_cast<uint64_t>(gc.num_forests)
-			+ 3 * static_cast<uint64_t>(gc.total_length)) * sizeof(T)
-		+ (2 * (static_cast<uint64_t>(gc.num_forests) + 1)
-			+ static_cast<uint64_t>(gc.forest_trees_len)
-			+ static_cast<uint64_t>(gc.forest_coprod_data_len)
-			+ static_cast<uint64_t>(gc.total_length)) * sizeof(uint32_t);
-	configure_dynamic_smem(
-		branched_sig_to_log_sig_backprop_ker<T>, smem, "CUDA branched log sig backprop");
-	for (uint64_t batch_offset = 0; batch_offset < batch_size;) {
-		const auto batch_chunk = make_cuda_batch_grid_chunk(
-			1, batch_size, batch_offset);
-		branched_sig_to_log_sig_backprop_ker<T><<<batch_chunk.grid, block, smem>>>(
-			bsig, derivs, out, gc.total_length, gc.num_forests,
-			gc.d_forest_offsets32, gc.d_forest_trees32,
-			gc.d_forest_coprod_offsets32, gc.d_forest_coprod_data32,
-			gc.d_single_tree_forest32,
-			gc.forest_trees_len, gc.forest_coprod_data_len,
-			gc.max_nodes, scalar_term, batch_chunk.offset, batch_chunk.size);
-		batch_offset += batch_chunk.size;
+	if (method == 3)
+		throw std::invalid_argument(
+			"method=3 is not supported in branched_sig_to_log_sig_backprop");
+	if (method < 0 || method > 2)
+		throw std::invalid_argument(
+			"branched log signature method must be 0, 1, 2, or 3");
+	if (method != 0 && !planar)
+		throw std::invalid_argument(
+			"compressed branched log signatures require planar=True");
+	const auto& gc = get_branched_log_gpu_cache(
+		dimension, max_nodes, planar);
+	if (method == 0) {
+		branched_sig_to_log_sig_backprop_cuda_method_<T, 0>(
+			bsig, derivs, out, batch_size, gc, nullptr, scalar_term);
+		return;
 	}
-	cudaDeviceSynchronize();
-	check_cuda_error();
+	const auto& basis = get_cuda_mkw_basis_gpu_cache_(
+		dimension, max_nodes, method);
+	if (method == 1)
+		branched_sig_to_log_sig_backprop_cuda_method_<T, 1>(
+			bsig, derivs, out, batch_size, gc, &basis, scalar_term);
+	else
+		branched_sig_to_log_sig_backprop_cuda_method_<T, 2>(
+			bsig, derivs, out, batch_size, gc, &basis, scalar_term);
 }
 
 extern "C" {
 
-	CUSIG_API int branched_sig_to_log_sig_cuda_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar, bool scalar_term) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_to_log_sig_cuda_<float>(bsig, out, batch_size, dimension, max_nodes, planar, scalar_term));
+	CUSIG_API int branched_sig_to_log_sig_cuda_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar, bool scalar_term) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_to_log_sig_cuda_<float>(bsig, out, batch_size, dimension, max_nodes, method, planar, scalar_term));
 	}
 
-	CUSIG_API int branched_sig_to_log_sig_cuda_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar, bool scalar_term) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_to_log_sig_cuda_<double>(bsig, out, batch_size, dimension, max_nodes, planar, scalar_term));
+	CUSIG_API int branched_sig_to_log_sig_cuda_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar, bool scalar_term) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_to_log_sig_cuda_<double>(bsig, out, batch_size, dimension, max_nodes, method, planar, scalar_term));
 	}
 
-	CUSIG_API int branched_sig_to_log_sig_backprop_cuda_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar, bool scalar_term) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_to_log_sig_backprop_cuda_<float>(bsig, derivs, out, batch_size, dimension, max_nodes, planar, scalar_term));
+	CUSIG_API int branched_sig_to_log_sig_backprop_cuda_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar, bool scalar_term) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_to_log_sig_backprop_cuda_<float>(bsig, derivs, out, batch_size, dimension, max_nodes, method, planar, scalar_term));
 	}
 
-	CUSIG_API int branched_sig_to_log_sig_backprop_cuda_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar, bool scalar_term) noexcept {
-		CUSIG_SAFE_CALL(branched_sig_to_log_sig_backprop_cuda_<double>(bsig, derivs, out, batch_size, dimension, max_nodes, planar, scalar_term));
+	CUSIG_API int branched_sig_to_log_sig_backprop_cuda_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar, bool scalar_term) noexcept {
+		CUSIG_SAFE_CALL(branched_sig_to_log_sig_backprop_cuda_<double>(bsig, derivs, out, batch_size, dimension, max_nodes, method, planar, scalar_term));
 	}
 
 }

--- a/siglib/cusig/cu_branched_signature.cu
+++ b/siglib/cusig/cu_branched_signature.cu
@@ -17,6 +17,7 @@
 #include "cusig.h"
 #include "cu_macros.h"
 #include "cu_atomic.h"
+#include "cu_branched_log_sig_cache.h"
 #include "cu_disk_cache.h"
 #include "cu_path_transforms.h"
 #include "cu_utils.h"
@@ -27,11 +28,6 @@
 #include <vector>
 #include <memory>
 #include <unordered_map>
-
-void prepare_cuda_branched_log_sig_gpu_cache_(
-	const BranchedSigCache& cache);
-bool is_cuda_branched_log_sig_gpu_cache_prepared_(
-	uint64_t dimension, uint64_t max_nodes, bool planar);
 
 // =========================================================================
 // GPU cache: mirrors BranchedSigCache on device memory
@@ -401,17 +397,40 @@ static void prepare_branched_sig_gpu_cache_(
 static void prepare_branched_log_sig_gpu_cache_(
 	uint64_t dimension,
 	uint64_t max_nodes,
+	int method,
 	bool planar,
 	bool use_disk
 ) {
-	if (is_cuda_branched_log_sig_gpu_cache_prepared_(
-		dimension, max_nodes, planar))
+	if (method < 0 || method > 3)
+		throw std::invalid_argument(
+			"branched log signature method must be 0, 1, 2, or 3");
+	if (method == 3 && max_nodes > 12)
+		throw std::runtime_error(
+			"CUDA MKW BCH method supports degree at most 12");
+	if (method != 0 && !planar)
+		throw std::invalid_argument(
+			"compressed branched log signatures require planar=True");
+	if (method == 0) {
+		if (is_cuda_branched_log_sig_gpu_cache_prepared_(
+			dimension, max_nodes, planar))
+			return;
+
+		BranchedSigCache host_cache;
+		prepare_branched_sig_gpu_cache_(
+			dimension, max_nodes, planar, use_disk, &host_cache);
+		prepare_cuda_branched_log_sig_gpu_cache_(host_cache);
 		return;
+	}
 
 	BranchedSigCache host_cache;
 	prepare_branched_sig_gpu_cache_(
 		dimension, max_nodes, planar, use_disk, &host_cache);
-	prepare_cuda_branched_log_sig_gpu_cache_(host_cache);
+	if (!is_cuda_branched_log_sig_gpu_cache_prepared_(
+		dimension, max_nodes, planar))
+		prepare_cuda_branched_log_sig_gpu_cache_(host_cache);
+	prepare_cuda_mkw_basis_cache_(host_cache, method, use_disk);
+	if (method == 3)
+		prepare_cuda_branched_bch_cache_(host_cache, use_disk);
 }
 
 static const BranchedSigCacheGPU& get_gpu_cache(
@@ -2214,10 +2233,11 @@ extern "C" {
 	}
 
 	CUSIG_API int prepare_branched_log_sig_cuda(
-		uint64_t dimension, uint64_t max_nodes, bool planar, bool use_disk
+		uint64_t dimension, uint64_t max_nodes, int method,
+		bool planar, bool use_disk
 	) noexcept {
 		CUSIG_SAFE_CALL(prepare_branched_log_sig_gpu_cache_(
-			dimension, max_nodes, planar, use_disk));
+			dimension, max_nodes, method, planar, use_disk));
 	}
 
 	CUSIG_API int prepare_branched_sig_coef_cuda(const uint64_t* tree_data, uint64_t tree_data_len, uint64_t data_dimension, uint64_t dimension, uint64_t max_nodes, bool planar, bool use_disk) noexcept {

--- a/siglib/cusig/cu_log_sig_cache.h
+++ b/siglib/cusig/cu_log_sig_cache.h
@@ -291,24 +291,20 @@ public:
 // lyndon_proj_matrix (ported from cpsig/words.cpp)
 // =========================================================================
 
-inline void cu_lyndon_proj_matrix(
+template<typename WordToFlatIndex, typename ConcatenateFlatIndex>
+inline void cu_lyndon_proj_matrix_from_words(
 	CuSparseIntMatrix& out,
 	const std::vector<cu_word>& lyndon_words,
-	std::vector<uint64_t> lyndon_idx,
-	uint64_t dimension,
-	uint64_t degree
+	uint64_t flat_word_count,
+	WordToFlatIndex word_to_flat_idx,
+	ConcatenateFlatIndex concatenate_flat_idx
 ) {
 	std::unordered_set<cu_word, CuWordHash> lyndon_set(lyndon_words.begin(), lyndon_words.end());
-	uint64_t n = host_sig_length(dimension, degree);
-	uint64_t m_ = lyndon_words.size();
-
-	auto level_index_uptr = std::make_unique<uint64_t[]>(degree + 2);
-	uint64_t* level_index = level_index_uptr.get();
-	host_populate_level_index(level_index, dimension, degree + 2);
-
-	CuSparseIntMatrix full_mat_transpose(m_, n);
+	const uint64_t m_ = lyndon_words.size();
+	CuSparseIntMatrix full_mat_transpose(m_, flat_word_count);
 
 	std::unordered_map<cu_word, uint64_t, CuWordHash> col_idx;
+	col_idx.reserve(m_);
 	for (uint64_t i = 0; i < m_; ++i) {
 		col_idx[lyndon_words[i]] = i;
 	}
@@ -317,27 +313,34 @@ inline void cu_lyndon_proj_matrix(
 		cu_word w = lyndon_words[i];
 
 		if (w.size() == 1) {
-			full_mat_transpose.insert_entry(i, w[0] + 1, 1);
+			const uint64_t flat_idx = word_to_flat_idx(w);
+			if (flat_idx >= flat_word_count)
+				throw std::out_of_range("lyndon projection word index out of range");
+			full_mat_transpose.insert_entry(i, flat_idx, 1);
 		}
 		else {
 			cu_word v = cu_longest_lyndon_suffix_(w, lyndon_set);
 			cu_word u(w.begin(), w.end() - v.size());
 
-			uint64_t jw = col_idx[w];
-			uint64_t jv = col_idx[v];
-			uint64_t ju = col_idx[u];
+			const uint64_t jw = col_idx.at(w);
+			const uint64_t jv = col_idx.at(v);
+			const uint64_t ju = col_idx.at(u);
 
 			for (const auto& eu : full_mat_transpose.rows[ju]) {
-				if (eu.val) {
-					for (const auto& ev : full_mat_transpose.rows[jv]) {
-						if (ev.val) {
-							uint64_t ic = cu_concatenate_idx(eu.col, ev.col, v.size(), dimension);
-							int val = eu.val * ev.val;
-							full_mat_transpose.add_to_entry(jw, ic, val);
-							ic = cu_concatenate_idx(ev.col, eu.col, u.size(), dimension);
-							full_mat_transpose.add_to_entry(jw, ic, -val);
-						}
-					}
+				if (eu.val == 0)
+					continue;
+				for (const auto& ev : full_mat_transpose.rows[jv]) {
+					if (ev.val == 0)
+						continue;
+					uint64_t flat_idx = concatenate_flat_idx(eu.col, ev.col, v.size());
+					if (flat_idx >= flat_word_count)
+						throw std::out_of_range("lyndon projection concatenation index out of range");
+					const int coeff = eu.val * ev.val;
+					full_mat_transpose.add_to_entry(jw, flat_idx, coeff);
+					flat_idx = concatenate_flat_idx(ev.col, eu.col, u.size());
+					if (flat_idx >= flat_word_count)
+						throw std::out_of_range("lyndon projection concatenation index out of range");
+					full_mat_transpose.add_to_entry(jw, flat_idx, -coeff);
 				}
 			}
 		}
@@ -348,10 +351,36 @@ inline void cu_lyndon_proj_matrix(
 	out.resize(full_mat.m, full_mat.m);
 
 	for (uint64_t i = 0; i < m_; ++i) {
-		out.rows[i] = full_mat.rows[lyndon_idx[i]];
+		const uint64_t flat_idx = word_to_flat_idx(lyndon_words[i]);
+		if (flat_idx >= flat_word_count)
+			throw std::out_of_range("lyndon projection word index out of range");
+		out.rows[i] = full_mat.rows[flat_idx];
 	}
 
 	out.drop_diagonal();
+}
+
+inline void cu_lyndon_proj_matrix(
+	CuSparseIntMatrix& out,
+	const std::vector<cu_word>& lyndon_words,
+	std::vector<uint64_t> lyndon_idx,
+	uint64_t dimension,
+	uint64_t degree
+) {
+	std::unordered_map<cu_word, uint64_t, CuWordHash> flat_idx;
+	flat_idx.reserve(lyndon_words.size());
+	for (uint64_t i = 0; i < lyndon_words.size(); ++i)
+		flat_idx[lyndon_words[i]] = lyndon_idx[i];
+	cu_lyndon_proj_matrix_from_words(
+		out,
+		lyndon_words,
+		host_sig_length(dimension, degree),
+		[&flat_idx](const cu_word& w) {
+			return flat_idx.at(w);
+		},
+		[dimension](uint64_t i, uint64_t j, uint64_t len_j) {
+			return cu_concatenate_idx(i, j, len_j, dimension);
+		});
 }
 
 // =========================================================================
@@ -526,11 +555,15 @@ constexpr const char* cu_cache_version = "v2";
 
 class CuCacheFile {
 public:
-	CuCacheFile(uint64_t dimension, uint64_t degree) {
+	CuCacheFile(
+		uint64_t dimension,
+		uint64_t degree,
+		const std::string& prefix = ""
+	) {
 		auto& dir = get_cuda_cache_dir_();
 		if (dir.empty() || !std::filesystem::exists(dir / cu_cache_folder_name))
 			throw cache_dir_not_set_error("Unexpected internal error. Cache directory was not set correctly.");
-		file_name_ = std::to_string(dimension) + "_" + std::to_string(degree) + "_" + cu_cache_version + ".bin";
+		file_name_ = prefix + std::to_string(dimension) + "_" + std::to_string(degree) + "_" + cu_cache_version + ".bin";
 		file_path_ = dir / cu_cache_folder_name / file_name_;
 	}
 
@@ -751,6 +784,7 @@ void clear_cuda_bch_cache_();
 // Forward declaration - defined in cu_branched_signature.cu
 void clear_cuda_branched_sig_gpu_cache_();
 void clear_cuda_branched_log_sig_gpu_cache_();
+void clear_cuda_branched_bch_cache_();
 void release_sig_kernel_poly_state();
 
 inline void clear_cache_cuda_(bool use_disk) {
@@ -761,6 +795,7 @@ inline void clear_cache_cuda_(bool use_disk) {
 	clear_cuda_bch_cache_();
 	clear_cuda_branched_sig_gpu_cache_();
 	clear_cuda_branched_log_sig_gpu_cache_();
+	clear_cuda_branched_bch_cache_();
 	release_sig_kernel_poly_state();
 	free_cuda_log_sig_workspace_();
 	free_cuda_log_sig_backprop_workspace_();

--- a/siglib/cusig/cusig.h
+++ b/siglib/cusig/cusig.h
@@ -624,14 +624,24 @@ extern "C" {
 	/** @defgroup branched_log_sig_cuda_functions Branched log signature CUDA functions
 	* @{
 	*/
-	/** @brief Prepares the branched-signature and derived branched-log caches on the active CUDA device. */
-	[[nodiscard]] CUSIG_API int prepare_branched_log_sig_cuda(uint64_t dimension, uint64_t max_nodes, bool planar = false, bool use_disk = false) noexcept;
+	/**
+	* @brief Prepares the branched-signature and derived branched-log caches on the active CUDA device.
+	* @param method Branched log-signature method in the range 0 to 3. Methods 1 to 3 require planar=true. Method 3 supports max_nodes up to 12.
+	*/
+	[[nodiscard]] CUSIG_API int prepare_branched_log_sig_cuda(uint64_t dimension, uint64_t max_nodes, int method, bool planar = false, bool use_disk = false) noexcept;
 
-	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_cuda_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_cuda_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_cuda_f(const float* bsig, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_cuda_d(const double* bsig, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar = false, bool scalar_term = true) noexcept;
 
-	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_backprop_cuda_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
-	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_backprop_cuda_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_backprop_cuda_f(const float* bsig, const float* derivs, float* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar = false, bool scalar_term = true) noexcept;
+	[[nodiscard]] CUSIG_API int branched_sig_to_log_sig_backprop_cuda_d(const double* bsig, const double* derivs, double* out, uint64_t batch_size, uint64_t dimension, uint64_t max_nodes, int method, bool planar = false, bool scalar_term = true) noexcept;
+
+	/** @brief Computes planar method 3 directly from a path. */
+	[[nodiscard]] CUSIG_API int branched_log_sig_from_path_cuda_f(const float* path, float* out, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes) noexcept;
+	[[nodiscard]] CUSIG_API int branched_log_sig_from_path_cuda_d(const double* path, double* out, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes) noexcept;
+
+	[[nodiscard]] CUSIG_API int branched_log_sig_from_path_backprop_cuda_f(const float* derivs, float* path_derivs, const float* path, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes) noexcept;
+	[[nodiscard]] CUSIG_API int branched_log_sig_from_path_backprop_cuda_d(const double* derivs, double* path_derivs, const double* path, uint64_t batch_size, uint64_t length, uint64_t dimension, uint64_t max_nodes) noexcept;
 	/** @} */
 
 	/** @defgroup linear_sig_cuda_functions Linear sig CUDA functions

--- a/siglib/cusig/cusig_lifecycle.cu
+++ b/siglib/cusig/cusig_lifecycle.cu
@@ -23,6 +23,7 @@ void release_exp_sig_state();
 void release_sig_combine_state();
 void release_branched_sig_gpu_state();
 void release_branched_log_sig_gpu_state();
+void clear_cuda_branched_bch_cache_();
 void release_log_sig_combine_state();
 void release_sig_kernel_poly_state();
 
@@ -41,6 +42,7 @@ extern "C" {
 		try { release_sig_combine_state();      } catch (...) {}
 		try { release_branched_sig_gpu_state(); } catch (...) {}
 		try { release_branched_log_sig_gpu_state(); } catch (...) {}
+		try { clear_cuda_branched_bch_cache_(); } catch (...) {}
 	}
 
 }

--- a/siglib/cusig_unit_testing/cu_test_branched.cpp
+++ b/siglib/cusig_unit_testing/cu_test_branched.cpp
@@ -357,3 +357,497 @@ TEST(branchedSigCoefCudaTest, ForwardAndBackpropMatchFull) {
     cudaFree(d_sparse_grad);
     cudaFree(d_full_grad);
 }
+
+TEST(branchedLogSigFromPathCudaTest, ForwardAndBackwardMatchMethodTwo) {
+    const uint64_t batch_size = 2;
+    const uint64_t length = 5;
+    const uint64_t dimension = 2;
+    const uint64_t max_nodes = 3;
+    const uint64_t full_length = compute_branched_sig_length(
+        dimension, max_nodes, true);
+    const uint64_t log_length = compute_branched_log_sig_length(
+        dimension, max_nodes, true);
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 3, true, false));
+
+    const std::vector<double> path{
+        0.1, -0.2, 0.4, 0.3, 0.4, 0.3, -0.1, 0.8, 0.2, -0.4,
+        -0.3, 0.2, 0.6, -0.5, 0.6, -0.5, 0.9, 0.1, -0.2, 0.7
+    };
+    std::vector<double> derivs(batch_size * log_length);
+    for (uint64_t index = 0; index < derivs.size(); ++index)
+        derivs[index] = 0.09 * static_cast<double>(index + 1) - 0.4;
+
+    double* d_path = nullptr;
+    double* d_out = nullptr;
+    double* d_derivs = nullptr;
+    double* d_path_derivs = nullptr;
+    double* d_bsig = nullptr;
+    double* d_method_two_out = nullptr;
+    double* d_bsig_derivs = nullptr;
+    double* d_method_two_path_derivs = nullptr;
+    cudaMalloc(&d_path, path.size() * sizeof(double));
+    cudaMalloc(&d_out, derivs.size() * sizeof(double));
+    cudaMalloc(&d_derivs, derivs.size() * sizeof(double));
+    cudaMalloc(&d_path_derivs, path.size() * sizeof(double));
+    cudaMalloc(&d_bsig, batch_size * full_length * sizeof(double));
+    cudaMalloc(&d_method_two_out, derivs.size() * sizeof(double));
+    cudaMalloc(&d_bsig_derivs,
+        batch_size * full_length * sizeof(double));
+    cudaMalloc(&d_method_two_path_derivs, path.size() * sizeof(double));
+    cudaMemcpy(d_path, path.data(), path.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+    cudaMemcpy(d_derivs, derivs.data(), derivs.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+
+    ASSERT_EQ(0, branched_sig_cuda_d(
+        d_path, d_bsig, batch_size, dimension, length, max_nodes,
+        false, false, 1., true, true));
+    ASSERT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_bsig, d_method_two_out, batch_size, dimension, max_nodes,
+        2, true, true));
+    ASSERT_EQ(0, branched_sig_to_log_sig_backprop_cuda_d(
+        d_bsig, d_derivs, d_bsig_derivs, batch_size, dimension,
+        max_nodes, 2, true, true));
+    ASSERT_EQ(0, branched_sig_backprop_cuda_d(
+        d_path, d_method_two_path_derivs, d_bsig_derivs, d_bsig,
+        batch_size, dimension, length, max_nodes,
+        false, false, 1., true, true));
+    ASSERT_EQ(0, branched_log_sig_from_path_cuda_d(
+        d_path, d_out, batch_size, length, dimension, max_nodes));
+    ASSERT_EQ(0, branched_log_sig_from_path_backprop_cuda_d(
+        d_derivs, d_path_derivs, d_path, batch_size, length,
+        dimension, max_nodes));
+    ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+    std::vector<double> expected(derivs.size());
+    std::vector<double> expected_gradient(path.size());
+    std::vector<double> actual(derivs.size());
+    std::vector<double> actual_gradient(path.size());
+    std::vector<double> actual_derivs(derivs.size());
+    cudaMemcpy(expected.data(), d_method_two_out,
+        expected.size() * sizeof(double), cudaMemcpyDeviceToHost);
+    cudaMemcpy(expected_gradient.data(), d_method_two_path_derivs,
+        expected_gradient.size() * sizeof(double), cudaMemcpyDeviceToHost);
+    cudaMemcpy(actual.data(), d_out, actual.size() * sizeof(double),
+        cudaMemcpyDeviceToHost);
+    cudaMemcpy(actual_gradient.data(), d_path_derivs,
+        actual_gradient.size() * sizeof(double), cudaMemcpyDeviceToHost);
+    cudaMemcpy(actual_derivs.data(), d_derivs,
+        actual_derivs.size() * sizeof(double), cudaMemcpyDeviceToHost);
+    for (uint64_t index = 0; index < actual.size(); ++index)
+        EXPECT_NEAR(actual[index], expected[index], 2e-11);
+    for (uint64_t index = 0; index < actual_gradient.size(); ++index)
+        EXPECT_NEAR(actual_gradient[index], expected_gradient[index], 2e-10);
+    EXPECT_EQ(actual_derivs, derivs);
+
+    cudaFree(d_path);
+    cudaFree(d_out);
+    cudaFree(d_derivs);
+    cudaFree(d_path_derivs);
+    cudaFree(d_bsig);
+    cudaFree(d_method_two_out);
+    cudaFree(d_bsig_derivs);
+    cudaFree(d_method_two_path_derivs);
+}
+
+TEST(branchedLogSigFromPathCudaTest, FloatForwardAndBackwardMatchMethodTwo) {
+    const uint64_t batch_size = 1;
+    const uint64_t length = 4;
+    const uint64_t dimension = 2;
+    const uint64_t max_nodes = 3;
+    const uint64_t full_length = compute_branched_sig_length(
+        dimension, max_nodes, true);
+    const uint64_t log_length = compute_branched_log_sig_length(
+        dimension, max_nodes, true);
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 3, true, false));
+
+    const std::vector<float> path{
+        0.2f, -0.1f, 0.5f, 0.3f, -0.4f, 0.8f, 0.7f, -0.2f
+    };
+    std::vector<float> derivs(log_length);
+    for (uint64_t index = 0; index < derivs.size(); ++index)
+        derivs[index] = 0.05f * static_cast<float>(index + 1) - 0.3f;
+
+    float* d_path = nullptr;
+    float* d_out = nullptr;
+    float* d_derivs = nullptr;
+    float* d_path_derivs = nullptr;
+    float* d_bsig = nullptr;
+    float* d_method_two_out = nullptr;
+    float* d_bsig_derivs = nullptr;
+    float* d_method_two_path_derivs = nullptr;
+    cudaMalloc(&d_path, path.size() * sizeof(float));
+    cudaMalloc(&d_out, derivs.size() * sizeof(float));
+    cudaMalloc(&d_derivs, derivs.size() * sizeof(float));
+    cudaMalloc(&d_path_derivs, path.size() * sizeof(float));
+    cudaMalloc(&d_bsig, batch_size * full_length * sizeof(float));
+    cudaMalloc(&d_method_two_out, derivs.size() * sizeof(float));
+    cudaMalloc(&d_bsig_derivs,
+        batch_size * full_length * sizeof(float));
+    cudaMalloc(&d_method_two_path_derivs, path.size() * sizeof(float));
+    cudaMemcpy(d_path, path.data(), path.size() * sizeof(float),
+        cudaMemcpyHostToDevice);
+    cudaMemcpy(d_derivs, derivs.data(), derivs.size() * sizeof(float),
+        cudaMemcpyHostToDevice);
+    ASSERT_EQ(0, branched_sig_cuda_f(
+        d_path, d_bsig, batch_size, dimension, length, max_nodes,
+        false, false, 1.f, true, true));
+    ASSERT_EQ(0, branched_sig_to_log_sig_cuda_f(
+        d_bsig, d_method_two_out, batch_size, dimension, max_nodes,
+        2, true, true));
+    ASSERT_EQ(0, branched_sig_to_log_sig_backprop_cuda_f(
+        d_bsig, d_derivs, d_bsig_derivs, batch_size, dimension,
+        max_nodes, 2, true, true));
+    ASSERT_EQ(0, branched_sig_backprop_cuda_f(
+        d_path, d_method_two_path_derivs, d_bsig_derivs, d_bsig,
+        batch_size, dimension, length, max_nodes,
+        false, false, 1.f, true, true));
+    ASSERT_EQ(0, branched_log_sig_from_path_cuda_f(
+        d_path, d_out, batch_size, length, dimension, max_nodes));
+    ASSERT_EQ(0, branched_log_sig_from_path_backprop_cuda_f(
+        d_derivs, d_path_derivs, d_path, batch_size, length,
+        dimension, max_nodes));
+    ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+    std::vector<float> expected(derivs.size());
+    std::vector<float> expected_gradient(path.size());
+    std::vector<float> actual(derivs.size());
+    std::vector<float> actual_gradient(path.size());
+    cudaMemcpy(expected.data(), d_method_two_out,
+        expected.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(expected_gradient.data(), d_method_two_path_derivs,
+        expected_gradient.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(actual.data(), d_out, actual.size() * sizeof(float),
+        cudaMemcpyDeviceToHost);
+    cudaMemcpy(actual_gradient.data(), d_path_derivs,
+        actual_gradient.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    for (uint64_t index = 0; index < actual.size(); ++index)
+        EXPECT_NEAR(actual[index], expected[index], 2e-5);
+    for (uint64_t index = 0; index < actual_gradient.size(); ++index)
+        EXPECT_NEAR(actual_gradient[index], expected_gradient[index], 2e-4);
+
+    cudaFree(d_path);
+    cudaFree(d_out);
+    cudaFree(d_derivs);
+    cudaFree(d_path_derivs);
+    cudaFree(d_bsig);
+    cudaFree(d_method_two_out);
+    cudaFree(d_bsig_derivs);
+    cudaFree(d_method_two_path_derivs);
+}
+
+TEST(branchedLogSigFromPathCudaTest, ZeroIncrementGradientFiniteDifference) {
+    const uint64_t length = 5;
+    const uint64_t dimension = 2;
+    const uint64_t max_nodes = 3;
+    const uint64_t log_length = compute_branched_log_sig_length(
+        dimension, max_nodes, true);
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 3, true, false));
+
+    std::vector<double> path{
+        0.1, -0.2, 0.4, 0.3, 0.4, 0.3, -0.1, 0.8, 0.2, -0.4
+    };
+    std::vector<double> derivs(log_length);
+    for (uint64_t index = 0; index < derivs.size(); ++index)
+        derivs[index] = 0.07 * static_cast<double>(index + 1) - 0.25;
+
+    double* d_path = nullptr;
+    double* d_out = nullptr;
+    double* d_derivs = nullptr;
+    double* d_path_derivs = nullptr;
+    cudaMalloc(&d_path, path.size() * sizeof(double));
+    cudaMalloc(&d_out, log_length * sizeof(double));
+    cudaMalloc(&d_derivs, derivs.size() * sizeof(double));
+    cudaMalloc(&d_path_derivs, path.size() * sizeof(double));
+    cudaMemcpy(d_derivs, derivs.data(), derivs.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+    cudaMemcpy(d_path, path.data(), path.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+    ASSERT_EQ(0, branched_log_sig_from_path_backprop_cuda_d(
+        d_derivs, d_path_derivs, d_path, 1, length, dimension, max_nodes));
+    ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+    std::vector<double> gradient(path.size());
+    cudaMemcpy(gradient.data(), d_path_derivs, gradient.size() * sizeof(double),
+        cudaMemcpyDeviceToHost);
+
+    const double epsilon = 1e-6;
+    std::vector<double> out_plus(log_length);
+    std::vector<double> out_minus(log_length);
+    for (uint64_t path_index = 0; path_index < path.size(); ++path_index) {
+        const double original = path[path_index];
+        path[path_index] = original + epsilon;
+        cudaMemcpy(d_path, path.data(), path.size() * sizeof(double),
+            cudaMemcpyHostToDevice);
+        ASSERT_EQ(0, branched_log_sig_from_path_cuda_d(
+            d_path, d_out, 1, length, dimension, max_nodes));
+        cudaMemcpy(out_plus.data(), d_out, out_plus.size() * sizeof(double),
+            cudaMemcpyDeviceToHost);
+
+        path[path_index] = original - epsilon;
+        cudaMemcpy(d_path, path.data(), path.size() * sizeof(double),
+            cudaMemcpyHostToDevice);
+        ASSERT_EQ(0, branched_log_sig_from_path_cuda_d(
+            d_path, d_out, 1, length, dimension, max_nodes));
+        cudaMemcpy(out_minus.data(), d_out, out_minus.size() * sizeof(double),
+            cudaMemcpyDeviceToHost);
+        path[path_index] = original;
+
+        double numerical = 0.;
+        for (uint64_t output_index = 0; output_index < log_length;
+            ++output_index) {
+            numerical += derivs[output_index]
+                * (out_plus[output_index] - out_minus[output_index])
+                / (2. * epsilon);
+        }
+        EXPECT_NEAR(gradient[path_index], numerical, 2e-7);
+    }
+
+    cudaFree(d_path);
+    cudaFree(d_out);
+    cudaFree(d_derivs);
+    cudaFree(d_path_derivs);
+}
+
+TEST(branchedLogSigFromPathCudaTest, LengthOneReturnsZeros) {
+    const uint64_t batch_size = 2;
+    const uint64_t length = 1;
+    const uint64_t dimension = 2;
+    const uint64_t max_nodes = 3;
+    const uint64_t log_length = compute_branched_log_sig_length(
+        dimension, max_nodes, true);
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 3, true, false));
+
+    const std::vector<double> path{ 0.2, -0.3, 0.7, 0.1 };
+    const std::vector<double> derivs(batch_size * log_length, 1.);
+    double* d_path = nullptr;
+    double* d_out = nullptr;
+    double* d_derivs = nullptr;
+    double* d_path_derivs = nullptr;
+    cudaMalloc(&d_path, path.size() * sizeof(double));
+    cudaMalloc(&d_out, derivs.size() * sizeof(double));
+    cudaMalloc(&d_derivs, derivs.size() * sizeof(double));
+    cudaMalloc(&d_path_derivs, path.size() * sizeof(double));
+    cudaMemcpy(d_path, path.data(), path.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+    cudaMemcpy(d_derivs, derivs.data(), derivs.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+
+    ASSERT_EQ(0, branched_log_sig_from_path_cuda_d(
+        d_path, d_out, batch_size, length, dimension, max_nodes));
+    ASSERT_EQ(0, branched_log_sig_from_path_backprop_cuda_d(
+        d_derivs, d_path_derivs, d_path, batch_size, length,
+        dimension, max_nodes));
+    std::vector<double> output(derivs.size());
+    std::vector<double> gradient(path.size());
+    cudaMemcpy(output.data(), d_out, output.size() * sizeof(double),
+        cudaMemcpyDeviceToHost);
+    cudaMemcpy(gradient.data(), d_path_derivs, gradient.size() * sizeof(double),
+        cudaMemcpyDeviceToHost);
+    for (double value : output)
+        EXPECT_DOUBLE_EQ(value, 0.);
+    for (double value : gradient)
+        EXPECT_DOUBLE_EQ(value, 0.);
+
+    cudaFree(d_path);
+    cudaFree(d_out);
+    cudaFree(d_derivs);
+    cudaFree(d_path_derivs);
+}
+
+TEST(branchedLogSigFromPathCudaTest, DegreeLimit) {
+    EXPECT_EQ(0, prepare_branched_log_sig_cuda(0, 12, 3, true, false));
+    EXPECT_NE(0, prepare_branched_log_sig_cuda(0, 13, 3, true, false));
+}
+
+TEST(branchedLogSigFromPathCudaTest, EmptyPathRejected) {
+    EXPECT_NE(0, branched_log_sig_from_path_cuda_d(
+        nullptr, nullptr, 1, 0, 2, 3));
+    EXPECT_NE(0, branched_log_sig_from_path_backprop_cuda_d(
+        nullptr, nullptr, nullptr, 1, 0, 2, 3));
+}
+
+TEST(branchedSigToLogSigCudaTest, MethodsZeroToTwoFiniteDifference) {
+    const uint64_t batch_size = 2;
+    const uint64_t dimension = 3;
+    const uint64_t max_nodes = 4;
+    const uint64_t full_length = compute_branched_sig_length(
+        dimension, max_nodes, true);
+    const uint64_t compact_length = compute_branched_log_sig_length(
+        dimension, max_nodes, true);
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 2, true, false));
+
+    for (bool scalar_term : { true, false }) {
+        const uint64_t input_length = scalar_term
+            ? full_length : full_length - 1;
+        std::vector<double> input(batch_size * input_length);
+        for (uint64_t batch = 0; batch < batch_size; ++batch) {
+            for (uint64_t index = 0; index < input_length; ++index) {
+                if (scalar_term && index == 0) {
+                    input[batch * input_length] = 1.;
+                } else {
+                    const int64_t centered = static_cast<int64_t>(
+                        (batch * 31 + index * 7) % 19) - 9;
+                    input[batch * input_length + index]
+                        = 0.015 * static_cast<double>(centered);
+                }
+            }
+        }
+
+        double* d_input = nullptr;
+        cudaMalloc(&d_input, input.size() * sizeof(double));
+        cudaMemcpy(d_input, input.data(), input.size() * sizeof(double),
+            cudaMemcpyHostToDevice);
+
+        for (int method = 0; method <= 2; ++method) {
+            const uint64_t output_length = method == 0
+                ? input_length : compact_length;
+            std::vector<double> derivs(batch_size * output_length);
+            for (uint64_t index = 0; index < derivs.size(); ++index) {
+                const int64_t centered = static_cast<int64_t>(
+                    (index * 11) % 23) - 11;
+                derivs[index] = 0.02 * static_cast<double>(centered);
+            }
+
+            double* d_output = nullptr;
+            double* d_derivs = nullptr;
+            double* d_gradient = nullptr;
+            cudaMalloc(&d_output,
+                batch_size * output_length * sizeof(double));
+            cudaMalloc(&d_derivs, derivs.size() * sizeof(double));
+            cudaMalloc(&d_gradient, input.size() * sizeof(double));
+            cudaMemcpy(d_derivs, derivs.data(), derivs.size() * sizeof(double),
+                cudaMemcpyHostToDevice);
+
+            ASSERT_EQ(0, branched_sig_to_log_sig_cuda_d(
+                d_input, d_output, batch_size, dimension, max_nodes,
+                method, true, scalar_term));
+            ASSERT_EQ(0, branched_sig_to_log_sig_backprop_cuda_d(
+                d_input, d_derivs, d_gradient, batch_size, dimension,
+                max_nodes, method, true, scalar_term));
+            ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+            std::vector<double> actual(batch_size * output_length);
+            std::vector<double> actual_gradient(input.size());
+            std::vector<double> actual_derivs(derivs.size());
+            cudaMemcpy(actual.data(), d_output,
+                actual.size() * sizeof(double), cudaMemcpyDeviceToHost);
+            cudaMemcpy(actual_gradient.data(), d_gradient,
+                actual_gradient.size() * sizeof(double),
+                cudaMemcpyDeviceToHost);
+            cudaMemcpy(actual_derivs.data(), d_derivs,
+                actual_derivs.size() * sizeof(double), cudaMemcpyDeviceToHost);
+            for (double value : actual)
+                EXPECT_TRUE(std::isfinite(value));
+            EXPECT_EQ(actual_derivs, derivs);
+
+            const double epsilon = 1e-6;
+            std::vector<double> out_plus(actual.size());
+            std::vector<double> out_minus(actual.size());
+            uint64_t checked = 0;
+            for (uint64_t input_index = 0;
+                input_index < input.size() && checked < 8; ++input_index) {
+                if (scalar_term && input_index % input_length == 0)
+                    continue;
+                const double original = input[input_index];
+                input[input_index] = original + epsilon;
+                cudaMemcpy(d_input, input.data(), input.size() * sizeof(double),
+                    cudaMemcpyHostToDevice);
+                ASSERT_EQ(0, branched_sig_to_log_sig_cuda_d(
+                    d_input, d_output, batch_size, dimension, max_nodes,
+                    method, true, scalar_term));
+                cudaMemcpy(out_plus.data(), d_output,
+                    out_plus.size() * sizeof(double), cudaMemcpyDeviceToHost);
+
+                input[input_index] = original - epsilon;
+                cudaMemcpy(d_input, input.data(), input.size() * sizeof(double),
+                    cudaMemcpyHostToDevice);
+                ASSERT_EQ(0, branched_sig_to_log_sig_cuda_d(
+                    d_input, d_output, batch_size, dimension, max_nodes,
+                    method, true, scalar_term));
+                cudaMemcpy(out_minus.data(), d_output,
+                    out_minus.size() * sizeof(double), cudaMemcpyDeviceToHost);
+                input[input_index] = original;
+
+                double numerical = 0.;
+                for (uint64_t output_index = 0;
+                    output_index < derivs.size(); ++output_index) {
+                    numerical += derivs[output_index]
+                        * (out_plus[output_index] - out_minus[output_index])
+                        / (2. * epsilon);
+                }
+                EXPECT_NEAR(actual_gradient[input_index], numerical, 2e-7);
+                ++checked;
+            }
+            cudaMemcpy(d_input, input.data(), input.size() * sizeof(double),
+                cudaMemcpyHostToDevice);
+
+            cudaFree(d_output);
+            cudaFree(d_derivs);
+            cudaFree(d_gradient);
+        }
+        cudaFree(d_input);
+    }
+}
+
+TEST(branchedSigToLogSigCudaTest, CacheUpgradeClearAndDiskRoundTrip) {
+    const uint64_t dimension = 1;
+    const uint64_t max_nodes = 3;
+    const uint64_t full_length = compute_branched_sig_length(
+        dimension, max_nodes, true);
+    const uint64_t compact_length = compute_branched_log_sig_length(
+        dimension, max_nodes, true);
+    const std::vector<double> input(full_length, 0.);
+
+    double* d_input = nullptr;
+    double* d_output = nullptr;
+    cudaMalloc(&d_input, input.size() * sizeof(double));
+    cudaMalloc(&d_output, compact_length * sizeof(double));
+    cudaMemcpy(d_input, input.data(), input.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+
+    ASSERT_EQ(0, clear_cache_cuda(true));
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 1, true, false));
+    EXPECT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 1, true, true));
+    EXPECT_NE(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 2, true, true));
+
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 2, true, false));
+    EXPECT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 1, true, true));
+    EXPECT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 2, true, true));
+
+    ASSERT_EQ(0, clear_cache_cuda(false));
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 3, true, false));
+    EXPECT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 1, true, true));
+    EXPECT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 2, true, true));
+
+    ASSERT_EQ(0, clear_cache_cuda(false));
+    EXPECT_NE(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 1, true, true));
+    EXPECT_NE(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 2, true, true));
+
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 2, true, true));
+    ASSERT_EQ(0, clear_cache_cuda(false));
+    ASSERT_EQ(0, prepare_branched_log_sig_cuda(
+        dimension, max_nodes, 1, true, true));
+    EXPECT_EQ(0, branched_sig_to_log_sig_cuda_d(
+        d_input, d_output, 1, dimension, max_nodes, 2, true, true));
+
+    cudaFree(d_input);
+    cudaFree(d_output);
+    EXPECT_EQ(0, clear_cache_cuda(true));
+}

--- a/siglib/jax_ffi/pysiglib_jax_ffi.cc
+++ b/siglib/jax_ffi/pysiglib_jax_ffi.cc
@@ -436,6 +436,9 @@ struct CudaFns<float> {
     static constexpr auto bsig_to_log_sig = branched_sig_to_log_sig_cuda_f;
     static constexpr auto bsig_to_log_sig_backprop = branched_sig_to_log_sig_backprop_cuda_f;
 
+    static constexpr auto branched_log_sig_from_path = branched_log_sig_from_path_cuda_f;
+    static constexpr auto branched_log_sig_from_path_backprop = branched_log_sig_from_path_backprop_cuda_f;
+
     static constexpr auto log_sig_from_path = log_sig_from_path_cuda_f;
     static constexpr auto log_sig_from_path_backprop = log_sig_from_path_backprop_cuda_f;
 
@@ -479,6 +482,9 @@ struct CudaFns<double> {
 
     static constexpr auto bsig_to_log_sig = branched_sig_to_log_sig_cuda_d;
     static constexpr auto bsig_to_log_sig_backprop = branched_sig_to_log_sig_backprop_cuda_d;
+
+    static constexpr auto branched_log_sig_from_path = branched_log_sig_from_path_cuda_d;
+    static constexpr auto branched_log_sig_from_path_backprop = branched_log_sig_from_path_backprop_cuda_d;
 
     static constexpr auto log_sig_from_path = log_sig_from_path_cuda_d;
     static constexpr auto log_sig_from_path_backprop = log_sig_from_path_backprop_cuda_d;
@@ -2918,7 +2924,7 @@ ffi::Error BranchedSigToLogSigBackpropCpu(
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
 template <typename T>
-ffi::Error BranchedSigToLogSigCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t /*n_jobs*/, bool planar,
+ffi::Error BranchedSigToLogSigCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t method, std::int64_t /*n_jobs*/, bool planar,
     ffi::AnyBuffer& bsig, ffi::Result<ffi::AnyBuffer>& out) {
     SigSpec spec;
     if (auto msg = GetSigSpec(bsig, spec); !msg.empty()) return InvalidArgument(msg);
@@ -2926,13 +2932,14 @@ ffi::Error BranchedSigToLogSigCudaImpl(cudaStream_t stream, std::int64_t dimensi
     if (sync != cudaSuccess) return InternalError(cudaGetErrorString(sync));
     int err_code = CudaFns<T>::bsig_to_log_sig(BufferData<T>(bsig), BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
-        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), planar, true);
+        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes),
+        static_cast<int>(method), planar, true);
     if (err_code != 0) return NativeCallError("branched_sig_to_log_sig_cuda", err_code);
     return ffi::Error::Success();
 }
 
 template <typename T>
-ffi::Error BranchedSigToLogSigBackpropCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t /*n_jobs*/, bool planar,
+ffi::Error BranchedSigToLogSigBackpropCudaImpl(cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes, std::int64_t method, std::int64_t /*n_jobs*/, bool planar,
     ffi::AnyBuffer& bsig, ffi::AnyBuffer& cotangent, ffi::Result<ffi::AnyBuffer>& out) {
     SigSpec spec;
     if (auto msg = GetSigSpec(bsig, spec); !msg.empty()) return InvalidArgument(msg);
@@ -2941,7 +2948,8 @@ ffi::Error BranchedSigToLogSigBackpropCudaImpl(cudaStream_t stream, std::int64_t
     int err_code = CudaFns<T>::bsig_to_log_sig_backprop(BufferData<T>(bsig), BufferData<T>(cotangent),
         BufferData<T>(out),
         spec.is_batch ? spec.batch_size : 1,
-        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes), planar, true);
+        static_cast<std::uint64_t>(dimension), static_cast<std::uint64_t>(max_nodes),
+        static_cast<int>(method), planar, true);
     if (err_code != 0) return NativeCallError("branched_sig_to_log_sig_backprop_cuda", err_code);
     return ffi::Error::Success();
 }
@@ -2950,13 +2958,10 @@ ffi::Error BranchedSigToLogSigCuda(
     cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
     std::int64_t method, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig, ffi::Result<ffi::AnyBuffer> out) {
-    if (method != 0) {
-        return InvalidArgument(
-            "MKW branched log signature methods 1, 2 and 3 are only implemented on CPU");
-    }
     if (auto msg = ValidateFloatBuffer("bsig", bsig); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
-        return BranchedSigToLogSigCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, bsig, out);
+        return BranchedSigToLogSigCudaImpl<T>(
+            stream, dimension, max_nodes, method, n_jobs, planar, bsig, out);
     });
 }
 
@@ -2964,13 +2969,11 @@ ffi::Error BranchedSigToLogSigBackpropCuda(
     cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
     std::int64_t method, std::int64_t n_jobs, bool planar,
     ffi::AnyBuffer bsig, ffi::AnyBuffer cotangent, ffi::Result<ffi::AnyBuffer> out) {
-    if (method != 0) {
-        return InvalidArgument(
-            "MKW branched log signature methods 1, 2 and 3 are only implemented on CPU");
-    }
     if (auto msg = ValidateSameFloatDtype("bsig", bsig, "cotangent", cotangent); !msg.empty()) return InvalidArgument(msg);
     return DispatchFloatDtype(BufferElementType(bsig), [&]<typename T>() -> ffi::Error {
-        return BranchedSigToLogSigBackpropCudaImpl<T>(stream, dimension, max_nodes, n_jobs, planar, bsig, cotangent, out);
+        return BranchedSigToLogSigBackpropCudaImpl<T>(
+            stream, dimension, max_nodes, method, n_jobs, planar, bsig,
+            cotangent, out);
     });
 }
 #endif
@@ -3038,20 +3041,70 @@ ffi::Error BranchedLogSigFromPathBackpropCpu(
 }
 
 #ifdef PYSIGLIB_JAX_WITH_CUDA
-ffi::Error BranchedLogSigFromPathCuda(
-    cudaStream_t, std::int64_t, std::int64_t, std::int64_t,
-    ffi::AnyBuffer, ffi::Result<ffi::AnyBuffer>
+template <typename T>
+ffi::Error BranchedLogSigFromPathCudaImpl(
+    cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+    ffi::AnyBuffer& path, ffi::Result<ffi::AnyBuffer>& out
 ) {
-    return InvalidArgument(
-        "MKW branched log signature method 3 is only implemented on CPU");
+    PathSpec spec;
+    if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
+    auto sync = cudaStreamSynchronize(stream);
+    if (sync != cudaSuccess) return InternalError(cudaGetErrorString(sync));
+
+    const std::uint64_t batch = spec.is_batch ? spec.batch_size : 1;
+    const int err_code = CudaFns<T>::branched_log_sig_from_path(
+        BufferData<T>(path), BufferData<T>(out), batch, spec.length,
+        static_cast<std::uint64_t>(dimension),
+        static_cast<std::uint64_t>(max_nodes));
+    if (err_code != 0) return NativeCallError(
+        "branched_log_sig_from_path_cuda", err_code);
+    return ffi::Error::Success();
+}
+
+template <typename T>
+ffi::Error BranchedLogSigFromPathBackpropCudaImpl(
+    cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+    ffi::AnyBuffer& cotangent, ffi::AnyBuffer& path,
+    ffi::Result<ffi::AnyBuffer>& out
+) {
+    PathSpec spec;
+    if (auto msg = GetPathSpec(path, spec); !msg.empty()) return InvalidArgument(msg);
+    auto sync = cudaStreamSynchronize(stream);
+    if (sync != cudaSuccess) return InternalError(cudaGetErrorString(sync));
+
+    const std::uint64_t batch = spec.is_batch ? spec.batch_size : 1;
+    const int err_code = CudaFns<T>::branched_log_sig_from_path_backprop(
+        BufferData<T>(cotangent), BufferData<T>(out), BufferData<T>(path),
+        batch, spec.length, static_cast<std::uint64_t>(dimension),
+        static_cast<std::uint64_t>(max_nodes));
+    if (err_code != 0) return NativeCallError(
+        "branched_log_sig_from_path_backprop_cuda", err_code);
+    return ffi::Error::Success();
+}
+
+ffi::Error BranchedLogSigFromPathCuda(
+    cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+    std::int64_t /*n_jobs*/, ffi::AnyBuffer path,
+    ffi::Result<ffi::AnyBuffer> out
+) {
+    if (auto msg = ValidateFloatBuffer("path", path); !msg.empty()) return InvalidArgument(msg);
+    return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
+        return BranchedLogSigFromPathCudaImpl<T>(
+            stream, dimension, max_nodes, path, out);
+    });
 }
 
 ffi::Error BranchedLogSigFromPathBackpropCuda(
-    cudaStream_t, std::int64_t, std::int64_t, std::int64_t,
-    ffi::AnyBuffer, ffi::AnyBuffer, ffi::Result<ffi::AnyBuffer>
+    cudaStream_t stream, std::int64_t dimension, std::int64_t max_nodes,
+    std::int64_t /*n_jobs*/, ffi::AnyBuffer cotangent, ffi::AnyBuffer path,
+    ffi::Result<ffi::AnyBuffer> out
 ) {
-    return InvalidArgument(
-        "MKW branched log signature method 3 is only implemented on CPU");
+    if (auto msg = ValidateSameFloatDtype(
+        "cotangent", cotangent, "path", path); !msg.empty()) return InvalidArgument(msg);
+    return DispatchFloatDtype(BufferElementType(path), [&]<typename T>() -> ffi::Error {
+        return BranchedLogSigFromPathBackpropCudaImpl<T>(
+            stream, dimension, max_nodes, cotangent, path, out);
+    });
 }
 #endif
 

--- a/siglib/test_app/dll_funcs.cpp
+++ b/siglib/test_app/dll_funcs.cpp
@@ -222,6 +222,7 @@ prepare_branched_sig_cuda_fn prepare_branched_sig_cuda = nullptr;
 prepare_branched_log_sig_cuda_fn prepare_branched_log_sig_cuda = nullptr;
 prepare_branched_sig_coef_fn prepare_branched_sig_coef = nullptr;
 branched_sig_length_fn branched_sig_length = nullptr;
+branched_log_sig_length_fn branched_log_sig_length = nullptr;
 branched_sig_d_fn branched_sig_d = nullptr;
 branched_sig_cuda_d_fn branched_sig_cuda_d = nullptr;
 prepare_branched_sig_coef_cuda_fn prepare_branched_sig_coef_cuda = nullptr;
@@ -229,8 +230,11 @@ branched_sig_coef_cuda_d_fn branched_sig_coef_cuda_d = nullptr;
 branched_sig_coef_backprop_cuda_d_fn branched_sig_coef_backprop_cuda_d = nullptr;
 branched_sig_to_log_sig_d_fn branched_sig_to_log_sig_d = nullptr;
 branched_sig_to_log_sig_cuda_d_fn branched_sig_to_log_sig_cuda_d = nullptr;
+branched_sig_to_log_sig_backprop_cuda_d_fn branched_sig_to_log_sig_backprop_cuda_d = nullptr;
 branched_log_sig_from_path_d_fn branched_log_sig_from_path_d = nullptr;
 branched_log_sig_from_path_backprop_d_fn branched_log_sig_from_path_backprop_d = nullptr;
+branched_log_sig_from_path_cuda_d_fn branched_log_sig_from_path_cuda_d = nullptr;
+branched_log_sig_from_path_backprop_cuda_d_fn branched_log_sig_from_path_backprop_cuda_d = nullptr;
 
 
 void get_cpsig_fn_ptrs()
@@ -262,6 +266,7 @@ void get_cpsig_fn_ptrs()
     GET_FN(prepare_branched_log_sig, cpsig);
     GET_FN(prepare_branched_sig_coef, cpsig);
     GET_FN(branched_sig_length, cpsig);
+    GET_FN(branched_log_sig_length, cpsig);
     GET_FN(branched_sig_d, cpsig);
     GET_FN(branched_sig_to_log_sig_d, cpsig);
     GET_FN(branched_log_sig_from_path_d, cpsig);
@@ -295,4 +300,7 @@ void get_cusig_fn_ptrs()
     GET_FN(branched_sig_coef_cuda_d, cusig);
     GET_FN(branched_sig_coef_backprop_cuda_d, cusig);
     GET_FN(branched_sig_to_log_sig_cuda_d, cusig);
+    GET_FN(branched_sig_to_log_sig_backprop_cuda_d, cusig);
+    GET_FN(branched_log_sig_from_path_cuda_d, cusig);
+    GET_FN(branched_log_sig_from_path_backprop_cuda_d, cusig);
 }

--- a/siglib/test_app/dll_funcs.h
+++ b/siglib/test_app/dll_funcs.h
@@ -177,23 +177,28 @@ extern log_sig_combine_backprop_cuda_d_fn log_sig_combine_backprop_cuda_d;
 using prepare_branched_sig_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
 using prepare_branched_log_sig_fn = int(CDECL_*)(uint64_t, uint64_t, int, bool, bool);
 using prepare_branched_sig_cuda_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
-using prepare_branched_log_sig_cuda_fn = int(CDECL_*)(uint64_t, uint64_t, bool, bool);
+using prepare_branched_log_sig_cuda_fn = int(CDECL_*)(uint64_t, uint64_t, int, bool, bool);
 using branched_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t, bool);
+using branched_log_sig_length_fn = uint64_t(CDECL_*)(uint64_t, uint64_t, bool);
 using branched_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int, bool, bool, double, bool, bool, const double*, uint64_t, uint64_t, uint64_t);
 using branched_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, bool, const double*, uint64_t, uint64_t, uint64_t);
 using prepare_branched_sig_coef_cuda_fn = int(CDECL_*)(const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool);
 using branched_sig_coef_cuda_d_fn = int(CDECL_*)(const double*, double*, const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t, uint64_t, uint64_t);
 using branched_sig_coef_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, const double*, const double*, const uint64_t*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, bool, bool, double, bool, const double*, uint64_t, uint64_t, uint64_t);
 using branched_sig_to_log_sig_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, int, int, bool, bool);
-using branched_sig_to_log_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, bool, bool);
+using branched_sig_to_log_sig_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, int, bool, bool);
+using branched_sig_to_log_sig_backprop_cuda_d_fn = int(CDECL_*)(const double*, const double*, double*, uint64_t, uint64_t, uint64_t, int, bool, bool);
 using branched_log_sig_from_path_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t, int);
 using branched_log_sig_from_path_backprop_d_fn = int(CDECL_*)(const double*, double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t, int);
+using branched_log_sig_from_path_cuda_d_fn = int(CDECL_*)(const double*, double*, uint64_t, uint64_t, uint64_t, uint64_t);
+using branched_log_sig_from_path_backprop_cuda_d_fn = int(CDECL_*)(const double*, double*, const double*, uint64_t, uint64_t, uint64_t, uint64_t);
 
 extern prepare_branched_sig_fn prepare_branched_sig;
 extern prepare_branched_log_sig_fn prepare_branched_log_sig;
 extern prepare_branched_sig_cuda_fn prepare_branched_sig_cuda;
 extern prepare_branched_log_sig_cuda_fn prepare_branched_log_sig_cuda;
 extern branched_sig_length_fn branched_sig_length;
+extern branched_log_sig_length_fn branched_log_sig_length;
 extern branched_sig_d_fn branched_sig_d;
 extern branched_sig_cuda_d_fn branched_sig_cuda_d;
 extern prepare_branched_sig_coef_cuda_fn prepare_branched_sig_coef_cuda;
@@ -201,8 +206,11 @@ extern branched_sig_coef_cuda_d_fn branched_sig_coef_cuda_d;
 extern branched_sig_coef_backprop_cuda_d_fn branched_sig_coef_backprop_cuda_d;
 extern branched_sig_to_log_sig_d_fn branched_sig_to_log_sig_d;
 extern branched_sig_to_log_sig_cuda_d_fn branched_sig_to_log_sig_cuda_d;
+extern branched_sig_to_log_sig_backprop_cuda_d_fn branched_sig_to_log_sig_backprop_cuda_d;
 extern branched_log_sig_from_path_d_fn branched_log_sig_from_path_d;
 extern branched_log_sig_from_path_backprop_d_fn branched_log_sig_from_path_backprop_d;
+extern branched_log_sig_from_path_cuda_d_fn branched_log_sig_from_path_cuda_d;
+extern branched_log_sig_from_path_backprop_cuda_d_fn branched_log_sig_from_path_backprop_cuda_d;
 
 #if defined(_WIN32)
 #define GET_FN_PTR ::GetProcAddress

--- a/tests/test_branched_log_sig_methods.py
+++ b/tests/test_branched_log_sig_methods.py
@@ -21,6 +21,7 @@ import torch
 
 import pysiglib
 import pysiglib.torch_api as torch_api
+from conftest import check_close, skip_no_cuda
 from pysiglib.branched_log_sig_backprop import (
     _branched_log_sig_from_path_backprop,
 )
@@ -539,10 +540,6 @@ def test_branched_log_sig_method_validation():
         pysiglib.prepare_branched_log_sig(2, 2, 1)
     with pytest.raises(ValueError, match="one of 0, 1, 2 or 3"):
         pysiglib.branched_log_sig(path, 2, planar=True, method=4)
-    for method in (1, 2, 3):
-        with pytest.raises(NotImplementedError, match="only supported on CPU"):
-            pysiglib.prepare_branched_log_sig(
-                2, 2, method, planar=True, device="cuda")
 
 
 def test_prepare_compressed_device_both_prepares_cpu():
@@ -652,13 +649,285 @@ def test_method_three_rejects_correction():
             path, 2, planar=True, method=3, correction=correction)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
-def test_compressed_method_rejects_cuda_tensor():
-    dimension, degree = 2, 2
-    length = pysiglib.branched_sig_length(
-        dimension, degree, planar=True, scalar_term=True)
-    bsig = torch.zeros(length, dtype=torch.float64, device="cuda")
+@pytest.mark.parametrize(
+    "time_aug,lead_lag",
+    [(False, False), (True, False), (False, True), (True, True)],
+)
+@pytest.mark.parametrize("batch_shape", [(), (0,)])
+def test_method_three_rejects_empty_paths(
+        batch_shape, time_aug, lead_lag):
+    path = np.empty(batch_shape + (0, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="empty path"):
+        pysiglib.branched_log_sig(
+            path, 2, planar=True, method=3,
+            time_aug=time_aug, lead_lag=lead_lag)
 
-    with pytest.raises(NotImplementedError, match="only supported on CPU"):
-        pysiglib.branched_sig_to_log_sig(
+    cotangent = np.empty(
+        batch_shape + (
+            pysiglib.branched_log_sig_length(2, 2, planar=True),),
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="empty path"):
+        _branched_log_sig_from_path_backprop(cotangent, path, 2)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("scalar_term", [False, True])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_cuda_compressed_forward_and_backward_match_cpu(
+        method, scalar_term, dtype):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="both")
+    path = np.stack([_path(), 0.6 * _path()]).astype(dtype)
+    bsig = pysiglib.branched_sig(
+        path, degree, planar=True, scalar_term=scalar_term)
+    expected = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+    weights = np.random.default_rng(8162).normal(
+        size=expected.shape).astype(dtype)
+    expected_grad = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, weights, dimension, degree, planar=True, method=method)
+
+    torch_dtype = torch.float32 if dtype == np.float32 else torch.float64
+    bsig_cuda = torch.tensor(
+        bsig, dtype=torch_dtype, device="cuda", requires_grad=True)
+    weights_cuda = torch.tensor(weights, dtype=torch_dtype, device="cuda")
+    saved_weights = weights_cuda.clone()
+    actual = torch_api.branched_sig_to_log_sig(
+        bsig_cuda, dimension, degree, planar=True, method=method)
+    explicit_grad = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig_cuda.detach(), weights_cuda, dimension, degree,
+        planar=True, method=method)
+    (actual * weights_cuda).sum().backward()
+
+    check_close(actual, expected, single_atol=2e-5, double_atol=2e-10)
+    check_close(
+        explicit_grad, expected_grad,
+        single_atol=5e-5, double_atol=2e-9)
+    check_close(
+        bsig_cuda.grad, expected_grad,
+        single_atol=5e-5, double_atol=2e-9)
+    torch.testing.assert_close(weights_cuda, saved_weights)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("scalar_term", [False, True])
+def test_cuda_compressed_empty_batch(scalar_term):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cuda")
+    input_width = pysiglib.branched_sig_length(
+        dimension, degree, planar=True, scalar_term=scalar_term)
+    compact_width = pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True)
+    bsig = torch.empty(
+        (0, input_width), dtype=torch.float64, device="cuda")
+    result = torch_api.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=2)
+    cotangent = torch.empty(
+        (0, compact_width), dtype=torch.float64, device="cuda")
+    gradient = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, cotangent, dimension, degree, planar=True, method=2)
+
+    assert result.shape == (0, compact_width)
+    assert gradient.shape == bsig.shape
+
+
+@skip_no_cuda
+def test_cuda_compressed_cache_upgrade_clear_and_disk_round_trip(tmp_path):
+    dimension, degree = 2, 3
+    input_width = pysiglib.branched_sig_length(
+        dimension, degree, planar=True, scalar_term=True)
+    bsig = torch.cat((
+        torch.ones(1, dtype=torch.float64, device="cuda"),
+        torch.linspace(
+            -0.2, 0.3, input_width - 1,
+            dtype=torch.float64, device="cuda"),
+    ))
+    pysiglib.set_cache_dir(str(tmp_path))
+    pysiglib.clear_cache(use_disk=True)
+    try:
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 1, planar=True, device="cuda")
+        torch_api.branched_sig_to_log_sig(
             bsig, dimension, degree, planar=True, method=1)
+        with pytest.raises(Exception, match="cache"):
+            torch_api.branched_sig_to_log_sig(
+                bsig, dimension, degree, planar=True, method=2)
+
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 2, planar=True, device="cuda",
+            use_disk=True)
+        expected = torch_api.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=2)
+
+        pysiglib.clear_cache(use_disk=False, device="cuda")
+        with pytest.raises(Exception, match="cache"):
+            torch_api.branched_sig_to_log_sig(
+                bsig, dimension, degree, planar=True, method=1)
+
+        pysiglib.prepare_branched_log_sig(
+            dimension, degree, 1, planar=True, device="cuda",
+            use_disk=True)
+        actual = torch_api.branched_sig_to_log_sig(
+            bsig, dimension, degree, planar=True, method=2)
+        torch.testing.assert_close(actual, expected)
+    finally:
+        pysiglib.clear_cache(use_disk=True)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("method", [0, 1, 2])
+def test_cuda_direct_branched_log_sig_with_correction_matches_cpu(method):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="both")
+    path = torch.tensor(
+        _path(), dtype=torch.float64, requires_grad=True)
+    correction = torch.linspace(
+        -0.02, 0.03,
+        (path.shape[0] - 1) * dimension * dimension,
+        dtype=torch.float64,
+    ).reshape(path.shape[0] - 1, dimension * dimension)
+    expected = torch_api.branched_log_sig(
+        path, degree, planar=True, method=method,
+        correction=correction)
+    weights = torch.linspace(
+        -0.4, 0.6, expected.numel(), dtype=torch.float64)
+    (expected * weights).sum().backward()
+
+    path_cuda = path.detach().cuda().requires_grad_(True)
+    actual = torch_api.branched_log_sig(
+        path_cuda,
+        degree, planar=True, method=method,
+        correction=correction.cuda(),
+    )
+    (actual * weights.cuda()).sum().backward()
+
+    check_close(actual, expected, double_atol=2e-9)
+    check_close(path_cuda.grad, path.grad, double_atol=2e-8)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("dimension,degree", [(0, 3), (2, 0)])
+def test_cuda_compressed_zero_width(dimension, degree):
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="cuda")
+    bsig = torch.ones(1, dtype=torch.float64, device="cuda")
+    cotangent = torch.empty(0, dtype=torch.float64, device="cuda")
+
+    output = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=2)
+    gradient = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, cotangent, dimension, degree, planar=True, method=2)
+
+    assert output.shape == (0,)
+    torch.testing.assert_close(gradient, torch.zeros_like(bsig))
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("batch", [False, True])
+def test_cuda_method_three_forward_and_backward_match_cpu(dtype, batch):
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="both")
+    path = np.insert(_path().astype(dtype), 2, _path()[1], axis=0)
+    if batch:
+        path = np.stack([path, 0.7 * path])
+    expected = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=3)
+    weights = np.random.default_rng(9163).normal(
+        size=expected.shape).astype(dtype)
+    expected_grad = _branched_log_sig_from_path_backprop(
+        weights, path, degree)
+
+    torch_dtype = torch.float32 if dtype == np.float32 else torch.float64
+    path_cuda = torch.tensor(
+        path, dtype=torch_dtype, device="cuda", requires_grad=True)
+    weights_cuda = torch.tensor(weights, dtype=torch_dtype, device="cuda")
+    saved_weights = weights_cuda.clone()
+    actual = torch_api.branched_log_sig(
+        path_cuda, degree, planar=True, method=3)
+    explicit_grad = _branched_log_sig_from_path_backprop(
+        weights_cuda, path_cuda.detach(), degree)
+    (actual * weights_cuda).sum().backward()
+
+    tolerance = 5e-4 if dtype == np.float32 else 2e-9
+    check_close(actual, expected, atol=tolerance)
+    check_close(explicit_grad, expected_grad, atol=tolerance)
+    check_close(path_cuda.grad, expected_grad, atol=tolerance)
+    torch.testing.assert_close(weights_cuda, saved_weights)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("method", [0, 1, 2, 3])
+@pytest.mark.parametrize(
+    "time_aug,lead_lag", [(True, False), (False, True), (True, True)])
+def test_cuda_augmentation_matches_cpu(method, time_aug, lead_lag):
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, time_aug=time_aug,
+        lead_lag=lead_lag, device="both")
+    path_cpu = torch.tensor(
+        _path(), dtype=torch.float64, requires_grad=True)
+    expected = torch_api.branched_log_sig(
+        path_cpu, degree, planar=True, method=method, time_aug=time_aug,
+        lead_lag=lead_lag)
+    weights = torch.linspace(
+        -0.3, 0.7, expected.numel(), dtype=torch.float64)
+    (expected * weights).sum().backward()
+
+    path_cuda = torch.tensor(
+        _path(), dtype=torch.float64, device="cuda", requires_grad=True)
+    actual = torch_api.branched_log_sig(
+        path_cuda, degree, planar=True, method=method, time_aug=time_aug,
+        lead_lag=lead_lag)
+    (actual * weights.cuda()).sum().backward()
+
+    check_close(actual, expected, double_atol=2e-9)
+    check_close(path_cuda.grad, path_cpu.grad, double_atol=2e-8)
+
+
+@skip_no_cuda
+def test_cuda_method_three_length_one_returns_zero_gradient():
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cuda")
+    path = torch.tensor(
+        [[0.2, -0.3]], dtype=torch.float64, device="cuda",
+        requires_grad=True)
+    output = torch_api.branched_log_sig(
+        path, degree, planar=True, method=3)
+    output.sum().backward()
+
+    assert torch.count_nonzero(output) == 0
+    assert torch.count_nonzero(path.grad) == 0
+
+
+@skip_no_cuda
+def test_cuda_method_three_degree_zero_returns_empty_output_and_zero_gradient():
+    dimension, degree = 2, 0
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="cuda")
+    path = torch.tensor(
+        [[0.0, 0.1], [0.3, -0.2], [0.7, 0.4]],
+        dtype=torch.float64, device="cuda", requires_grad=True)
+    output = torch_api.branched_log_sig(
+        path, degree, planar=True, method=3)
+    output.sum().backward()
+
+    assert output.shape == (0,)
+    assert torch.count_nonzero(path.grad) == 0
+
+
+@skip_no_cuda
+def test_cuda_method_three_rejects_degree_above_twelve():
+    with pytest.raises(
+        NotImplementedError,
+        match="CUDA MKW BCH method supports degree at most 12",
+    ):
+        pysiglib.prepare_branched_log_sig(
+            1, 13, 3, planar=True, device="cuda")

--- a/tests/test_cuda_grid_limits.py
+++ b/tests/test_cuda_grid_limits.py
@@ -16,6 +16,7 @@
 import torch
 
 import pysiglib
+import pysiglib.torch_api as torch_api
 from conftest import skip_no_cuda
 
 
@@ -84,6 +85,32 @@ def test_branched_cuda_batch_above_grid_y_limit():
     blog_grad = pysiglib.branched_sig_to_log_sig_backprop(
         bsig, torch.ones_like(blog_sig), 1, 1)
     torch.testing.assert_close(blog_grad, torch.ones_like(blog_grad))
+
+    pysiglib.prepare_branched_log_sig(
+        1, 1, 3, planar=True, device="cuda")
+    planar_bsig = pysiglib.branched_sig(path, 1, planar=True)
+    for method in (1, 2):
+        compact = pysiglib.branched_sig_to_log_sig(
+            planar_bsig, 1, 1, planar=True, method=method)
+        torch.testing.assert_close(compact, torch.ones_like(compact))
+
+        compact_grad = pysiglib.branched_sig_to_log_sig_backprop(
+            planar_bsig, torch.ones_like(compact), 1, 1,
+            planar=True, method=method)
+        torch.testing.assert_close(
+            compact_grad, torch.ones_like(compact_grad))
+
+    direct_path = path.clone().detach().requires_grad_(True)
+    direct = torch_api.branched_log_sig(
+        direct_path, 1, planar=True, method=3)
+    torch.testing.assert_close(direct, torch.ones_like(direct))
+    direct.sum().backward()
+    torch.testing.assert_close(
+        direct_path.grad[:, 0, :],
+        -torch.ones_like(direct_path.grad[:, 0, :]))
+    torch.testing.assert_close(
+        direct_path.grad[:, 1, :],
+        torch.ones_like(direct_path.grad[:, 1, :]))
 
     requested = [(0,)]
     pysiglib.prepare_branched_sig_coef(

--- a/tests/test_jax_branched_log_sig_methods.py
+++ b/tests/test_jax_branched_log_sig_methods.py
@@ -42,6 +42,16 @@ def _planar_bsig(dimension, degree, *, batch=False, scalar_term=False):
         path, degree, planar=True, scalar_term=scalar_term)
 
 
+def _gpu_device():
+    try:
+        devices = jax.devices("gpu")
+    except RuntimeError:
+        devices = []
+    if not devices:
+        pytest.skip("JAX GPU device unavailable")
+    return devices[0]
+
+
 @pytest.mark.parametrize("method", [1, 2])
 @pytest.mark.parametrize("scalar_term", [False, True])
 @pytest.mark.parametrize("jitted", [False, True])
@@ -186,26 +196,42 @@ def test_jax_branched_log_sig_method_validation():
             bsig, dimension, degree, planar=True, method=-1)
 
 
-def test_jax_compressed_branched_log_sig_rejects_gpu_array():
-    gpu_devices = [
-        device for device in jax.devices()
-        if device.platform in ("cuda", "gpu")
-    ]
-    if not gpu_devices:
-        pytest.skip("JAX GPU device unavailable")
+@pytest.mark.parametrize("method", [1, 2])
+@pytest.mark.parametrize("scalar_term", [False, True])
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_cuda_compressed_value_and_grad_match_cpu(
+        method, scalar_term, jitted):
+    gpu = _gpu_device()
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, method, planar=True, device="both",
+        use_disk=False)
+    bsig = _planar_bsig(
+        dimension, degree, batch=True, scalar_term=scalar_term)
+    expected = pysiglib.branched_sig_to_log_sig(
+        bsig, dimension, degree, planar=True, method=method)
+    weights = np.random.default_rng(6741).normal(size=expected.shape)
+    expected_grad = pysiglib.branched_sig_to_log_sig_backprop(
+        bsig, weights, dimension, degree, planar=True, method=method)
+    bsig_gpu = jax.device_put(jnp.asarray(bsig), gpu)
+    weights_gpu = jax.device_put(jnp.asarray(weights), gpu)
 
-    dimension, degree = 1, 1
-    bsig = jax.device_put(
-        jnp.ones(
-            pysiglib.branched_sig_length(
-                dimension, degree, planar=True, scalar_term=True),
-            dtype=jnp.float64,
-        ),
-        gpu_devices[0],
-    )
-    with pytest.raises(NotImplementedError, match="only implemented on CPU"):
-        jax_api.branched_sig_to_log_sig(
-            bsig, dimension, degree, planar=True, method=1)
+    def convert(value):
+        return jax_api.branched_sig_to_log_sig(
+            value, dimension, degree, planar=True, method=method)
+
+    def loss(value):
+        return jnp.sum(convert(value) * weights_gpu)
+
+    convert_fn = jax.jit(convert) if jitted else convert
+    grad_fn = jax.jit(jax.grad(loss)) if jitted else jax.grad(loss)
+    actual = convert_fn(bsig_gpu)
+    actual_grad = grad_fn(bsig_gpu)
+
+    np.testing.assert_allclose(
+        np.asarray(actual), expected, atol=2e-9, rtol=2e-9)
+    np.testing.assert_allclose(
+        np.asarray(actual_grad), expected_grad, atol=2e-8, rtol=2e-8)
 
 
 @pytest.mark.parametrize("jitted", [False, True])
@@ -288,3 +314,92 @@ def test_jax_method_three_rejects_correction():
     with pytest.raises(ValueError, match="correction is not supported"):
         jax_api.branched_log_sig(
             path, 2, planar=True, method=3, correction=correction)
+
+
+@pytest.mark.parametrize(
+    "time_aug,lead_lag",
+    [(False, False), (True, False), (False, True), (True, True)],
+)
+@pytest.mark.parametrize("batch_shape", [(), (0,)])
+def test_jax_method_three_rejects_empty_paths(
+        batch_shape, time_aug, lead_lag):
+    path = jnp.empty(batch_shape + (0, 2), dtype=jnp.float64)
+    with pytest.raises(ValueError, match="empty path"):
+        jax_api.branched_log_sig(
+            path, 2, planar=True, method=3,
+            time_aug=time_aug, lead_lag=lead_lag)
+
+
+@pytest.mark.parametrize("jitted", [False, True])
+@pytest.mark.parametrize("batch", [False, True])
+def test_jax_cuda_method_three_value_and_grad_match_cpu(jitted, batch):
+    gpu = _gpu_device()
+    dimension, degree = 2, 3
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="both",
+        use_disk=False)
+    rng = np.random.default_rng(5814)
+    shape = (2, 5, dimension) if batch else (5, dimension)
+    path = np.cumsum(rng.normal(scale=0.2, size=shape), axis=-2)
+    expected = pysiglib.branched_log_sig(
+        path, degree, planar=True, method=3)
+    weights = rng.normal(size=expected.shape)
+    expected_grad = _branched_log_sig_from_path_backprop(
+        weights, path, degree)
+    path_gpu = jax.device_put(jnp.asarray(path), gpu)
+    weights_gpu = jax.device_put(jnp.asarray(weights), gpu)
+
+    def compute(value):
+        return jax_api.branched_log_sig(
+            value, degree, planar=True, method=3)
+
+    def loss(value):
+        return jnp.sum(compute(value) * weights_gpu)
+
+    compute_fn = jax.jit(compute) if jitted else compute
+    grad_fn = jax.jit(jax.grad(loss)) if jitted else jax.grad(loss)
+    actual = compute_fn(path_gpu)
+    actual_grad = grad_fn(path_gpu)
+
+    np.testing.assert_allclose(
+        np.asarray(actual), expected, atol=2e-9, rtol=2e-9)
+    np.testing.assert_allclose(
+        np.asarray(actual_grad), expected_grad, atol=2e-8, rtol=2e-8)
+
+
+@pytest.mark.parametrize("jitted", [False, True])
+def test_jax_cuda_empty_batch_compressed_and_method_three(jitted):
+    gpu = _gpu_device()
+    dimension, degree = 2, 2
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 2, planar=True, device="both",
+        use_disk=False)
+    pysiglib.prepare_branched_log_sig(
+        dimension, degree, 3, planar=True, device="both",
+        use_disk=False)
+    bsig_length = pysiglib.branched_sig_length(
+        dimension, degree, planar=True, scalar_term=True)
+    compact_length = pysiglib.branched_log_sig_length(
+        dimension, degree, planar=True)
+    bsig = jax.device_put(
+        jnp.empty((0, bsig_length), dtype=jnp.float64), gpu)
+    path = jax.device_put(
+        jnp.empty((0, 3, dimension), dtype=jnp.float64), gpu)
+
+    def convert(value):
+        return jax_api.branched_sig_to_log_sig(
+            value, dimension, degree, planar=True, method=2)
+
+    def direct(value):
+        return jax_api.branched_log_sig(
+            value, degree, planar=True, method=3)
+
+    convert_fn = jax.jit(convert) if jitted else convert
+    direct_fn = jax.jit(direct) if jitted else direct
+    converted = convert_fn(bsig)
+    computed = direct_fn(path)
+
+    assert converted.shape == (0, compact_length)
+    assert computed.shape == (0, compact_length)
+    converted.block_until_ready()
+    computed.block_until_ready()


### PR DESCRIPTION
Stack layer 4 of 8. This layer adds CUDA implementations for MKW Lyndon and BCH branched log signatures, aligns their bindings and cache lifecycle, and covers CUDA grid limits and native behavior. Validation: full Python unit suite with the matching CUDA plugin, 2728 passed and 24 skipped.