### PR TITLE
Add CodSpeed memory benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,7 +39,24 @@ jobs:
           cmake --build build --target bench_cpsig -j$(nproc)
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: ./build/benchmarks/bench_cpsig
+
+      - name: Build cpsig + benchmarks for memory
+        env:
+          CIBUILDWHEEL: "1"
+        run: |
+          cmake -B build-memory \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPYSIGLIB_BENCHMARKS=ON \
+            -DPYSIGLIB_JAX_FFI=OFF \
+            -DCODSPEED_MODE=memory
+          cmake --build build-memory --target bench_cpsig -j$(nproc)
+
+      - name: Run memory benchmarks
+        uses: CodSpeedHQ/action@v5
+        with:
+          mode: memory
+          run: ./build-memory/benchmarks/bench_cpsig


### PR DESCRIPTION
## Summary

- upgrade the CodSpeed GitHub Action from v4 to v5. This update was released earlier this month. CodSpeed v5 models instruction costs more realistically, while memory metrics expose increases in allocations and peak usage. I think this should make it easier to catch meaningful regressions versus noise. https://codspeed.io/changelog.
- I have run the full C++ benchmark suite in memory mode alongside simulation

For a given benchmark, the memory benchmarks look like this:
<img width="1254" height="390" alt="image" src="https://github.com/user-attachments/assets/d1efd3f5-1a0c-49b5-8f6c-94f1b5f9a19f" />