### PR TITLE
Simplify BCH scheduling across CPU and CUDA

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -15,11 +15,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(google_benchmark)
 
 add_executable(bench_cpsig bench_cpsig.cpp)
-target_link_libraries(bench_cpsig PRIVATE
-    benchmark::benchmark
-    cpsig
-    pysiglib_preparation
-)
+target_link_libraries(bench_cpsig PRIVATE benchmark::benchmark cpsig)
 target_include_directories(bench_cpsig PRIVATE
     "${CMAKE_SOURCE_DIR}/siglib/cpsig"
     "${CMAKE_SOURCE_DIR}/siglib/shared"

--- a/benchmarks/bench_cpsig.cpp
+++ b/benchmarks/bench_cpsig.cpp
@@ -15,7 +15,6 @@
 
 #include <benchmark/benchmark.h>
 #include "cpsig.h"
-#include "preparation/log_sig/bch_cache.h"
 
 #include <cstdint>
 #include <random>
@@ -96,18 +95,6 @@ static void BM_prepare_log_sig_bch(benchmark::State& state) {
     }
 }
 BENCHMARK(BM_prepare_log_sig_bch)->Unit(benchmark::kMicrosecond);
-
-static void BM_generate_bch_coefficients_degree_14(benchmark::State& state) {
-    constexpr uint64_t degree = 14;
-    for (auto _ : state) {
-        BchCache cache;
-        cache.degree = degree;
-        build_bch_formula_data(cache);
-        benchmark::DoNotOptimize(cache.bch_coefficients.data());
-    }
-}
-BENCHMARK(BM_generate_bch_coefficients_degree_14)
-    ->Unit(benchmark::kMillisecond);
 
 static void BM_prepare_branched_sig_nonplanar(benchmark::State& state) {
     for (auto _ : state) {

--- a/siglib/cpsig/cp_bch.h
+++ b/siglib/cpsig/cp_bch.h
@@ -57,35 +57,6 @@ inline void clear_bch_cache() {
 	// BCH data is owned by the LogSigCache registry.
 }
 
-template<typename Function>
-FORCE_INLINE void for_each_bch_node_(
-	const BchCache& cache, Function&& function
-) {
-	if (cache.all_bch_nodes_live) {
-		for (uint64_t node = 2; node < cache.bch_coefficients.size(); ++node)
-			function(node);
-	}
-	else {
-		for (uint32_t node : cache.live_bch_nodes)
-			function(node);
-	}
-}
-
-template<typename Function>
-FORCE_INLINE void for_each_bch_node_reverse_(
-	const BchCache& cache, Function&& function
-) {
-	if (cache.all_bch_nodes_live) {
-		for (uint64_t node = cache.bch_coefficients.size(); node-- > 2;)
-			function(node);
-	}
-	else {
-		for (auto node = cache.live_bch_nodes.rbegin();
-			node != cache.live_bch_nodes.rend(); ++node)
-			function(*node);
-	}
-}
-
 // ========================================================================
 // Lie bracket of two dense vectors using the commutator table
 // ========================================================================
@@ -145,7 +116,7 @@ void bch_combine_impl_(
 	const BchCache& cache, T* memo
 ) {
 	uint64_t m = cache.m;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	for (uint64_t i = 0; i < m; ++i) {
 		out[i] = ls1[i] + ls2[i];
@@ -163,13 +134,13 @@ void bch_combine_impl_(
 
 	// Forward pass: BCH indices are topologically sorted (children < parent),
 	// so memo[lf] and memo[rf] are always already computed when we reach w.
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const T* v1 = memo + lf * m;
 		const T* v2 = memo + rf * m;
 		T* result = memo + w * m;
-		const T c_w = static_cast<T>(cache.bch_coefficients[w]);
+		const T c_w = static_cast<T>(cache.bch_operation(w).coefficient);
 
 		// Fused lie_bracket + output accumulation via k-grouped commutator table
 		for (uint64_t k = 0; k < m; ++k) {
@@ -182,7 +153,7 @@ void bch_combine_impl_(
 			result[k] = sum;
 			if (c_w != T(0)) out[k] += c_w * sum;
 		}
-	});
+	}
 }
 
 // ========================================================================
@@ -198,7 +169,7 @@ void bch_combine_linear_impl_(
 ) {
 	uint64_t m = cache.m;
 	uint64_t dim = cache.dimension;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	std::memcpy(out, ls1, m * sizeof(T));
 	if (cache.linear_input_prefix) {
@@ -221,13 +192,13 @@ void bch_combine_linear_impl_(
 	const uint32_t* k_j = cache.comm_k_j.data();
 	const double* k_val_d = cache.comm_k_val_d.data();
 
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const T* v1 = memo + lf * m;
 		const T* v2 = memo + rf * m;
 		T* result = memo + w * m;
-		const T c_w = static_cast<T>(cache.bch_coefficients[w]);
+		const T c_w = static_cast<T>(cache.bch_operation(w).coefficient);
 		const auto [begin, end] = cache.linear_range[w];
 		std::fill(result, result + begin, T(0));
 		std::fill(result + end, result + m, T(0));
@@ -260,7 +231,7 @@ void bch_combine_linear_impl_(
 			result[k] = sum;
 			if (c_w != T(0)) out[k] += c_w * sum;
 		}
-	});
+	}
 }
 
 // 4-wide BCH combination (works on both AVX2 and NEON).
@@ -270,7 +241,7 @@ inline void bch_combine_impl_x4_(
 	const BchCache& cache, double* memo
 ) {
 	uint64_t m = cache.m;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	vec4_add(out, ls1, ls2, m);
 	if (m2 <= 2) return;
@@ -283,20 +254,20 @@ inline void bch_combine_impl_x4_(
 	const uint32_t* k_j = cache.comm_k_j.data();
 	const double* k_val_d = cache.comm_k_val_d.data();
 
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const double* v1 = memo + lf * m * 4;
 		const double* v2 = memo + rf * m * 4;
 		double* result = memo + w * m * 4;
-		const double c_w = cache.bch_coefficients[w];
+		const double c_w = cache.bch_operation(w).coefficient;
 
 		for (uint64_t k = 0; k < m; ++k) {
 			vec4_commutator_accum(&result[k * 4], v1, v2, k_i, k_j, k_val_d, k_ptr[k], k_ptr[k + 1]);
 			if (c_w != 0.0)
 				vec4_fmadd(&out[k * 4], &result[k * 4], c_w, 1);
 		}
-	});
+	}
 }
 // 4-wide BCH with a degree-one second input.
 inline void bch_combine_linear_impl_x4_(
@@ -305,7 +276,7 @@ inline void bch_combine_linear_impl_x4_(
 ) {
 	uint64_t m = cache.m;
 	uint64_t dim = cache.dimension;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	vec4_add(out, ls1, ls2, dim);
 	std::memcpy(&out[dim * 4], &ls1[dim * 4], (m - dim) * 4 * sizeof(double));
@@ -319,13 +290,13 @@ inline void bch_combine_linear_impl_x4_(
 	const uint32_t* k_j = cache.comm_k_j.data();
 	const double* k_val_d = cache.comm_k_val_d.data();
 
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const double* v1 = memo + lf * m * 4;
 		const double* v2 = memo + rf * m * 4;
 		double* result = memo + w * m * 4;
-		const double c_w = cache.bch_coefficients[w];
+		const double c_w = cache.bch_operation(w).coefficient;
 		const auto [begin, end] = cache.linear_range[w];
 		std::memset(result, 0, begin * 4 * sizeof(double));
 		std::memset(result + end * 4, 0, (m - end) * 4 * sizeof(double));
@@ -336,7 +307,7 @@ inline void bch_combine_linear_impl_x4_(
 			if (c_w != 0.0)
 				vec4_fmadd(&out[k * 4], &result[k * 4], c_w, 1);
 		}
-	});
+	}
 }
 // 4-wide BCH backprop for a degree-one second input.
 template<bool prune_linear>
@@ -346,7 +317,7 @@ inline void bch_combine_linear_backprop_impl_x4_(
 	const BchCache& cache, double* workspace
 ) {
 	uint64_t m = cache.m;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	if (m2 <= 2) {
 		std::memcpy(d_ls1, d_out, m * 4 * sizeof(double));
@@ -372,9 +343,9 @@ inline void bch_combine_linear_backprop_impl_x4_(
 	const uint32_t n_pairs = cache.n_pairs;
 
 	// Forward recompute (output-grouped, 4-wide)
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = 2; w < m2; ++w) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const double* v1 = memo + lf * m * 4;
 		const double* v2 = memo + rf * m * 4;
 		double* result = memo + w * m * 4;
@@ -384,12 +355,12 @@ inline void bch_combine_linear_backprop_impl_x4_(
 		for (uint64_t k = begin; k < end; ++k)
 			vec4_commutator_accum(&result[k * 4], v1, v2, k_i, k_j, k_c,
 				k_ptr[k], k_ptr[k + 1]);
-	});
+	}
 
 	// d_memo init
 	std::memset(d_memo, 0, 2 * m * 4 * sizeof(double));
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const double c_w = cache.bch_coefficients[w];
+	for (uint64_t w = 2; w < m2; ++w) {
+		const double c_w = cache.bch_operation(w).coefficient;
 		double* dm = d_memo + w * m * 4;
 		if constexpr (prune_linear) {
 			const auto [begin, end] = cache.linear_range[w];
@@ -406,12 +377,12 @@ inline void bch_combine_linear_backprop_impl_x4_(
 		else {
 			std::memset(dm, 0, m * 4 * sizeof(double));
 		}
-	});
+	}
 
 	// Reverse BCH (pair-grouped, 4-wide)
-	for_each_bch_node_reverse_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = m2; w-- > 2;) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const double* v1 = memo + lf * m * 4;
 		const double* v2 = memo + rf * m * 4;
 		const double* dm_w = d_memo + w * m * 4;
@@ -430,7 +401,7 @@ inline void bch_combine_linear_backprop_impl_x4_(
 				vec4_bracket_grad(dm_lf, dm_rf, dm_w, v1, v2, ij_i[p], ij_j[p],
 					ij_k, ij_c, ij_ptr[p], ij_ptr[p + 1]);
 		}
-	});
+	}
 
 	// Add the direct gradient to the accumulated BCH leaf gradients.
 	vec4_add(d_ls1, d_out, d_memo, m);
@@ -449,7 +420,7 @@ void bch_combine_backprop_impl_(
 	const BchCache& cache, T* workspace
 ) {
 	uint64_t m = cache.m;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	// d_ls1 = d_out, d_ls2 = d_out (from the addition)
 	std::memcpy(d_ls1, d_out, m * sizeof(T));
@@ -475,9 +446,9 @@ void bch_combine_backprop_impl_(
 	if constexpr (linear_input)
 		bch_combine_linear_impl_(ls1, ls2, d_memo, cache, memo);
 	if constexpr (!linear_input) {
-		for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-			const uint64_t lf = cache.bch_left_factor[w];
-			const uint64_t rf = cache.bch_right_factor[w];
+		for (uint64_t w = 2; w < m2; ++w) {
+			const uint64_t lf = cache.bch_operation(w).left;
+			const uint64_t rf = cache.bch_operation(w).right;
 			const T* v1 = memo + lf * m;
 			const T* v2 = memo + rf * m;
 			T* result = memo + w * m;
@@ -494,13 +465,13 @@ void bch_combine_backprop_impl_(
 					result[ij_k[idx]] += static_cast<T>(ij_c[idx]) * prod;
 				}
 			}
-		});
+		}
 	}
 
 	// Initialize d_memo: d_memo[w] = c_w * d_out for w >= 2, zero for leaves
 	std::memset(d_memo, 0, 2 * m * sizeof(T));
-	for_each_bch_node_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const T c_w = static_cast<T>(cache.bch_coefficients[w]);
+	for (uint64_t w = 2; w < m2; ++w) {
+		const T c_w = static_cast<T>(cache.bch_operation(w).coefficient);
 		T* RESTRICT dm = d_memo + w * m;
 		if constexpr (linear_input && prune_linear) {
 			const auto [begin, end] = cache.linear_range[w];
@@ -523,13 +494,13 @@ void bch_combine_backprop_impl_(
 				std::memset(dm, 0, m * sizeof(T));
 			}
 		}
-	});
+	}
 
 	// Reverse BCH loop using pair-grouped table
 	// For each (i,j) pair, compute S = sum_k c * dm_w[k], then scatter 4 updates
-	for_each_bch_node_reverse_(cache, [&](uint64_t w) FORCE_INLINE_LAMBDA {
-		const uint64_t lf = cache.bch_left_factor[w];
-		const uint64_t rf = cache.bch_right_factor[w];
+	for (uint64_t w = m2; w-- > 2;) {
+		const uint64_t lf = cache.bch_operation(w).left;
+		const uint64_t rf = cache.bch_operation(w).right;
 		const T* v1 = memo + lf * m;
 		const T* v2 = memo + rf * m;
 		const T* dm_w = d_memo + w * m;
@@ -568,7 +539,7 @@ void bch_combine_backprop_impl_(
 				dm_rf[i] -= S * v1[j];
 			}
 		}
-	});
+	}
 
 	// Accumulate leaf gradients
 	for (uint64_t i = 0; i < m; ++i) {

--- a/siglib/cpsig/cp_branched_log_signature.cpp
+++ b/siglib/cpsig/cp_branched_log_signature.cpp
@@ -827,7 +827,7 @@ void branched_log_sig_from_path_(
 	if (bch.m == 0)
 		return;
 	const uint64_t path_stride = length * dimension;
-	const uint64_t m2 = bch.bch_coefficients.size();
+	const uint64_t m2 = bch.bch_size();
 
 	auto work_range = [&](uint64_t start, uint64_t end) {
 		std::vector<T> increment(dimension);
@@ -892,7 +892,7 @@ void branched_log_sig_from_path_backprop_(
 		std::fill(path_derivs, path_derivs + batch_size * path_stride, T(0));
 		return;
 	}
-	const uint64_t m2 = bch.bch_coefficients.size();
+	const uint64_t m2 = bch.bch_size();
 	const uint64_t workspace_size = 7 * bch.m + 2 * m2 * bch.m;
 
 	auto work_range = [&](uint64_t start, uint64_t end) {

--- a/siglib/cpsig/cp_log_signature.h
+++ b/siglib/cpsig/cp_log_signature.h
@@ -229,7 +229,7 @@ void log_sig_combine_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	std::vector<T> memo(m2 * m);
 	bch_combine_impl_<T>(log_sig1, log_sig2, out, cache, memo.data());
 }
@@ -255,7 +255,7 @@ void log_sig_combine_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	auto func = [&](const T* ls1, const T* ls2, T* o) {
 		thread_local std::vector<T> tl_memo;
@@ -303,7 +303,7 @@ void log_sig_join_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	std::vector<T> memo(m2 * m);
 	log_sig_join_impl_<T>(log_sig, displacement, out, cache, memo.data());
 }
@@ -329,7 +329,7 @@ void log_sig_join_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	auto func = [&](const T* ls, const T* disp, T* o) {
 		thread_local std::vector<T> tl_memo;
@@ -369,7 +369,7 @@ void log_sig_join_backprop_(
 
 	// Reuse bch_combine_backprop_impl_ - it handles the full BCH backward
 	auto d_ls2 = std::make_unique<T[]>(m);
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	std::vector<T> workspace(2 * m2 * m);
 	bch_combine_backprop_impl_<T>(d_out, d_logsig, d_ls2.get(), log_sig, linear_ls.get(),
 		cache, workspace.data());
@@ -399,7 +399,7 @@ void log_sig_join_backprop_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	auto func = [&](uint64_t start, uint64_t end) {
 		std::vector<T> workspace(2 * m2 * m);
@@ -483,7 +483,7 @@ inline void log_sig_from_path_x4_(
 	std::memset(seg, 0, m * 4 * sizeof(double));
 
 	double* acc = temp;
-	double* src = memo + cache.bch_coefficients.size() * m * 4;
+	double* src = memo + cache.bch_size() * m * 4;
 
 	for (uint64_t s = 1; s < length - 1; ++s) {
 		for (uint64_t k = 0; k < dimension; ++k) {
@@ -505,7 +505,7 @@ inline void log_sig_from_path_backprop_x4_(
 	const BchCache& cache, double* workspace
 ) {
 	uint64_t m = cache.m;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	uint64_t n_segs = length - 1;
 	const bool prune_backprop = cache.prune_linear_backprop;
 
@@ -611,7 +611,7 @@ void batch_log_sig_from_path_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	uint64_t path_stride = length * dimension;
 	uint64_t scalar_start = 0;
 
@@ -670,7 +670,7 @@ void log_sig_from_path_backprop_(
 	const BchCache& cache, T* workspace
 ) {
 	uint64_t m = cache.m;
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	uint64_t n_segs = length - 1;
 	const bool prune_backprop = cache.prune_linear_backprop;
 
@@ -777,7 +777,7 @@ void batch_log_sig_from_path_backprop_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	uint64_t path_stride = length * dimension;
 	uint64_t ws_size = 7 * m + 2 * m2 * m;
 	uint64_t scalar_start = 0;
@@ -837,7 +837,7 @@ void log_sig_combine_backprop_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 	std::vector<T> workspace(2 * m2 * m);
 	bch_combine_backprop_impl_<T>(d_out, d_ls1, d_ls2, ls1, ls2, cache, workspace.data());
 }
@@ -863,7 +863,7 @@ void log_sig_combine_backprop_(
 		return;
 	}
 
-	uint64_t m2 = cache.bch_coefficients.size();
+	uint64_t m2 = cache.bch_size();
 
 	auto func = [&](const T* dout, T* dls1, T* dls2, const T* l1, const T* l2) {
 		thread_local std::vector<T> tl_workspace;

--- a/siglib/cpsig_unit_testing/cp_test_preparation.cpp
+++ b/siglib/cpsig_unit_testing/cp_test_preparation.cpp
@@ -17,11 +17,13 @@
 
 #include "cp_bch.h"
 #include "log_sig/bch_cache.h"
+#include "log_sig/bch_data.h"
 #include "branched_sig/branched_log_sig_cache.h"
 #include "branched_sig/branched_sig_cache_io.h"
 #include "cache_io.h"
 #include "polynomial_sig_kernel/polynomial_sig_kernel_tables.h"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -35,26 +37,23 @@ std::filesystem::path test_cache_directory_() {
 }
 
 TEST(preparationCacheTest, HardcodedBchCoversDegreeTwenty) {
-	BchCache cache;
-	cache.degree = 20;
-	build_bch_formula_data(cache);
-	ASSERT_EQ(cache.bch_coefficients.size(), 111013);
-	EXPECT_DOUBLE_EQ(cache.bch_coefficients[0], 1.0);
-	EXPECT_DOUBLE_EQ(cache.bch_coefficients[1], 1.0);
-	EXPECT_DOUBLE_EQ(cache.bch_coefficients[2], 0.5);
-	EXPECT_DOUBLE_EQ(cache.bch_coefficients[3], 1.0 / 12.0);
-	EXPECT_DOUBLE_EQ(cache.bch_coefficients[4], 1.0 / 12.0);
-	EXPECT_DOUBLE_EQ(cache.bch_coefficients[5], 0.0);
+	const BchHardcodedData* formula = get_hardcoded_bch_data(20);
+	ASSERT_NE(formula, nullptr);
+	ASSERT_EQ(formula->size, 111013);
+	EXPECT_DOUBLE_EQ(formula->coefficients[0], 1.0);
+	EXPECT_DOUBLE_EQ(formula->coefficients[1], 1.0);
+	EXPECT_DOUBLE_EQ(formula->coefficients[2], 0.5);
+	EXPECT_DOUBLE_EQ(formula->coefficients[3], 1.0 / 12.0);
+	EXPECT_DOUBLE_EQ(formula->coefficients[4], 1.0 / 12.0);
+	EXPECT_DOUBLE_EQ(formula->coefficients[5], 0.0);
 	EXPECT_DOUBLE_EQ(
-		cache.bch_coefficients[110262],
+		formula->coefficients[110262],
 		43867.0 / 10218188434341888000.0);
-	EXPECT_EQ(cache.bch_left_factor.back(), 58635);
-	EXPECT_EQ(cache.bch_right_factor.back(), 1);
-	ASSERT_EQ(cache.bch_left_factor.size(), cache.bch_coefficients.size());
-	ASSERT_EQ(cache.bch_right_factor.size(), cache.bch_coefficients.size());
-	for (uint64_t node = 2; node < cache.bch_coefficients.size(); ++node) {
-		EXPECT_LT(cache.bch_left_factor[node], node);
-		EXPECT_LT(cache.bch_right_factor[node], node);
+	EXPECT_EQ(formula->left_factor[formula->size - 1], 58635);
+	EXPECT_EQ(formula->right_factor[formula->size - 1], 1);
+	for (uint64_t node = 2; node < formula->size; ++node) {
+		EXPECT_LT(formula->left_factor[node], node);
+		EXPECT_LT(formula->right_factor[node], node);
 	}
 }
 
@@ -62,14 +61,14 @@ TEST(preparationCacheTest, BchHandlesZeroAndRejectsAboveHardcodedTable) {
 	BchCache empty;
 	empty.degree = 0;
 	EXPECT_NO_THROW(build_bch_formula_data(empty));
-	EXPECT_TRUE(empty.bch_coefficients.empty());
+	EXPECT_TRUE(empty.bch_operations.empty());
 
 	BchCache too_large;
 	too_large.degree = 21;
 	EXPECT_THROW(build_bch_formula_data(too_large), std::invalid_argument);
 }
 
-TEST(preparationCacheTest, LiveBchPlansAreMinimalAndTopological) {
+TEST(preparationCacheTest, BchOperationsAreCompactAndTopological) {
 	struct ExpectedPlanSize {
 		uint64_t degree;
 		size_t live_nodes;
@@ -86,70 +85,70 @@ TEST(preparationCacheTest, LiveBchPlansAreMinimalAndTopological) {
 		BchCache cache;
 		cache.degree = degree;
 		build_bch_formula_data(cache);
-		build_live_bch_nodes(cache);
-		EXPECT_EQ(cache.live_bch_nodes.size(), expected_size);
-		EXPECT_EQ(cache.all_bch_nodes_live,
-			expected_size + 2 == cache.bch_coefficients.size());
-
-		std::vector<uint8_t> available(cache.bch_coefficients.size(), 0);
-		if (!available.empty())
-			available[0] = 1;
-		if (available.size() > 1)
-			available[1] = 1;
-		for (uint32_t node : cache.live_bch_nodes) {
-			EXPECT_TRUE(available[cache.bch_left_factor[node]]);
-			EXPECT_TRUE(available[cache.bch_right_factor[node]]);
-			available[node] = 1;
-		}
-		for (uint64_t node = 2; node < cache.bch_coefficients.size(); ++node) {
-			if (cache.bch_coefficients[node] != 0.0)
-				EXPECT_TRUE(available[node]);
+		EXPECT_EQ(cache.bch_operations.size(), expected_size);
+		EXPECT_EQ(cache.bch_size(), expected_size + 2);
+		for (uint64_t operation_index = 0;
+			operation_index < cache.bch_operations.size(); ++operation_index) {
+			const BchOperation& operation = cache.bch_operations[operation_index];
+			const uint64_t node = operation_index + 2;
+			EXPECT_LT(operation.left, node);
+			EXPECT_LT(operation.right, node);
 		}
 	}
 }
 
-TEST(preparationCacheTest, PrunedAndFullBchPlansAgree) {
-	const uint64_t degrees[] = { 3, 4, 5, 8 };
-	for (uint64_t degree : degrees) {
+TEST(preparationCacheTest, CompactAndRangedBchMatchFullFormula) {
+	for (uint64_t degree : { 1, 3, 4, 5, 8 }) {
 		SCOPED_TRACE(degree);
-		LogSigCache log_cache(2, degree, 3);
-		const BchCache& pruned = log_cache.bch();
-		BchCache full = pruned;
-		full.live_bch_nodes.clear();
-		for (uint64_t node = 2; node < full.bch_coefficients.size(); ++node)
-			full.live_bch_nodes.push_back(static_cast<uint32_t>(node));
-		full.all_bch_nodes_live = true;
-
-		const uint64_t m = pruned.m;
-		const uint64_t m2 = pruned.bch_coefficients.size();
-		std::vector<double> ls1(m), ls2(m), d_out(m);
-		for (uint64_t index = 0; index < m; ++index) {
-			ls1[index] = 0.03125 * (static_cast<int>(index % 9) - 4);
-			ls2[index] = 0.015625 * (static_cast<int>(index % 7) - 3);
-			d_out[index] = 0.0625 * (static_cast<int>(index % 5) - 2);
+		LogSigCache cache(2, degree, 3);
+		const BchCache& compact = cache.bch();
+		BchCache full = compact;
+		full.bch_operations.clear();
+		const auto& formula = *get_hardcoded_bch_data(degree);
+		for (uint64_t w = 2; w < formula.size; ++w)
+			full.bch_operations.push_back({ formula.coefficients[w],
+				static_cast<uint32_t>(formula.left_factor[w]),
+				static_cast<uint32_t>(formula.right_factor[w]) });
+		const uint64_t m = compact.m;
+		std::vector<double> left(m), right(m), derivs(m), expected(m), actual(m);
+		for (uint64_t k = 0; k < m; ++k) {
+			left[k] = 0.03125 * (static_cast<int>(k % 9) - 4);
+			right[k] = 0.015625 * (static_cast<int>(k % 7) - 3);
+			derivs[k] = 0.0625 * (static_cast<int>(k % 5) - 2);
 		}
-		std::vector<double> pruned_out(m), full_out(m);
-		std::vector<double> pruned_memo(m2 * m), full_memo(m2 * m);
-		bch_combine_impl_(
-			ls1.data(), ls2.data(), pruned_out.data(), pruned,
-			pruned_memo.data());
-		bch_combine_impl_(
-			ls1.data(), ls2.data(), full_out.data(), full,
-			full_memo.data());
-		EXPECT_EQ(pruned_out, full_out);
+		std::vector<double> workspace(2 * full.bch_size() * m);
+		bch_combine_impl_(left.data(), right.data(), expected.data(), full, workspace.data());
+		bch_combine_impl_(left.data(), right.data(), actual.data(), compact, workspace.data());
+		EXPECT_EQ(actual, expected);
+		std::vector<double> expected_left(m), expected_right(m), actual_left(m), actual_right(m);
+		bch_combine_backprop_impl_(derivs.data(), expected_left.data(), expected_right.data(),
+			left.data(), right.data(), full, workspace.data());
+		bch_combine_backprop_impl_(derivs.data(), actual_left.data(), actual_right.data(),
+			left.data(), right.data(), compact, workspace.data());
+		EXPECT_EQ(actual_left, expected_left);
+		EXPECT_EQ(actual_right, expected_right);
 
-		std::vector<double> pruned_d_ls1(m), pruned_d_ls2(m);
-		std::vector<double> full_d_ls1(m), full_d_ls2(m);
-		std::vector<double> pruned_workspace(2 * m2 * m);
-		std::vector<double> full_workspace(2 * m2 * m);
-		bch_combine_backprop_impl_<double>(
-			d_out.data(), pruned_d_ls1.data(), pruned_d_ls2.data(),
-			ls1.data(), ls2.data(), pruned, pruned_workspace.data());
-		bch_combine_backprop_impl_<double>(
-			d_out.data(), full_d_ls1.data(), full_d_ls2.data(),
-			ls1.data(), ls2.data(), full, full_workspace.data());
-		EXPECT_EQ(pruned_d_ls1, full_d_ls1);
-		EXPECT_EQ(pruned_d_ls2, full_d_ls2);
+		// Independently evaluate brackets, discarding coordinates outside the plan.
+		std::copy(left.begin(), left.end(), workspace.begin());
+		std::copy(right.begin(), right.end(), workspace.begin() + m);
+		for (uint64_t k = 0; k < m; ++k)
+			actual[k] = left[k] + right[k];
+		ASSERT_EQ(compact.bch_ranges.size(), compact.bch_operations.size());
+		for (uint64_t w = 2; w < compact.bch_size(); ++w) {
+			const auto& op = compact.bch_operation(w);
+			const auto [begin, end] = compact.bch_ranges[w - 2];
+			ASSERT_LE(begin, end);
+			ASSERT_LE(end, m);
+			double* result = workspace.data() + w * m;
+			lie_bracket(workspace.data() + op.left * m, workspace.data() + op.right * m,
+				result, m, compact.commutator_table);
+			std::fill(result, result + begin, 0.0);
+			std::fill(result + end, result + m, 0.0);
+			for (uint64_t k = begin; k < end; ++k)
+				actual[k] += op.coefficient * result[k];
+		}
+		for (uint64_t k = 0; k < m; ++k)
+			EXPECT_NEAR(actual[k], expected[k], 1e-12);
 	}
 }
 

--- a/siglib/cusig/cache_lifecycle/cu_log_sig_cache.h
+++ b/siglib/cusig/cache_lifecycle/cu_log_sig_cache.h
@@ -17,6 +17,7 @@
 
 #include "cu_disk_cache.h"
 #include "cu_utils.h"
+#include "preparation/log_sig/bch_cache.h"
 #include "preparation/log_sig/log_sig_cache.h"
 #include "preparation/log_sig/lyndon_words.h"
 
@@ -27,19 +28,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-struct CUDABchPlan {
-	// A null node list is the dense all-nodes-live plan.
-	uint32_t* nodes = nullptr;
-	uint64_t size = 0;
-
-#ifdef __CUDACC__
-	__host__ __device__ __forceinline__
-#endif
-	uint32_t operator[](uint64_t index) const {
-		return nodes ? nodes[index] : static_cast<uint32_t>(index + 2);
-	}
-};
 
 struct CUDACommutatorView {
 	const uint32_t* row_output = nullptr;
@@ -70,10 +58,8 @@ struct CUDACommutatorPlan {
 };
 
 struct CUDABchCache {
-	double* d_bch_coefficients = nullptr;
-	uint64_t* d_bch_left_factor = nullptr;
-	uint64_t* d_bch_right_factor = nullptr;
-	CUDABchPlan bch_plan;
+	BchOperation* d_bch_operations = nullptr;
+	BchRange* d_bch_ranges = nullptr;
 	CUDACommutatorPlan commutator_plan;
 	uint64_t* d_linear_range = nullptr;
 	uint64_t m2 = 0;
@@ -96,11 +82,8 @@ struct CUDABchCache {
 	CUDABchCache(const CUDABchCache&) = delete;
 	CUDABchCache& operator=(const CUDABchCache&) = delete;
 	CUDABchCache(CUDABchCache&& other) noexcept
-		: d_bch_coefficients(std::exchange(other.d_bch_coefficients, nullptr)),
-		d_bch_left_factor(std::exchange(other.d_bch_left_factor, nullptr)),
-		d_bch_right_factor(std::exchange(other.d_bch_right_factor, nullptr)),
-		bch_plan{ std::exchange(other.bch_plan.nodes, nullptr),
-			std::exchange(other.bch_plan.size, 0) },
+		: d_bch_operations(std::exchange(other.d_bch_operations, nullptr)),
+		d_bch_ranges(std::exchange(other.d_bch_ranges, nullptr)),
 		commutator_plan(std::move(other.commutator_plan)),
 		d_linear_range(std::exchange(other.d_linear_range, nullptr)),
 		m2(std::exchange(other.m2, 0)),
@@ -120,10 +103,8 @@ struct CUDABchCache {
 		d_linear_a_idx(std::exchange(other.d_linear_a_idx, nullptr)) {}
 
 	~CUDABchCache() {
-		if (d_bch_coefficients) cudaFree(d_bch_coefficients);
-		if (d_bch_left_factor) cudaFree(d_bch_left_factor);
-		if (d_bch_right_factor) cudaFree(d_bch_right_factor);
-		if (bch_plan.nodes) cudaFree(bch_plan.nodes);
+		if (d_bch_operations) cudaFree(d_bch_operations);
+		if (d_bch_ranges) cudaFree(d_bch_ranges);
 		if (d_linear_range) cudaFree(d_linear_range);
 		if (d_comm_k_ptr) cudaFree(d_comm_k_ptr);
 		if (d_comm_k_i) cudaFree(d_comm_k_i);

--- a/siglib/cusig/cache_lifecycle/cusig_lifecycle.cu
+++ b/siglib/cusig/cache_lifecycle/cusig_lifecycle.cu
@@ -15,6 +15,7 @@
 
 #include "cusig.h"
 #include "../../shared/last_error.h"
+#include "../cu_path_reduction.h"
 #include <cuda_runtime.h>
 
 void release_signature_state();
@@ -39,6 +40,7 @@ extern "C" {
 		try { release_signature_state();        } catch (...) {}
 		try { release_log_sig_state();          } catch (...) {}
 		try { release_log_sig_combine_state();  } catch (...) {}
+		try { release_cuda_path_workspaces();   } catch (...) {}
 		try { release_sig_kernel_poly_state();   } catch (...) {}
 		try { release_exp_sig_state();          } catch (...) {}
 		try { release_sig_combine_state();      } catch (...) {}

--- a/siglib/cusig/cu_branched_log_bch.cu
+++ b/siglib/cusig/cu_branched_log_bch.cu
@@ -17,6 +17,7 @@
 #include "cache_lifecycle/cu_branched_log_sig_cache.h"
 #include "cu_log_sig_combine.h"
 #include "cu_macros.h"
+#include "cu_path_reduction.h"
 #include "cu_utils.h"
 #include "../shared/branched_log_horner.h"
 
@@ -34,10 +35,7 @@
 namespace {
 
 struct CuMkwBchDeviceData {
-	const double* bch_coefficients = nullptr;
-	const uint64_t* bch_left_factor = nullptr;
-	const uint64_t* bch_right_factor = nullptr;
-	CUDABchPlan bch_plan;
+	const BchOperation* bch_operations = nullptr;
 	const uint32_t* comm_k_ptr = nullptr;
 	const uint32_t* comm_k_i = nullptr;
 	const uint32_t* comm_k_j = nullptr;
@@ -99,10 +97,7 @@ struct CuMkwBchCache {
 
 	CuMkwBchDeviceData device_data() const noexcept {
 		return {
-			bch.d_bch_coefficients,
-			bch.d_bch_left_factor,
-			bch.d_bch_right_factor,
-			bch.bch_plan,
+			bch.d_bch_operations,
 			bch.d_comm_k_ptr,
 			bch.d_comm_k_i,
 			bch.d_comm_k_j,
@@ -175,16 +170,15 @@ struct HostMkwPruning_ {
 };
 
 HostMkwPruning_ build_mkw_pruning_(
-	const BchHardcodedData& formula,
+	const BchCache& bch,
 	const HostMkwBchTables_& tables,
 	const std::vector<uint64_t>& weights,
-	const std::vector<uint32_t>& segment_idx,
-	const std::vector<uint32_t>& bch_nodes
+	const std::vector<uint32_t>& segment_idx
 ) {
 	// Propagate exact coordinate support through the BCH expression tree.
 	// This selects sparse plans only when they save enough work to justify them.
 	const uint64_t m = weights.size();
-	const uint64_t m2 = formula.size;
+	const uint64_t m2 = bch.bch_size();
 	std::vector<uint8_t> input_mask(m, 0);
 	for (uint32_t index : segment_idx)
 		input_mask[index] = 1;
@@ -202,8 +196,9 @@ HostMkwPruning_ build_mkw_pruning_(
 			min_weight[1] = 1;
 	}
 	for (uint64_t w = 2; w < m2; ++w) {
-		const uint64_t left = formula.left_factor[w];
-		const uint64_t right = formula.right_factor[w];
+		const BchOperation& operation = bch.bch_operation(w);
+		const uint64_t left = operation.left;
+		const uint64_t right = operation.right;
 		min_weight[w] = min_weight[left] + min_weight[right];
 		max_weight[w] = std::min(
 			weights.empty() ? uint64_t(0) : weights.back(),
@@ -226,8 +221,9 @@ HostMkwPruning_ build_mkw_pruning_(
 		support[1] = input_mask;
 	pruning.output_ptr.assign(m2 + 1, 0);
 	for (uint64_t w = 2; w < m2; ++w) {
-		const auto& left_support = support[formula.left_factor[w]];
-		const auto& right_support = support[formula.right_factor[w]];
+		const BchOperation& operation = bch.bch_operation(w);
+		const auto& left_support = support[operation.left];
+		const auto& right_support = support[operation.right];
 		pruning.output_ptr[w] = pruning.output_idx.size();
 		for (uint64_t k = 0; k < m; ++k) {
 			const uint64_t before = pruning.op_idx.size();
@@ -250,8 +246,9 @@ HostMkwPruning_ build_mkw_pruning_(
 	pruning.linear_a_ptr.resize(m2 * m + 1, 0);
 	pruning.reverse_ptr.assign(m2 + 1, 0);
 	for (uint64_t w = 2; w < m2; ++w) {
-		const auto& left_support = support[formula.left_factor[w]];
-		const auto& right_support = support[formula.right_factor[w]];
+		const BchOperation& operation = bch.bch_operation(w);
+		const auto& left_support = support[operation.left];
+		const auto& right_support = support[operation.right];
 		pruning.reverse_ptr[w] = pruning.reverse_idx.size();
 		for (uint64_t a = 0; a < m; ++a) {
 			const uint64_t row = w * m + a;
@@ -270,10 +267,10 @@ HostMkwPruning_ build_mkw_pruning_(
 		pruning.reverse_ptr[w + 1] = pruning.reverse_idx.size();
 	}
 
-	const uint64_t node_count = bch_nodes.size();
+	const uint64_t node_count = bch.bch_operations.size();
 	const uint64_t nnz = tables.k_i.size();
 	pruning.dense_forward_work = node_count * (m + nnz);
-	for (uint32_t node : bch_nodes) {
+	for (uint64_t node = 2; node < m2; ++node) {
 		const uint64_t output_begin = pruning.output_ptr[node];
 		const uint64_t output_end = pruning.output_ptr[node + 1];
 		pruning.exact_forward_work += output_end - output_begin;
@@ -284,7 +281,7 @@ HostMkwPruning_ build_mkw_pruning_(
 	const uint64_t dense_reverse_work = node_count
 		* (m + tables.a_k.size());
 	uint64_t exact_reverse_work = 0;
-	for (uint32_t node : bch_nodes) {
+	for (uint64_t node = 2; node < m2; ++node) {
 		const uint64_t reverse_begin = pruning.reverse_ptr[node];
 		const uint64_t reverse_end = pruning.reverse_ptr[node + 1];
 		exact_reverse_work += reverse_end - reverse_begin;
@@ -321,12 +318,7 @@ std::unique_ptr<CuMkwBchCache> build_cuda_mkw_bch_cache_(
 	if (cache.max_nodes == 0)
 		return result;
 
-	const BchHardcodedData* formula = get_hardcoded_bch_data(cache.max_nodes);
-	if (formula == nullptr)
-		throw std::runtime_error(
-			"CUDA MKW BCH method supports degree at most 20");
-	result->bch.m2 = formula->size;
-	result->bch.bch_plan.size = host_bch.live_bch_nodes.size();
+	result->bch.m2 = host_bch.bch_size();
 
 	std::vector<uint32_t> segment_idx;
 	std::vector<double> segment_coefficients;
@@ -360,8 +352,7 @@ std::unique_ptr<CuMkwBchCache> build_cuda_mkw_bch_cache_(
 	tables.a_partner = host_bch.comm_a_partner;
 	tables.a_signed_c = host_bch.comm_a_signed_c;
 	const HostMkwPruning_ pruning = build_mkw_pruning_(
-		*formula, tables, host_bch.coordinate_weights, segment_idx,
-		host_bch.live_bch_nodes);
+		host_bch, tables, host_bch.coordinate_weights, segment_idx);
 	result->bch.linear_dense_forward_work = pruning.dense_forward_work;
 	result->bch.linear_active_forward_work = pruning.exact_forward_work;
 	result->bch.linear_zero_work = pruning.exact_zero_work;
@@ -369,18 +360,7 @@ std::unique_ptr<CuMkwBchCache> build_cuda_mkw_bch_cache_(
 	result->exact_zero_work = pruning.exact_zero_work;
 	result->prune_reverse = pruning.prune_reverse;
 
-	std::vector<double> bch_coefficients(
-		formula->coefficients, formula->coefficients + formula->size);
-	std::vector<uint64_t> bch_left(
-		formula->left_factor, formula->left_factor + formula->size);
-	std::vector<uint64_t> bch_right(
-		formula->right_factor, formula->right_factor + formula->size);
-	upload_mkw_vector_(result->bch.d_bch_coefficients, bch_coefficients);
-	upload_mkw_vector_(result->bch.d_bch_left_factor, bch_left);
-	upload_mkw_vector_(result->bch.d_bch_right_factor, bch_right);
-	if (!host_bch.all_bch_nodes_live)
-		upload_mkw_vector_(
-			result->bch.bch_plan.nodes, host_bch.live_bch_nodes);
+	upload_mkw_vector_(result->bch.d_bch_operations, host_bch.bch_operations);
 	upload_mkw_vector_(result->bch.d_linear_range, pruning.range);
 	upload_mkw_vector_(result->bch.d_comm_k_ptr, tables.k_ptr);
 	upload_mkw_vector_(result->bch.d_comm_k_i, tables.k_i);
@@ -449,11 +429,13 @@ __device__ __forceinline__ void evaluate_mkw_bch_nodes_(
 ) {
 	const uint64_t tid = threadIdx.x;
 	const uint64_t stride = blockDim.x;
-	for (uint64_t plan_index = 0;
-		plan_index < data.bch_plan.size; ++plan_index) {
-		const uint32_t w = data.bch_plan[plan_index];
-		const T* left_global = memo + data.bch_left_factor[w] * data.m;
-		const T* right_global = memo + data.bch_right_factor[w] * data.m;
+	for (uint32_t operation_index = 0;
+		operation_index + 2 < data.m2; ++operation_index) {
+		const uint32_t w = operation_index + 2;
+		const T* left_global = memo
+			+ data.bch_operations[operation_index].left * data.m;
+		const T* right_global = memo
+			+ data.bch_operations[operation_index].right * data.m;
 		const T* left = left_global;
 		const T* right = right_global;
 		if constexpr (Shared) {
@@ -483,7 +465,7 @@ __device__ __forceinline__ void evaluate_mkw_bch_nodes_(
 				result[k] = value;
 				if constexpr (Accumulate) {
 					const T bch_coefficient = static_cast<T>(
-						data.bch_coefficients[w]);
+						data.bch_operations[operation_index].coefficient);
 					if (bch_coefficient != T(0))
 						out[k] += bch_coefficient * value;
 				}
@@ -502,7 +484,7 @@ __device__ __forceinline__ void evaluate_mkw_bch_nodes_(
 				result[k] = value;
 				if constexpr (Accumulate) {
 					const T bch_coefficient = static_cast<T>(
-						data.bch_coefficients[w]);
+						data.bch_operations[operation_index].coefficient);
 					if (bch_coefficient != T(0))
 						out[k] += bch_coefficient * value;
 				}
@@ -512,65 +494,42 @@ __device__ __forceinline__ void evaluate_mkw_bch_nodes_(
 	}
 }
 
-template<typename T, bool Sparse, bool Shared>
-__global__ void branched_log_sig_from_path_kernel_(
-	const T* __restrict__ path,
-	T* __restrict__ out,
-	T* __restrict__ workspace,
-	uint64_t length,
-	uint64_t dimension,
-	CuMkwBchDeviceData data
-) {
-	const uint64_t batch_idx = blockIdx.x;
-	const uint64_t tid = threadIdx.x;
-	const uint64_t stride = blockDim.x;
-	const T* path_row = path + batch_idx * length * dimension;
-	T* out_row = out + batch_idx * data.m;
-	T* memo = workspace + batch_idx * data.m2 * data.m;
+template<typename T>
+struct MkwPathSegment_ {
+	CuMkwBchDeviceData data;
 
-	T* shared_left = nullptr;
-	T* shared_right = nullptr;
-	if constexpr (Shared) {
-		extern __shared__ char shared_bytes[];
-		shared_left = reinterpret_cast<T*>(shared_bytes);
-		shared_right = shared_left + data.m;
-	}
-
-	for (uint64_t k = tid; k < data.m; k += stride) {
-		out_row[k] = T(0);
-		memo[data.m + k] = T(0);
-	}
-	if constexpr (Sparse) {
-		for (uint64_t plan_index = 0;
-			plan_index < data.bch_plan.size; ++plan_index) {
-			T* result = memo + data.bch_plan[plan_index] * data.m;
-			for (uint64_t k = tid; k < data.m; k += stride)
-				result[k] = T(0);
-		}
-	}
-	__syncthreads();
-	if (length == 1)
-		return;
-
-	evaluate_mkw_segment_(
-		path_row, path_row + dimension, out_row, T(1), data);
-	__syncthreads();
-	for (uint64_t segment = 1; segment + 1 < length; ++segment) {
-		const T* left = path_row + segment * dimension;
-		const T* right = left + dimension;
-		for (uint64_t k = tid; k < data.m; k += stride)
-			memo[k] = out_row[k];
-		evaluate_mkw_segment_(left, right, memo + data.m, T(1), data);
+	__device__ void operator()(
+		const T* left, const T* right, T* out
+	) const {
+		for (uint64_t k = threadIdx.x; k < data.m; k += blockDim.x)
+			out[k] = T(0);
 		__syncthreads();
-		for (uint64_t q = tid; q < data.segment_count; q += stride) {
-			const uint32_t coordinate = data.segment_idx[q];
-			out_row[coordinate] += memo[data.m + coordinate];
+		evaluate_mkw_segment_(left, right, out, T(1), data);
+	}
+};
+
+template<typename T, bool Shared>
+struct MkwBchCombine_ {
+	CuMkwBchDeviceData data;
+
+	__device__ void operator()(
+		const T* left, const T* right, T* out, T* memo, char* shared
+	) const {
+		for (uint64_t k = threadIdx.x; k < data.m; k += blockDim.x) {
+			const T left_value = left[k];
+			const T right_value = right[k];
+			memo[k] = left_value;
+			memo[data.m + k] = right_value;
+			out[k] = left_value + right_value;
 		}
 		__syncthreads();
-		evaluate_mkw_bch_nodes_<T, Sparse, Shared, true>(
-			memo, out_row, shared_left, shared_right, data);
+		T* shared_left = reinterpret_cast<T*>(shared);
+		T* shared_right = shared_left + data.m;
+		evaluate_mkw_bch_nodes_<T, false, Shared, true>(
+			memo, out, shared_left, shared_right, data);
 	}
-}
+};
+
 
 uint64_t checked_mkw_product_(
 	uint64_t left,
@@ -591,32 +550,6 @@ uint64_t checked_mkw_sum_(
 		throw std::overflow_error(message);
 	return left + right;
 }
-
-template<typename T, bool Shared>
-void launch_mkw_forward_(
-	bool sparse,
-	const T* path,
-	T* out,
-	T* workspace,
-	uint64_t batch,
-	uint64_t length,
-	uint64_t dimension,
-	unsigned int threads,
-	size_t shared_size,
-	const CuMkwBchDeviceData& data
-) {
-	if (sparse) {
-		branched_log_sig_from_path_kernel_<T, true, Shared><<<
-			static_cast<unsigned int>(batch), threads, shared_size>>>(
-				path, out, workspace, length, dimension, data);
-	}
-	else {
-		branched_log_sig_from_path_kernel_<T, false, Shared><<<
-			static_cast<unsigned int>(batch), threads, shared_size>>>(
-				path, out, workspace, length, dimension, data);
-	}
-}
-
 template<typename T>
 void branched_log_sig_from_path_cuda_(
 	const T* path,
@@ -644,61 +577,25 @@ void branched_log_sig_from_path_cuda_(
 		return;
 	}
 
-	const uint64_t workspace_per_batch = checked_mkw_product_(
-		data.m2, data.m, "MKW BCH workspace size overflow");
-	size_t free_memory = 0;
-	size_t total_memory = 0;
-	CUDA_CHECK(cudaMemGetInfo(&free_memory, &total_memory));
-	const uint64_t workspace_bytes = checked_mkw_product_(
-		workspace_per_batch, sizeof(T), "MKW BCH workspace byte size overflow");
-	const uint64_t reservation_bytes = checked_mkw_product_(
-		2, workspace_bytes, "MKW BCH memory reservation overflow");
-	uint64_t chunk_size = workspace_bytes == 0
-		? batch_size
-		: free_memory / reservation_bytes;
-	chunk_size = std::max<uint64_t>(1, chunk_size);
-	chunk_size = std::min<uint64_t>(
-		std::min<uint64_t>(batch_size, chunk_size), CUDA_GRID_X_LIMIT);
-	CudaBuf<T> workspace(checked_mkw_product_(
-		chunk_size, workspace_bytes, "MKW BCH workspace allocation overflow"));
-
+	const MkwPathSegment_<T> segment{ data };
+	const size_t shared_size = checked_cuda_size_mul(
+		checked_cuda_size_mul(2, static_cast<size_t>(data.m),
+			"MKW BCH shared workspace"),
+		sizeof(T), "MKW BCH shared workspace");
+	const bool use_shared = shared_size <= CUDA_BASE_DYNAMIC_SMEM;
 	unsigned int threads = static_cast<unsigned int>(
-		std::min<uint64_t>(64, data.m));
+		std::min<uint64_t>(256, data.m));
 	threads = std::max(32U, ((threads + 31) / 32) * 32);
-	const size_t shared_size = checked_mkw_product_(
-		checked_mkw_product_(2, data.m, "MKW BCH shared size overflow"),
-		sizeof(T), "MKW BCH shared byte size overflow");
-	const bool shared = shared_size <= CUDA_BASE_DYNAMIC_SMEM;
-	const uint64_t passes = length > 2 ? length - 2 : 0;
-	const long double dense_work = static_cast<long double>(passes)
-		* cache.bch.linear_dense_forward_work;
-	const long double exact_work = static_cast<long double>(passes)
-		* cache.exact_forward_work + cache.exact_zero_work;
-	const bool sparse = data.bch_plan.size != 0 && exact_work < dense_work;
-	const uint64_t path_stride = checked_mkw_product_(
-		length, dimension, "MKW BCH path stride overflow");
-	checked_mkw_product_(
-		batch_size, path_stride, "MKW BCH path size overflow");
-	checked_mkw_product_(
-		batch_size, data.m, "MKW BCH output size overflow");
-
-	for (uint64_t offset = 0; offset < batch_size; offset += chunk_size) {
-		const uint64_t current_batch = std::min(
-			chunk_size, batch_size - offset);
-		if (shared) {
-			launch_mkw_forward_<T, true>(
-				sparse, path + offset * path_stride,
-				out + offset * data.m, workspace.get(), current_batch,
-				length, dimension, threads, shared_size, data);
-		}
-		else {
-			launch_mkw_forward_<T, false>(
-				sparse, path + offset * path_stride,
-				out + offset * data.m, workspace.get(), current_batch,
-				length, dimension, threads, 0, data);
-		}
-		check_cuda_kernel_launch();
-	}
+	if (use_shared)
+		cuda_path_reduce<T>(
+			path, out, batch_size, length, dimension, data.m, data.m2,
+			threads, shared_size, segment, MkwBchCombine_<T, true>{ data },
+			"CUDA MKW path reduction");
+	else
+		cuda_path_reduce<T>(
+			path, out, batch_size, length, dimension, data.m, data.m2,
+			threads, 0, segment, MkwBchCombine_<T, false>{ data },
+			"CUDA MKW path reduction");
 }
 
 template<typename T>
@@ -750,11 +647,11 @@ __device__ __forceinline__ void reverse_mkw_bch_nodes_(
 ) {
 	const uint64_t tid = threadIdx.x;
 	const uint64_t stride = blockDim.x;
-	for (uint64_t plan_index = data.bch_plan.size;
-		plan_index-- > 0;) {
-		const uint32_t w = data.bch_plan[plan_index];
-		const uint64_t left_factor = data.bch_left_factor[w];
-		const uint64_t right_factor = data.bch_right_factor[w];
+	for (uint32_t operation_index = static_cast<uint32_t>(data.m2 - 2);
+		operation_index-- > 0;) {
+		const uint32_t w = operation_index + 2;
+		const uint32_t left_factor = data.bch_operations[operation_index].left;
+		const uint32_t right_factor = data.bch_operations[operation_index].right;
 		const T* left_global = memo + left_factor * data.m;
 		const T* right_global = memo + right_factor * data.m;
 		const T* left = left_global;
@@ -860,9 +757,8 @@ __global__ void branched_log_sig_from_path_backprop_kernel_(
 		memo[data.m + k] = T(0);
 	}
 	if constexpr (SparseForward) {
-		for (uint64_t plan_index = 0;
-			plan_index < data.bch_plan.size; ++plan_index) {
-			T* result = memo + data.bch_plan[plan_index] * data.m;
+		for (uint64_t w = 2; w < data.m2; ++w) {
+			T* result = memo + w * data.m;
 			for (uint64_t k = tid; k < data.m; k += stride)
 				result[k] = T(0);
 		}
@@ -940,20 +836,17 @@ __global__ void branched_log_sig_from_path_backprop_kernel_(
 			deriv_memo[data.m + k] = T(0);
 		}
 		if constexpr (SparseForward && !SparseReverse) {
-			for (uint64_t plan_index = 0;
-				plan_index < data.bch_plan.size; ++plan_index) {
-				T* node_derivs = deriv_memo
-					+ data.bch_plan[plan_index] * data.m;
+			for (uint64_t w = 2; w < data.m2; ++w) {
+				T* node_derivs = deriv_memo + w * data.m;
 				for (uint64_t k = tid; k < data.m; k += stride)
 					node_derivs[k] = T(0);
 			}
 		}
 		__syncthreads();
 		if constexpr (SparseForward) {
-			for (uint64_t plan_index = 0;
-				plan_index < data.bch_plan.size; ++plan_index) {
-				const uint32_t w = data.bch_plan[plan_index];
-				const T coefficient = static_cast<T>(data.bch_coefficients[w]);
+			for (uint64_t w = 2; w < data.m2; ++w) {
+				const T coefficient = static_cast<T>(
+					data.bch_operations[w - 2].coefficient);
 				for (uint64_t q = data.linear_output_ptr[w] + tid;
 					q < data.linear_output_ptr[w + 1]; q += stride) {
 					const uint32_t k = data.linear_output_idx[q];
@@ -963,10 +856,9 @@ __global__ void branched_log_sig_from_path_backprop_kernel_(
 			}
 		}
 		else {
-			for (uint64_t plan_index = 0;
-				plan_index < data.bch_plan.size; ++plan_index) {
-				const uint32_t w = data.bch_plan[plan_index];
-				const T coefficient = static_cast<T>(data.bch_coefficients[w]);
+			for (uint64_t w = 2; w < data.m2; ++w) {
+				const T coefficient = static_cast<T>(
+					data.bch_operations[w - 2].coefficient);
 				for (uint64_t k = tid; k < data.m; k += stride)
 					deriv_memo[w * data.m + k]
 						= coefficient * accumulated_derivs[k];
@@ -1122,10 +1014,8 @@ void branched_log_sig_from_path_backprop_cuda_(
 		* cache.bch.linear_dense_forward_work;
 	const long double exact_work = passes
 		* cache.exact_forward_work + cache.exact_zero_work;
-	const bool sparse_forward = data.bch_plan.size != 0
-		&& exact_work < dense_work;
-	const bool sparse_reverse = data.bch_plan.size != 0
-		&& cache.prune_reverse;
+	const bool sparse_forward = data.m2 > 2 && exact_work < dense_work;
+	const bool sparse_reverse = data.m2 > 2 && cache.prune_reverse;
 
 	for (uint64_t offset = 0; offset < batch_size; offset += chunk_size) {
 		const uint64_t current_batch = std::min(

--- a/siglib/cusig/cu_log_sig_combine.cu
+++ b/siglib/cusig/cu_log_sig_combine.cu
@@ -16,6 +16,7 @@
 #include "cusig.h"
 #include "cu_log_sig_combine.h"
 #include "cu_macros.h"
+#include "cu_path_reduction.h"
 #include "cu_utils.h"
 
 #include <algorithm>
@@ -28,10 +29,6 @@
 static std::mutex s_backprop_workspace_mu;
 static void*      s_bp_ws_buf          = nullptr;
 static size_t     s_bp_ws_bytes        = 0;
-
-static std::mutex s_from_path_workspace_mu;
-static void*      s_fp_ws_buf          = nullptr;
-static size_t     s_fp_ws_bytes        = 0;
 
 template<typename Function>
 void dispatch_commutator_view_(
@@ -48,7 +45,7 @@ __device__ __forceinline__ T evaluate_commutator_row_(
 	CUDACommutatorView commutator,
 	const T* v1,
 	const T* v2,
-	uint64_t row
+	uint32_t row
 ) {
 	T sum = T(0);
 	for (uint32_t index = commutator.ptr[row];
@@ -61,15 +58,102 @@ __device__ __forceinline__ T evaluate_commutator_row_(
 	return sum;
 }
 
+template<
+	typename T,
+	bool use_balanced_rows,
+	bool use_shared_operands
+>
+__device__ __forceinline__ void evaluate_bch_nodes_(
+	T* memo,
+	T* out,
+	char* shared,
+	const BchOperation* operations,
+	const BchRange* ranges,
+	uint32_t operation_count,
+	CUDACommutatorView commutator,
+	uint64_t m
+) {
+	T* shared_left = reinterpret_cast<T*>(shared);
+	T* shared_right = shared_left + m;
+	for (uint32_t operation_index = 0;
+		operation_index < operation_count; ++operation_index) {
+		const uint32_t node = operation_index + 2;
+		const BchOperation operation = operations[operation_index];
+		const BchRange range = ranges[operation_index];
+		T* result = memo + node * m;
+		const T* left = memo + operation.left * m;
+		const T* right = memo + operation.right * m;
+		if constexpr (use_shared_operands) {
+			for (uint32_t k = threadIdx.x; k < m; k += blockDim.x) {
+				shared_left[k] = left[k];
+				shared_right[k] = right[k];
+			}
+			__syncthreads();
+			left = shared_left;
+			right = shared_right;
+		}
+
+		const T coefficient = T(operation.coefficient);
+		for (uint32_t row = threadIdx.x;
+			row < range.begin; row += blockDim.x)
+			result[commutator.output<use_balanced_rows>(row)] = T(0);
+		for (uint32_t row = range.begin + threadIdx.x;
+			row < range.end; row += blockDim.x) {
+			const uint32_t k = commutator.output<use_balanced_rows>(row);
+			const T value = evaluate_commutator_row_(
+				commutator, left, right, row);
+			result[k] = value;
+			if (coefficient != T(0))
+				out[k] += coefficient * value;
+		}
+		for (uint32_t row = range.end + threadIdx.x;
+			row < m; row += blockDim.x)
+			result[commutator.output<use_balanced_rows>(row)] = T(0);
+		__syncthreads();
+	}
+}
+
+template<typename T>
+struct PathIncrement_ {
+	uint32_t dimension;
+	uint32_t size;
+
+	__device__ void operator()(
+		const T* left, const T* right, T* out
+	) const {
+		for (uint32_t k = threadIdx.x; k < size; k += blockDim.x)
+			out[k] = k < dimension ? right[k] - left[k] : T(0);
+	}
+};
+
+template<typename T, bool use_balanced_rows, bool use_shared_operands>
+struct BchCombine_ {
+	const BchOperation* operations;
+	const BchRange* ranges;
+	uint32_t operation_count;
+	CUDACommutatorView commutator;
+	uint32_t m;
+
+	__device__ void operator()(
+		const T* left, const T* right, T* out, T* memo, char* shared
+	) const {
+		for (uint32_t k = threadIdx.x; k < m; k += blockDim.x) {
+			const T left_value = left[k];
+			const T right_value = right[k];
+			memo[k] = left_value;
+			memo[m + k] = right_value;
+			out[k] = left_value + right_value;
+		}
+		__syncthreads();
+		evaluate_bch_nodes_<T, use_balanced_rows, use_shared_operands>(
+			memo, out, shared, operations, ranges, operation_count,
+			commutator, m);
+	}
+};
+
 void release_log_sig_combine_state() {
-	{
-		std::lock_guard<std::mutex> lock(s_backprop_workspace_mu);
-		if (s_bp_ws_buf) { cudaFree(s_bp_ws_buf); s_bp_ws_buf = nullptr; s_bp_ws_bytes = 0; }
-	}
-	{
-		std::lock_guard<std::mutex> lock(s_from_path_workspace_mu);
-		if (s_fp_ws_buf) { cudaFree(s_fp_ws_buf); s_fp_ws_buf = nullptr; s_fp_ws_bytes = 0; }
-	}
+	std::lock_guard<std::mutex> lock(s_backprop_workspace_mu);
+	if (s_bp_ws_buf) { cudaFree(s_bp_ws_buf); s_bp_ws_buf = nullptr; s_bp_ws_bytes = 0; }
 }
 
 // =========================================================================
@@ -82,73 +166,21 @@ __global__ void batch_log_sig_combine_kernel_(
 	const T* __restrict__ log_sig2,
 	T* __restrict__ out,
 	T* __restrict__ memo,
-	const double* __restrict__ bch_coefs,
-	const uint64_t* __restrict__ bch_lf,
-	const uint64_t* __restrict__ bch_rf,
-	CUDABchPlan bch_plan,
+	const BchOperation* __restrict__ operations,
+	const BchRange* __restrict__ ranges,
+	uint32_t operation_count,
 	CUDACommutatorView commutator,
-	uint64_t m, uint64_t m2
+	uint32_t m, uint32_t m2
 ) {
 	const uint64_t batch_idx = blockIdx.x;
-	const uint64_t tid = threadIdx.x;
-	const uint64_t stride = blockDim.x;
-
 	extern __shared__ char smem[];
-	T* s_v1 = reinterpret_cast<T*>(smem);
-	T* s_v2 = s_v1 + m;
-
 	const T* ls1 = log_sig1 + batch_idx * m;
 	const T* ls2 = log_sig2 + batch_idx * m;
 	T* o = out + batch_idx * m;
 	T* my_memo = memo + batch_idx * m2 * m;
-
-	// out = ls1 + ls2
-	for (uint64_t k = tid; k < m; k += stride) {
-		o[k] = ls1[k] + ls2[k];
-	}
-
-	if (m2 <= 2) return;
-
-	// Initialize leaves: memo[0] = ls1, memo[1] = ls2
-	for (uint64_t k = tid; k < m; k += stride) {
-		my_memo[k] = ls1[k];
-		my_memo[m + k] = ls2[k];
-	}
-
-	__syncthreads();
-
-	// BCH loop: indices are topologically sorted (children < parent)
-	for (uint64_t plan_index = 0;
-		plan_index < bch_plan.size; ++plan_index) {
-		const uint32_t w = bch_plan[plan_index];
-		const uint64_t lf = bch_lf[w];
-		const uint64_t rf = bch_rf[w];
-		T* result = my_memo + w * m;
-
-		const T* v1 = my_memo + lf * m;
-		const T* v2 = my_memo + rf * m;
-		if constexpr (use_shared_operands) {
-			for (uint64_t k = tid; k < m; k += stride) {
-				s_v1[k] = v1[k];
-				s_v2[k] = v2[k];
-			}
-			__syncthreads();
-			v1 = s_v1;
-			v2 = s_v2;
-		}
-
-		// lie_bracket via transposed commutator table + accumulate into output
-		const T c_w = T(bch_coefs[w]);
-		for (uint64_t row = tid; row < m; row += stride) {
-			const uint32_t k = commutator.output<use_balanced_rows>(row);
-			const T sum = evaluate_commutator_row_(
-				commutator, v1, v2, row);
-			result[k] = sum;
-			if (c_w != T(0)) o[k] += c_w * sum;
-		}
-
-		__syncthreads();
-	}
+	BchCombine_<T, use_balanced_rows, use_shared_operands>{
+		operations, ranges, operation_count, commutator, m
+	}(ls1, ls2, o, my_memo, smem);
 }
 
 // Degree < 2 special case: output = ls1 + ls2
@@ -225,8 +257,9 @@ void log_sig_combine_cuda_(
 					use_shared_operands ? shared_size : 0>>>(
 					log_sig1 + offset * m, log_sig2 + offset * m,
 					out + offset * m, d_memo,
-					cache.d_bch_coefficients, cache.d_bch_left_factor,
-					cache.d_bch_right_factor, cache.bch_plan,
+					cache.d_bch_operations,
+					cache.d_bch_ranges,
+					static_cast<uint32_t>(cache.m2 - 2),
 					commutator, m, m2);
 			};
 			if (use_shmem)
@@ -245,7 +278,7 @@ void log_sig_combine_cuda_(
 // CUDA backward kernels for log_sig_combine
 // =========================================================================
 
-template<typename T>
+template<typename T, bool use_shared_operands>
 __global__ void batch_log_sig_combine_backprop_kernel_(
 	const T* __restrict__ d_out,
 	T* __restrict__ d_ls1,
@@ -253,10 +286,7 @@ __global__ void batch_log_sig_combine_backprop_kernel_(
 	const T* __restrict__ ls1,
 	const T* __restrict__ ls2,
 	T* __restrict__ workspace,
-	const double* __restrict__ bch_coefs,
-	const uint64_t* __restrict__ bch_lf,
-	const uint64_t* __restrict__ bch_rf,
-	CUDABchPlan bch_plan,
+	const BchOperation* __restrict__ operations,
 	CUDACommutatorView commutator,
 	const uint32_t* __restrict__ comm_a_ptr,
 	const uint32_t* __restrict__ comm_a_k,
@@ -296,24 +326,29 @@ __global__ void batch_log_sig_combine_backprop_kernel_(
 	}
 	__syncthreads();
 
-	for (uint64_t plan_index = 0;
-		plan_index < bch_plan.size; ++plan_index) {
-		const uint32_t w = bch_plan[plan_index];
-		const uint64_t lf = bch_lf[w];
-		const uint64_t rf = bch_rf[w];
+	for (uint32_t operation_index = 0;
+		operation_index + 2 < m2; ++operation_index) {
+		const uint32_t w = operation_index + 2;
+		const BchOperation operation = operations[operation_index];
+		const uint32_t lf = operation.left;
+		const uint32_t rf = operation.right;
 		T* result = memo + w * m;
 
-		const T* v1_global = memo + lf * m;
-		const T* v2_global = memo + rf * m;
-		for (uint64_t k = tid; k < m; k += stride) {
-			s_v1[k] = v1_global[k];
-			s_v2[k] = v2_global[k];
+		const T* v1 = memo + lf * m;
+		const T* v2 = memo + rf * m;
+		if constexpr (use_shared_operands) {
+			for (uint64_t k = tid; k < m; k += stride) {
+				s_v1[k] = v1[k];
+				s_v2[k] = v2[k];
+			}
+			__syncthreads();
+			v1 = s_v1;
+			v2 = s_v2;
 		}
-		__syncthreads();
 
 		for (uint64_t k = tid; k < m; k += stride) {
 			result[k] = evaluate_commutator_row_(
-				commutator, s_v1, s_v2, k);
+				commutator, v1, v2, k);
 		}
 		__syncthreads();
 	}
@@ -323,144 +358,40 @@ __global__ void batch_log_sig_combine_backprop_kernel_(
 		d_memo[k] = T(0);
 		d_memo[m + k] = T(0);
 	}
-	for (uint64_t plan_index = 0;
-		plan_index < bch_plan.size; ++plan_index) {
-		const uint32_t w = bch_plan[plan_index];
+	for (uint32_t operation_index = 0;
+		operation_index + 2 < m2; ++operation_index) {
+		const uint32_t w = operation_index + 2;
 		for (uint64_t k = tid; k < m; k += stride) {
-			d_memo[w * m + k] = T(bch_coefs[w]) * my_dout[k];
+			d_memo[w * m + k]
+				= T(operations[operation_index].coefficient) * my_dout[k];
 		}
 	}
 	__syncthreads();
 
 	// Phase 4: Reverse BCH loop using input-grouped table
-	for (uint64_t plan_index = bch_plan.size; plan_index-- > 0;) {
-		const uint32_t w = bch_plan[plan_index];
-		const uint64_t lf = bch_lf[w];
-		const uint64_t rf = bch_rf[w];
+	for (uint32_t operation_index = static_cast<uint32_t>(m2 - 2);
+		operation_index-- > 0;) {
+		const uint32_t w = operation_index + 2;
+		const BchOperation operation = operations[operation_index];
+		const uint32_t lf = operation.left;
+		const uint32_t rf = operation.right;
 		const T* dm_w = d_memo + w * m;
 		T* dm_lf = d_memo + lf * m;
 		T* dm_rf = d_memo + rf * m;
 
-		// Load v1=memo[lf], v2=memo[rf] into shared memory
-		const T* v1_global = memo + lf * m;
-		const T* v2_global = memo + rf * m;
-		for (uint64_t k = tid; k < m; k += stride) {
-			s_v1[k] = v1_global[k];
-			s_v2[k] = v2_global[k];
+		const T* v1 = memo + lf * m;
+		const T* v2 = memo + rf * m;
+		if constexpr (use_shared_operands) {
+			for (uint64_t k = tid; k < m; k += stride) {
+				s_v1[k] = v1[k];
+				s_v2[k] = v2[k];
+			}
+			__syncthreads();
+			v1 = s_v1;
+			v2 = s_v2;
 		}
-		__syncthreads();
 
 		// Gather per input index a (no race conditions)
-		for (uint64_t a = tid; a < m; a += stride) {
-			T acc_dv1 = T(0);
-			T acc_dv2 = T(0);
-			const uint32_t start = comm_a_ptr[a];
-			const uint32_t end = comm_a_ptr[a + 1];
-			for (uint32_t idx = start; idx < end; ++idx) {
-				const uint32_t k = comm_a_k[idx];
-				const uint32_t partner = comm_a_partner[idx];
-				const int sc = comm_a_signed_c[idx];
-				const T dk = dm_w[k];
-				acc_dv1 += T(sc) * s_v2[partner] * dk;
-				acc_dv2 -= T(sc) * s_v1[partner] * dk;
-			}
-			dm_lf[a] += acc_dv1;
-			dm_rf[a] += acc_dv2;
-		}
-		__syncthreads();
-	}
-
-	// Phase 5: Accumulate leaf gradients
-	for (uint64_t k = tid; k < m; k += stride) {
-		my_dls1[k] += d_memo[k];
-		my_dls2[k] += d_memo[m + k];
-	}
-}
-
-template<typename T>
-__global__ void batch_log_sig_combine_backprop_kernel_noshmem_(
-	const T* __restrict__ d_out,
-	T* __restrict__ d_ls1,
-	T* __restrict__ d_ls2,
-	const T* __restrict__ ls1,
-	const T* __restrict__ ls2,
-	T* __restrict__ workspace,
-	const double* __restrict__ bch_coefs,
-	const uint64_t* __restrict__ bch_lf,
-	const uint64_t* __restrict__ bch_rf,
-	CUDABchPlan bch_plan,
-	CUDACommutatorView commutator,
-	const uint32_t* __restrict__ comm_a_ptr,
-	const uint32_t* __restrict__ comm_a_k,
-	const uint32_t* __restrict__ comm_a_partner,
-	const int* __restrict__ comm_a_signed_c,
-	uint64_t m, uint64_t m2
-) {
-	// Same as above but without shared memory for v1/v2
-	const uint64_t batch_idx = blockIdx.x;
-	const uint64_t tid = threadIdx.x;
-	const uint64_t stride = blockDim.x;
-
-	const T* my_dout = d_out + batch_idx * m;
-	T* my_dls1 = d_ls1 + batch_idx * m;
-	T* my_dls2 = d_ls2 + batch_idx * m;
-	const T* my_ls1 = ls1 + batch_idx * m;
-	const T* my_ls2 = ls2 + batch_idx * m;
-	T* memo = workspace + batch_idx * 2 * m2 * m;
-	T* d_memo = memo + m2 * m;
-
-	for (uint64_t k = tid; k < m; k += stride) {
-		my_dls1[k] = my_dout[k];
-		my_dls2[k] = my_dout[k];
-	}
-
-	if (m2 <= 2) return;
-
-	for (uint64_t k = tid; k < m; k += stride) {
-		memo[k] = my_ls1[k];
-		memo[m + k] = my_ls2[k];
-	}
-	__syncthreads();
-
-	for (uint64_t plan_index = 0;
-		plan_index < bch_plan.size; ++plan_index) {
-		const uint32_t w = bch_plan[plan_index];
-		const uint64_t lf = bch_lf[w];
-		const uint64_t rf = bch_rf[w];
-		const T* v1 = memo + lf * m;
-		const T* v2 = memo + rf * m;
-		T* result = memo + w * m;
-
-		for (uint64_t k = tid; k < m; k += stride) {
-			result[k] = evaluate_commutator_row_(
-				commutator, v1, v2, k);
-		}
-		__syncthreads();
-	}
-
-	for (uint64_t k = tid; k < m; k += stride) {
-		d_memo[k] = T(0);
-		d_memo[m + k] = T(0);
-	}
-	for (uint64_t plan_index = 0;
-		plan_index < bch_plan.size; ++plan_index) {
-		const uint32_t w = bch_plan[plan_index];
-		for (uint64_t k = tid; k < m; k += stride) {
-			d_memo[w * m + k] = T(bch_coefs[w]) * my_dout[k];
-		}
-	}
-	__syncthreads();
-
-	for (uint64_t plan_index = bch_plan.size; plan_index-- > 0;) {
-		const uint32_t w = bch_plan[plan_index];
-		const uint64_t lf = bch_lf[w];
-		const uint64_t rf = bch_rf[w];
-		const T* v1 = memo + lf * m;
-		const T* v2 = memo + rf * m;
-		const T* dm_w = d_memo + w * m;
-		T* dm_lf = d_memo + lf * m;
-		T* dm_rf = d_memo + rf * m;
-
 		for (uint64_t a = tid; a < m; a += stride) {
 			T acc_dv1 = T(0);
 			T acc_dv2 = T(0);
@@ -480,6 +411,7 @@ __global__ void batch_log_sig_combine_backprop_kernel_noshmem_(
 		__syncthreads();
 	}
 
+	// Phase 5: Accumulate leaf gradients
 	for (uint64_t k = tid; k < m; k += stride) {
 		my_dls1[k] += d_memo[k];
 		my_dls2[k] += d_memo[m + k];
@@ -549,136 +481,32 @@ void log_sig_combine_backprop_cuda_(
 		uint64_t current_batch = std::min(chunk_size, batch_size - offset);
 
 		if (use_shmem) {
-			batch_log_sig_combine_backprop_kernel_<T><<<static_cast<unsigned int>(current_batch), threads, shared_size>>>(
+			batch_log_sig_combine_backprop_kernel_<T, true><<<static_cast<unsigned int>(current_batch), threads, shared_size>>>(
 				d_out + offset * m,
 				d_ls1 + offset * m,
 				d_ls2 + offset * m,
 				ls1 + offset * m,
 				ls2 + offset * m,
 				s_workspace,
-				cache.d_bch_coefficients, cache.d_bch_left_factor, cache.d_bch_right_factor,
-				cache.bch_plan, commutator,
+				cache.d_bch_operations, commutator,
 				cache.d_comm_a_ptr, cache.d_comm_a_k, cache.d_comm_a_partner, cache.d_comm_a_signed_c,
 				m, m2
 			);
 		} else {
-			batch_log_sig_combine_backprop_kernel_noshmem_<T><<<static_cast<unsigned int>(current_batch), threads>>>(
+			batch_log_sig_combine_backprop_kernel_<T, false><<<static_cast<unsigned int>(current_batch), threads>>>(
 				d_out + offset * m,
 				d_ls1 + offset * m,
 				d_ls2 + offset * m,
 				ls1 + offset * m,
 				ls2 + offset * m,
 				s_workspace,
-				cache.d_bch_coefficients, cache.d_bch_left_factor, cache.d_bch_right_factor,
-				cache.bch_plan, commutator,
+				cache.d_bch_operations, commutator,
 				cache.d_comm_a_ptr, cache.d_comm_a_k, cache.d_comm_a_partner, cache.d_comm_a_signed_c,
 				m, m2
 			);
 		}
 
 		check_cuda_kernel_launch();
-	}
-}
-
-// =========================================================================
-// CUDA kernel: log_sig_from_path - full segment loop inside the kernel
-// =========================================================================
-
-template<
-	typename T,
-	bool use_linear_range,
-	bool use_balanced_rows,
-	bool use_shared_operands
->
-__global__ void batch_log_sig_from_path_kernel_(
-	const T* __restrict__ path,
-	T* __restrict__ out,
-	T* __restrict__ workspace,
-	const double* __restrict__ bch_coefs,
-	const uint64_t* __restrict__ bch_lf,
-	const uint64_t* __restrict__ bch_rf,
-	CUDABchPlan bch_plan,
-	const uint64_t* __restrict__ linear_range,
-	CUDACommutatorView commutator,
-	uint64_t m, uint64_t m2, uint64_t length, uint64_t dimension
-) {
-	const uint64_t batch_idx = blockIdx.x;
-	const uint64_t tid = threadIdx.x;
-	const uint64_t stride = blockDim.x;
-
-	extern __shared__ char smem[];
-	T* s_v1 = reinterpret_cast<T*>(smem);
-	T* s_v2 = s_v1 + m;
-
-	const T* my_path = path + batch_idx * length * dimension;
-	T* my_out = out + batch_idx * m;
-	T* memo = workspace + batch_idx * m2 * m;
-
-	for (uint64_t k = tid; k < m; k += stride) {
-		my_out[k] = (k < dimension) ? (my_path[dimension + k] - my_path[k]) : T(0);
-	}
-	if constexpr (use_linear_range) {
-		for (uint64_t plan_index = 0;
-			plan_index < bch_plan.size; ++plan_index) {
-			const uint32_t w = bch_plan[plan_index];
-			T* result = memo + w * m;
-			const uint64_t begin = linear_range[2 * w];
-			const uint64_t end = linear_range[2 * w + 1];
-			for (uint64_t k = tid; k < begin; k += stride)
-				result[k] = T(0);
-			for (uint64_t k = end + tid; k < m; k += stride)
-				result[k] = T(0);
-		}
-		__syncthreads();
-	}
-
-	for (uint64_t seg = 1; seg < length - 1; ++seg) {
-		const T* pa = my_path + seg * dimension;
-		const T* pb = my_path + (seg + 1) * dimension;
-
-		for (uint64_t k = tid; k < m; k += stride) {
-			memo[k] = my_out[k];
-			T seg_k = (k < dimension) ? (pb[k] - pa[k]) : T(0);
-			memo[m + k] = seg_k;
-			my_out[k] += seg_k;
-		}
-		__syncthreads();
-
-		for (uint64_t plan_index = 0;
-			plan_index < bch_plan.size; ++plan_index) {
-			const uint32_t w = bch_plan[plan_index];
-			const uint64_t lf = bch_lf[w];
-			const uint64_t rf = bch_rf[w];
-			uint64_t begin = 0;
-			uint64_t end = m;
-			if constexpr (use_linear_range) {
-				begin = linear_range[2 * w];
-				end = linear_range[2 * w + 1];
-			}
-			T* result = memo + w * m;
-
-			const T* v1 = memo + lf * m;
-			const T* v2 = memo + rf * m;
-			if constexpr (use_shared_operands) {
-				for (uint64_t k = tid; k < m; k += stride) {
-					s_v1[k] = v1[k];
-					s_v2[k] = v2[k];
-				}
-				__syncthreads();
-				v1 = s_v1;
-				v2 = s_v2;
-			}
-
-			const T c_w = T(bch_coefs[w]);
-			for (uint64_t row = begin + tid; row < end; row += stride) {
-				const uint32_t k = commutator.output<use_balanced_rows>(row);
-				const T sum = evaluate_commutator_row_(
-					commutator, v1, v2, row);
-				result[k] = sum;
-				if (c_w != T(0)) my_out[k] += c_w * sum;
-			}
-			__syncthreads();
-		}
 	}
 }
 
@@ -747,79 +575,40 @@ void log_sig_from_path_cuda_(
 		return;
 	}
 
-	uint64_t ws_per_batch = m2 * m;
+	if (batch_size == 0)
+		return;
+	const PathIncrement_<T> segment{
+		static_cast<uint32_t>(dimension), static_cast<uint32_t>(m) };
+	const size_t shared_size = checked_cuda_size_mul(
+		checked_cuda_size_mul(2, static_cast<size_t>(m),
+			"CUDA log-signature shared workspace"),
+		sizeof(T), "CUDA log-signature shared workspace");
 
-	std::lock_guard<std::mutex> lock(s_from_path_workspace_mu);
-
-	size_t needed_bytes = batch_size * ws_per_batch * sizeof(T);
-	if (needed_bytes > s_fp_ws_bytes) {
-		if (s_fp_ws_buf) { cudaFree(s_fp_ws_buf); s_fp_ws_buf = nullptr; s_fp_ws_bytes = 0; }
-		size_t free_mem, total_mem;
-		cudaMemGetInfo(&free_mem, &total_mem);
-		uint64_t max_batch = free_mem / (ws_per_batch * sizeof(T) * 2);
-		if (max_batch < 1) max_batch = 1;
-		uint64_t alloc_batch = std::min(batch_size, max_batch);
-		size_t alloc_bytes = alloc_batch * ws_per_batch * sizeof(T);
-		CUDA_CHECK(cudaMalloc(&s_fp_ws_buf, alloc_bytes));
-		s_fp_ws_bytes = alloc_bytes;
-	}
-
-	T* s_workspace = reinterpret_cast<T*>(s_fp_ws_buf);
-	size_t s_workspace_elems = s_fp_ws_bytes / sizeof(T);
-
-	uint64_t chunk_size = s_workspace_elems / ws_per_batch;
-	if (chunk_size > batch_size) chunk_size = batch_size;
-	if (chunk_size > CUDA_GRID_X_LIMIT) chunk_size = CUDA_GRID_X_LIMIT;
-
-	unsigned int threads = static_cast<unsigned int>(std::min(static_cast<uint64_t>(64), m));
-	threads = ((threads + 31) / 32) * 32;
-	if (threads < 32) threads = 32;
-
-	size_t shared_size = 2 * m * sizeof(T);
-	bool use_shmem = (shared_size <= CUDA_BASE_DYNAMIC_SMEM);
-	const uint64_t node_count = cache.bch_plan.size;
-	const uint64_t bch_passes = length - 2;
-	const long double dense_forward_work = bch_passes
-		* static_cast<long double>(cache.linear_dense_forward_work);
-	const long double pruned_forward_work = bch_passes
-		* static_cast<long double>(cache.linear_active_forward_work + 2 * node_count)
-		+ cache.linear_zero_work;
-	const uint64_t* linear_range = pruned_forward_work < dense_forward_work
-		? cache.d_linear_range : nullptr;
-	const CUDACommutatorView commutator = linear_range
-		? cache.linear_commutator_view()
-		: cache.dense_commutator_view();
-	const uint64_t path_stride = length * dimension;
-
-	dispatch_commutator_view_(commutator, [&]<bool use_balanced_rows>() {
-		for (uint64_t offset = 0; offset < batch_size; offset += chunk_size) {
-			const uint64_t current_batch = std::min(
-				chunk_size, batch_size - offset);
-			const auto launch = [&]<
-				bool use_range, bool use_shared_operands>() {
-				batch_log_sig_from_path_kernel_<T, use_range,
-					use_balanced_rows, use_shared_operands><<<
-					static_cast<unsigned int>(current_batch), threads,
-					use_shared_operands ? shared_size : 0>>>(
-					path + offset * path_stride, out + offset * m,
-					s_workspace, cache.d_bch_coefficients,
-					cache.d_bch_left_factor, cache.d_bch_right_factor,
-					cache.bch_plan, use_range ? linear_range : nullptr,
-					commutator, m, m2, length, dimension);
+	unsigned int threads = static_cast<unsigned int>(
+		std::min<uint64_t>(256, m));
+	threads = std::max(32U, ((threads + 31) / 32) * 32);
+	const bool use_shared = shared_size <= CUDA_BASE_DYNAMIC_SMEM;
+	const CUDACommutatorView dense_commutator = cache.dense_commutator_view();
+	dispatch_commutator_view_(
+		dense_commutator, [&]<bool use_balanced_rows>() {
+			const auto launch = [&]<bool use_shared_operands>() {
+				cuda_path_reduce<T>(
+					path, out, batch_size, length, dimension, m, m2,
+					threads,
+					use_shared_operands ? shared_size : 0,
+					segment,
+					BchCombine_<T, use_balanced_rows, use_shared_operands>{
+						cache.d_bch_operations,
+						cache.d_bch_ranges,
+						static_cast<uint32_t>(cache.m2 - 2),
+						dense_commutator, static_cast<uint32_t>(m) },
+					"CUDA log-signature path reduction");
 			};
-			if (linear_range) {
-				if (use_shmem)
-					launch.template operator()<true, true>();
-				else
-					launch.template operator()<true, false>();
-			} else if (use_shmem) {
-				launch.template operator()<false, true>();
-			} else {
-				launch.template operator()<false, false>();
-			}
-			check_cuda_kernel_launch();
-		}
-	});
+			if (use_shared)
+				launch.template operator()<true>();
+			else
+				launch.template operator()<false>();
+		});
 }
 
 // =========================================================================
@@ -840,10 +629,7 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 	T* __restrict__ d_path,
 	const T* __restrict__ path,
 	T* __restrict__ workspace,
-	const double* __restrict__ bch_coefs,
-	const uint64_t* __restrict__ bch_lf,
-	const uint64_t* __restrict__ bch_rf,
-	CUDABchPlan bch_plan,
+	const BchOperation* __restrict__ operations,
 	const uint64_t* __restrict__ linear_range,
 	CUDACommutatorView commutator,
 	const uint32_t* __restrict__ comm_a_ptr,
@@ -880,9 +666,9 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 	for (uint64_t k = tid; k < length * dimension; k += stride)
 		my_dpath[k] = T(0);
 	if constexpr (use_linear_range) {
-		for (uint64_t plan_index = 0;
-			plan_index < bch_plan.size; ++plan_index) {
-			const uint32_t w = bch_plan[plan_index];
+		for (uint32_t operation_index = 0;
+			operation_index + 2 < m2; ++operation_index) {
+			const uint32_t w = operation_index + 2;
 			T* result = memo + w * m;
 			const uint64_t begin = linear_range[2 * w];
 			const uint64_t end = linear_range[2 * w + 1];
@@ -916,11 +702,12 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 		}
 		__syncthreads();
 
-		for (uint64_t plan_index = 0;
-			plan_index < bch_plan.size; ++plan_index) {
-			const uint32_t w = bch_plan[plan_index];
-			const uint64_t lf = bch_lf[w];
-			const uint64_t rf = bch_rf[w];
+		for (uint32_t operation_index = 0;
+			operation_index + 2 < m2; ++operation_index) {
+			const uint32_t w = operation_index + 2;
+			const BchOperation operation = operations[operation_index];
+			const uint32_t lf = operation.left;
+			const uint32_t rf = operation.right;
 			uint64_t begin = 0;
 			uint64_t end = m;
 			if constexpr (use_linear_range) {
@@ -939,7 +726,7 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 				v1 = s_v1;
 				v2 = s_v2;
 			}
-			const T c_w = T(bch_coefs[w]);
+			const T c_w = T(operation.coefficient);
 			for (uint64_t k = begin + tid; k < end; k += stride) {
 				const T sum = evaluate_commutator_row_(
 					commutator, v1, v2, k);
@@ -975,10 +762,12 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 			}
 			__syncthreads();
 
-			for (uint64_t plan_index = 0;
-				plan_index < bch_plan.size; ++plan_index) {
-				const uint32_t w = bch_plan[plan_index];
-				const uint64_t lf = bch_lf[w]; const uint64_t rf = bch_rf[w];
+			for (uint32_t operation_index = 0;
+				operation_index + 2 < m2; ++operation_index) {
+				const uint32_t w = operation_index + 2;
+				const BchOperation operation = operations[operation_index];
+				const uint32_t lf = operation.left;
+				const uint32_t rf = operation.right;
 				T* result = memo + w * m;
 				const T* v1 = memo + lf * m;
 				const T* v2 = memo + rf * m;
@@ -991,7 +780,7 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 					v1 = s_v1;
 					v2 = s_v2;
 				}
-				const T c_w = T(bch_coefs[w]);
+				const T c_w = T(operation.coefficient);
 				for (uint64_t k = tid; k < m; k += stride) {
 					const T sum = evaluate_commutator_row_(
 						commutator, v1, v2, k);
@@ -1010,10 +799,12 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 		}
 		__syncthreads();
 
-		for (uint64_t plan_index = 0;
-			plan_index < bch_plan.size; ++plan_index) {
-			const uint32_t w = bch_plan[plan_index];
-			const uint64_t lf = bch_lf[w]; const uint64_t rf = bch_rf[w];
+		for (uint32_t operation_index = 0;
+			operation_index + 2 < m2; ++operation_index) {
+			const uint32_t w = operation_index + 2;
+			const BchOperation operation = operations[operation_index];
+			const uint32_t lf = operation.left;
+			const uint32_t rf = operation.right;
 			uint64_t begin = 0;
 			uint64_t end = m;
 			if constexpr (use_linear_range) {
@@ -1041,9 +832,9 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 
 		// d_memo init + reverse BCH backprop
 		for (uint64_t k = tid; k < m; k += stride) { d_memo[k] = T(0); d_memo[m + k] = T(0); }
-		for (uint64_t plan_index = 0;
-			plan_index < bch_plan.size; ++plan_index) {
-			const uint32_t w = bch_plan[plan_index];
+		for (uint32_t operation_index = 0;
+			operation_index + 2 < m2; ++operation_index) {
+			const uint32_t w = operation_index + 2;
 			uint64_t begin = 0;
 			uint64_t end = m;
 			if constexpr (use_linear_range) {
@@ -1051,14 +842,17 @@ __global__ void batch_log_sig_from_path_backprop_kernel_(
 				end = linear_range[2 * w + 1];
 			}
 			for (uint64_t k = begin + tid; k < end; k += stride)
-				d_memo[w * m + k] = T(bch_coefs[w]) * d_acc[k];
+				d_memo[w * m + k]
+					= T(operations[operation_index].coefficient) * d_acc[k];
 		}
 		__syncthreads();
 
-		for (uint64_t plan_index = bch_plan.size;
-			plan_index-- > 0;) {
-			const uint32_t w = bch_plan[plan_index];
-			const uint64_t lf = bch_lf[w]; const uint64_t rf = bch_rf[w];
+		for (uint32_t operation_index = static_cast<uint32_t>(m2 - 2);
+			operation_index-- > 0;) {
+			const uint32_t w = operation_index + 2;
+			const BchOperation operation = operations[operation_index];
+			const uint32_t lf = operation.left;
+			const uint32_t rf = operation.right;
 			const T* dm_w = d_memo + w * m; T* dm_lf = d_memo + lf * m; T* dm_rf = d_memo + rf * m;
 			const T* v1 = memo + lf * m;
 			const T* v2 = memo + rf * m;
@@ -1187,8 +981,8 @@ void log_sig_from_path_backprop_cuda_(
 	const bool save_states = prefer_saved_states
 		&& saved_workspace_bytes <= free_memory / 2;
 	const bool use_linear_reverse = save_states
-		&& (4 * cache.bch_plan.size >= m || m >= 512);
-	const uint64_t node_count = cache.bch_plan.size;
+		&& (4 * (m2 - 2) >= m || m >= 512);
+	const uint64_t node_count = m2 - 2;
 	const uint64_t bch_passes = 2 * (length - 2);
 	const long double dense_forward_work = bch_passes
 		* static_cast<long double>(cache.linear_dense_forward_work);
@@ -1240,15 +1034,13 @@ void log_sig_from_path_backprop_cuda_(
 	if (use_shared_operands) { \
 		batch_log_sig_from_path_backprop_kernel_<T, USE_RANGE, SAVE_STATES, USE_REVERSE, true><<<static_cast<unsigned int>(current_batch), threads, shared_size>>>( \
 			d_out + offset * m, d_path + offset * path_stride, path + offset * path_stride, workspace.get(), \
-			cache.d_bch_coefficients, cache.d_bch_left_factor, cache.d_bch_right_factor, \
-			cache.bch_plan, RANGE_PTR, commutator, \
+			cache.d_bch_operations, RANGE_PTR, commutator, \
 			cache.d_comm_a_ptr, cache.d_comm_a_k, cache.d_comm_a_partner, cache.d_comm_a_signed_c, \
 			A_PTR, A_IDX, m, m2, length, dimension); \
 	} else { \
 		batch_log_sig_from_path_backprop_kernel_<T, USE_RANGE, SAVE_STATES, USE_REVERSE, false><<<static_cast<unsigned int>(current_batch), threads, 0>>>( \
 			d_out + offset * m, d_path + offset * path_stride, path + offset * path_stride, workspace.get(), \
-			cache.d_bch_coefficients, cache.d_bch_left_factor, cache.d_bch_right_factor, \
-			cache.bch_plan, RANGE_PTR, commutator, \
+			cache.d_bch_operations, RANGE_PTR, commutator, \
 			cache.d_comm_a_ptr, cache.d_comm_a_k, cache.d_comm_a_partner, cache.d_comm_a_signed_c, \
 			A_PTR, A_IDX, m, m2, length, dimension); \
 	} \

--- a/siglib/cusig/cu_log_sig_combine.h
+++ b/siglib/cusig/cu_log_sig_combine.h
@@ -81,7 +81,7 @@ inline void upload_balanced_commutator_plan_(
 	};
 	const auto linear_divergent_work = [&] {
 		DivergentWork work;
-		for (uint32_t node : host.live_bch_nodes) {
+		for (uint64_t node = 2; node < host.bch_size(); ++node) {
 			const auto [begin, end] = host.linear_range[node];
 			const auto range_work = divergent_range_work(begin, end);
 			work.canonical += range_work.canonical;
@@ -89,9 +89,16 @@ inline void upload_balanced_commutator_plan_(
 		}
 		return work;
 	};
-	const auto dense_work = host.live_bch_nodes.empty()
-		? DivergentWork{}
-		: divergent_range_work(0, host.m);
+	const auto dense_work = [&] {
+		DivergentWork work;
+		for (const auto& range : host.bch_ranges) {
+			const auto range_work = divergent_range_work(
+				range.begin, range.end);
+			work.canonical += range_work.canonical;
+			work.balanced += range_work.balanced;
+		}
+		return work;
+	}();
 	const auto linear_work = linear_divergent_work();
 	const auto worthwhile = [](const auto& work) {
 		return work.canonical != 0
@@ -162,13 +169,9 @@ inline void upload_balanced_commutator_plan_(
 inline CUDABchCache upload_bch_cache_to_device_(const BchCache& host) {
 	CUDABchCache device;
 	device.m = host.m;
-	device.m2 = host.bch_coefficients.size();
-	device.bch_plan.size = host.live_bch_nodes.size();
-	upload_bch_vector_(device.d_bch_coefficients, host.bch_coefficients);
-	upload_bch_vector_(device.d_bch_left_factor, host.bch_left_factor);
-	upload_bch_vector_(device.d_bch_right_factor, host.bch_right_factor);
-	if (!host.all_bch_nodes_live)
-		upload_bch_vector_(device.bch_plan.nodes, host.live_bch_nodes);
+	device.m2 = host.bch_size();
+	upload_bch_vector_(device.d_bch_operations, host.bch_operations);
+	upload_bch_vector_(device.d_bch_ranges, host.bch_ranges);
 	upload_bch_vector_(device.d_comm_k_ptr, host.comm_k_ptr);
 	upload_bch_vector_(device.d_comm_k_i, host.comm_k_i);
 	upload_bch_vector_(device.d_comm_k_j, host.comm_k_j);
@@ -198,8 +201,9 @@ inline CUDABchCache upload_bch_cache_to_device_(const BchCache& host) {
 			linear_a_ptr[row] = linear_a_idx.size();
 			if (node < 2)
 				continue;
-			const uint64_t left = host.bch_left_factor[node];
-			const uint64_t right = host.bch_right_factor[node];
+			const auto& operation = host.bch_operation(node);
+			const uint64_t left = operation.left;
+			const uint64_t right = operation.right;
 			const auto [left_begin, left_end] = host.linear_range[left];
 			const auto [right_begin, right_end] = host.linear_range[right];
 			const bool active_left = input >= left_begin && input < left_end;
@@ -218,10 +222,10 @@ inline CUDABchCache upload_bch_cache_to_device_(const BchCache& host) {
 	upload_bch_vector_(device.d_linear_a_ptr, linear_a_ptr);
 	upload_bch_vector_(device.d_linear_a_idx, linear_a_idx);
 
-	const uint64_t nodes = device.bch_plan.size;
+	const uint64_t nodes = host.bch_operations.size();
 	device.linear_dense_forward_work = nodes
 		* (device.m + host.comm_k_i.size());
-	for (uint32_t node : host.live_bch_nodes) {
+	for (uint64_t node = 2; node < host.bch_size(); ++node) {
 		const auto [begin, end] = host.linear_range[node];
 		device.linear_active_forward_work += end - begin;
 		device.linear_zero_work += begin + device.m - end;

--- a/siglib/cusig/cu_path_reduction.h
+++ b/siglib/cusig/cu_path_reduction.h
@@ -1,0 +1,137 @@
+/* Copyright 2026 Daniil Shmelev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================================= */
+
+#pragma once
+
+#include "cu_runtime_utils.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+// Shared by ordinary and branched paths, and by float and double calls.
+// The mutex covers kernel completion as well as allocation and shutdown.
+struct CudaPathWorkspaces {
+	struct Entry {
+		std::unique_ptr<CudaBatchWorkspace<std::byte>> buffer;
+		size_t requested_bytes = 0;
+	};
+	std::mutex mutex;
+	std::unordered_map<int, Entry> devices;
+};
+
+inline CudaPathWorkspaces& cuda_path_workspaces() {
+	static CudaPathWorkspaces workspaces;
+	return workspaces;
+}
+
+inline void release_cuda_path_workspaces() {
+	auto& workspaces = cuda_path_workspaces();
+	std::lock_guard lock(workspaces.mutex);
+	workspaces.devices.clear();
+}
+
+#ifdef __CUDACC__
+
+template<typename T, typename Segment, typename Combine>
+__global__ void cuda_path_reduce_kernel(
+	const T* __restrict__ path,
+	T* __restrict__ out,
+	T* __restrict__ workspace,
+	uint64_t batch_size,
+	uint64_t length,
+	uint64_t dimension,
+	uint64_t element_size,
+	uint64_t memo_size,
+	Segment segment,
+	Combine combine
+) {
+	const uint64_t batch = cuda_batch_index();
+	if (batch >= batch_size)
+		return;
+	const T* path_row = path + batch * length * dimension;
+	T* out_row = out + batch * element_size;
+	T* memo = workspace + batch * memo_size;
+	extern __shared__ char shared[];
+
+	segment(path_row, path_row + dimension, out_row);
+	for (uint64_t index = 1; index + 1 < length; ++index) {
+		const T* left = path_row + index * dimension;
+		segment(left, left + dimension, memo + element_size);
+		__syncthreads();
+		combine(out_row, memo + element_size, out_row, memo, shared);
+	}
+}
+
+template<typename T, typename Segment, typename Combine>
+void cuda_path_reduce(
+	const T* path,
+	T* out,
+	uint64_t batch_size,
+	uint64_t length,
+	uint64_t dimension,
+	uint64_t element_size,
+	uint64_t memo_nodes,
+	unsigned int threads,
+	size_t shared_bytes,
+	Segment segment,
+	Combine combine,
+	const char* op_name
+) {
+	if (batch_size == 0)
+		return;
+	const size_t memo_size = checked_cuda_size_mul(
+		static_cast<size_t>(memo_nodes), element_size, op_name);
+	const size_t path_stride = checked_cuda_size_mul(
+		static_cast<size_t>(length), dimension, op_name);
+	const size_t row_bytes = checked_cuda_size_mul(memo_size, sizeof(T), op_name);
+	const size_t requested_bytes = checked_cuda_size_mul(
+		std::min(batch_size, CUDA_BATCH_GRID_CAPACITY), row_bytes, op_name);
+	auto& workspaces = cuda_path_workspaces();
+	std::lock_guard lock(workspaces.mutex);
+	int device;
+	CUDA_CHECK(cudaGetDevice(&device));
+	auto& entry = workspaces.devices[device];
+	const auto allocated_bytes = [&] {
+		return entry.buffer ? entry.buffer->capacity() * entry.buffer->row_elements() : 0;
+	};
+	if (!entry.buffer || requested_bytes > entry.requested_bytes
+		|| row_bytes > allocated_bytes()) {
+		entry.buffer.reset();
+		entry.buffer = std::make_unique<CudaBatchWorkspace<std::byte>>(
+			batch_size, row_bytes, op_name);
+		// Remember the request even when memory pressure forced a smaller chunk.
+		entry.requested_bytes = requested_bytes;
+	}
+	const uint64_t capacity = std::min<uint64_t>(
+		CUDA_BATCH_GRID_CAPACITY, allocated_bytes() / row_bytes);
+
+	for (uint64_t offset = 0; offset < batch_size;
+		offset += capacity) {
+		const uint64_t count = std::min(
+			capacity, batch_size - offset);
+		const dim3 grid = make_cuda_batch_grid_chunk(1, count, 0).grid;
+		cuda_path_reduce_kernel<T><<<grid, threads, shared_bytes>>>(
+			path + offset * path_stride, out + offset * element_size,
+			reinterpret_cast<T*>(entry.buffer->get()), count, length, dimension, element_size,
+			memo_size, segment, combine);
+	}
+	check_cuda_kernel_launch();
+}
+
+#endif

--- a/siglib/cusig_unit_testing/cu_test_branched.cpp
+++ b/siglib/cusig_unit_testing/cu_test_branched.cpp
@@ -360,7 +360,7 @@ TEST(branchedSigCoefCudaTest, ForwardAndBackpropMatchFull) {
 
 TEST(branchedLogSigFromPathCudaTest, ForwardAndBackwardMatchMethodTwo) {
     const uint64_t batch_size = 2;
-    const uint64_t length = 5;
+    const uint64_t length = 10;
     const uint64_t dimension = 2;
     const uint64_t max_nodes = 4;
     const uint64_t full_length = compute_branched_sig_length(
@@ -370,10 +370,9 @@ TEST(branchedLogSigFromPathCudaTest, ForwardAndBackwardMatchMethodTwo) {
     ASSERT_EQ(0, prepare_branched_log_sig_cuda(
         dimension, max_nodes, 3, true, false));
 
-    const std::vector<double> path{
-        0.1, -0.2, 0.4, 0.3, 0.4, 0.3, -0.1, 0.8, 0.2, -0.4,
-        -0.3, 0.2, 0.6, -0.5, 0.6, -0.5, 0.9, 0.1, -0.2, 0.7
-    };
+    std::vector<double> path(batch_size * length * dimension);
+    for (uint64_t index = 0; index < path.size(); ++index)
+        path[index] = 0.07 * static_cast<double>((index * 11) % 19) - 0.6;
     std::vector<double> derivs(batch_size * log_length);
     for (uint64_t index = 0; index < derivs.size(); ++index)
         derivs[index] = 0.09 * static_cast<double>(index + 1) - 0.4;

--- a/siglib/cusig_unit_testing/cu_test_log_sig.cpp
+++ b/siglib/cusig_unit_testing/cu_test_log_sig.cpp
@@ -191,6 +191,58 @@ TEST(logSignatureExpandedBackpropCudaTest, ManualDim1Test) {
 }
 
 // =========================================================================
+// Direct method-3 log signature from path
+// =========================================================================
+
+TEST(logSigFromPathCudaTest, MethodThreeMatchesSignatureLog) {
+    // Dead nodes, live zero-coefficient nodes, balanced rows and global operands.
+    const std::pair<uint64_t, uint64_t> cases[] = {
+        {2, 3}, {2, 4}, {2, 5}, {2, 8}, {4, 6}, {4, 7}, {2, 3} };
+    for (const auto [dimension, degree] : cases) {
+        SCOPED_TRACE(::testing::Message() << dimension << ", " << degree);
+        constexpr uint64_t batch_size = 2;
+        constexpr uint64_t length = 10;
+        std::vector<double> path(batch_size * length * dimension);
+        for (uint64_t i = 0; i < path.size(); ++i)
+            path[i] = 0.025 * static_cast<double>(static_cast<int>(i % 17) - 8);
+
+        ASSERT_EQ(0, prepare_log_sig_cuda(dimension, degree, 2));
+        std::vector<double> signature = compute_batch_sig_on_gpu(
+            path, batch_size, dimension, length, degree);
+        const uint64_t log_sig_len = log_sig_length_(dimension, degree);
+        std::vector<double> expected(batch_size * log_sig_len);
+        double* d_signature = nullptr;
+        double* d_expected = nullptr;
+        cudaMalloc(&d_signature, signature.size() * sizeof(double));
+        cudaMalloc(&d_expected, expected.size() * sizeof(double));
+        cudaMemcpy(d_signature, signature.data(), signature.size() * sizeof(double),
+            cudaMemcpyHostToDevice);
+        const int reference_error = sig_to_log_sig_cuda_d(
+            d_signature, d_expected, batch_size, dimension, degree, 2, true);
+        cudaMemcpy(expected.data(), d_expected, expected.size() * sizeof(double),
+            cudaMemcpyDeviceToHost);
+        cudaFree(d_signature);
+        cudaFree(d_expected);
+        ASSERT_EQ(0, reference_error);
+
+        ASSERT_EQ(0, prepare_log_sig_cuda(dimension, degree, 3));
+        check_result_typed(log_sig_from_path_cuda_d, path, expected,
+            batch_size, length, dimension, degree);
+        // Reuse across scalar types, then release and rebuild the workspace.
+        std::vector<float> float_path(path.begin(), path.end());
+        std::vector<float> float_expected(expected.begin(), expected.end());
+        check_result_typed(log_sig_from_path_cuda_f, float_path, float_expected,
+            batch_size, length, dimension, degree);
+        check_result_typed(log_sig_from_path_cuda_d, path, expected,
+            batch_size, length, dimension, degree);
+        cusig_shutdown();
+        ASSERT_EQ(0, prepare_log_sig_cuda(dimension, degree, 3));
+        check_result_typed(log_sig_from_path_cuda_d, path, expected,
+            batch_size, length, dimension, degree);
+    }
+}
+
+// =========================================================================
 // sig_to_log_sig_backprop CUDA tests (Lyndon words / method=1)
 // Ported from CPU logSignatureLyndonWordsBackpropTest
 // =========================================================================

--- a/siglib/shared/preparation/branched_sig/branched_log_sig_cache.cpp
+++ b/siglib/shared/preparation/branched_sig/branched_log_sig_cache.cpp
@@ -344,7 +344,7 @@ BranchedBchCache::BranchedBchCache(
 	// the MKW commutator table and segment lift are specific to branched paths.
 	build_commutator_views(bch);
 	build_bch_formula_data(bch);
-	build_live_bch_nodes(bch);
+	build_bch_operation_ranges(bch);
 
 	std::vector<double> linear_sig(branched_cache.total_length);
 	linear_coefficients.resize(m);

--- a/siglib/shared/preparation/log_sig/bch_cache.cpp
+++ b/siglib/shared/preparation/log_sig/bch_cache.cpp
@@ -116,7 +116,7 @@ void build_tensor_representations_(
 }
 
 void build_linear_bch_ranges_(BchCache& cache) {
-	const uint64_t formula_size = cache.bch_coefficients.size();
+	const uint64_t formula_size = cache.bch_size();
 	if (cache.coordinate_weights.size() != cache.m
 		|| cache.linear_input_mask.size() != cache.m)
 		throw std::runtime_error("BCH cache support data has an invalid size");
@@ -137,8 +137,9 @@ void build_linear_bch_ranges_(BchCache& cache) {
 			min_degree[1] = 1;
 	}
 	for (uint64_t node = 2; node < formula_size; ++node) {
-		const uint64_t left = cache.bch_left_factor[node];
-		const uint64_t right = cache.bch_right_factor[node];
+		const auto& operation = cache.bch_operation(node);
+		const uint64_t left = operation.left;
+		const uint64_t right = operation.right;
 		min_degree[node] = min_degree[left] + min_degree[right];
 		max_degree[node] = (std::min)(
 			cache.degree, max_degree[left] + max_degree[right]);
@@ -158,8 +159,9 @@ void build_linear_bch_ranges_(BchCache& cache) {
 	cache.linear_pair_ptr.assign(formula_size + 1, 0);
 	cache.linear_pair_idx.clear();
 	for (uint64_t node = 2; node < formula_size; ++node) {
-		const uint64_t left = cache.bch_left_factor[node];
-		const uint64_t right = cache.bch_right_factor[node];
+		const auto& operation = cache.bch_operation(node);
+		const uint64_t left = operation.left;
+		const uint64_t right = operation.right;
 		const auto [left_begin, left_end] = cache.linear_range[left];
 		const auto [right_begin, right_end] = cache.linear_range[right];
 		for (uint32_t pair = 0; pair < cache.n_pairs; ++pair) {
@@ -183,7 +185,47 @@ void build_linear_bch_ranges_(BchCache& cache) {
 	cache.prune_linear_backprop = dense_count > 0
 		&& cache.linear_pair_idx.size() <= dense_count - dense_count / 3;
 }
+
 }  // namespace
+
+void build_bch_operation_ranges(BchCache& cache) {
+	const uint64_t size = cache.bch_size();
+	std::vector<uint32_t> minimum_degree(size, 1);
+	for (uint64_t node = 2; node < size; ++node) {
+		const auto& operation = cache.bch_operation(node);
+		minimum_degree[node] = minimum_degree[operation.left]
+			+ minimum_degree[operation.right];
+	}
+
+	std::vector<uint32_t> maximum_degree(size, 0);
+	for (uint64_t node = 2; node < size; ++node) {
+		if (cache.bch_operation(node).coefficient != 0.0)
+			maximum_degree[node] = static_cast<uint32_t>(cache.degree);
+	}
+	for (uint64_t node = size; node-- > 2;) {
+		const auto& operation = cache.bch_operation(node);
+		const uint32_t required = maximum_degree[node];
+		if (required >= minimum_degree[operation.right])
+			maximum_degree[operation.left] = std::max(
+				maximum_degree[operation.left],
+				required - minimum_degree[operation.right]);
+		if (required >= minimum_degree[operation.left])
+			maximum_degree[operation.right] = std::max(
+				maximum_degree[operation.right],
+				required - minimum_degree[operation.left]);
+	}
+
+	cache.bch_ranges.resize(cache.bch_operations.size());
+	for (uint64_t node = 2; node < size; ++node) {
+		auto& range = cache.bch_ranges[node - 2];
+		range.begin = static_cast<uint32_t>(std::lower_bound(
+			cache.coordinate_weights.begin(), cache.coordinate_weights.end(),
+			minimum_degree[node]) - cache.coordinate_weights.begin());
+		range.end = static_cast<uint32_t>(std::upper_bound(
+			cache.coordinate_weights.begin(), cache.coordinate_weights.end(),
+			maximum_degree[node]) - cache.coordinate_weights.begin());
+	}
+}
 
 void build_commutator_views(BchCache& cache) {
 	const uint64_t m = cache.m;
@@ -365,12 +407,35 @@ bool load_hardcoded_bch_formula(BchCache& cache) {
 	const BchHardcodedData* data = get_hardcoded_bch_data(cache.degree);
 	if (data == nullptr)
 		return false;
-	cache.bch_coefficients.assign(
-		data->coefficients, data->coefficients + data->size);
-	cache.bch_left_factor.assign(
-		data->left_factor, data->left_factor + data->size);
-	cache.bch_right_factor.assign(
-		data->right_factor, data->right_factor + data->size);
+	cache.bch_ranges.clear();
+	std::vector<uint8_t> live(data->size, 0);
+	for (uint64_t node = 2; node < data->size; ++node)
+		live[node] = data->coefficients[node] != 0.0;
+	for (uint64_t node = data->size; node-- > 2;) {
+		if (!live[node])
+			continue;
+		if (data->left_factor[node] >= 2)
+			live[data->left_factor[node]] = 1;
+		if (data->right_factor[node] >= 2)
+			live[data->right_factor[node]] = 1;
+	}
+
+	std::vector<uint32_t> slots(data->size, UINT32_MAX);
+	if (data->size > 0)
+		slots[0] = 0;
+	if (data->size > 1)
+		slots[1] = 1;
+	cache.bch_operations.clear();
+	for (uint32_t node = 2; node < data->size; ++node) {
+		if (!live[node])
+			continue;
+		cache.bch_operations.push_back({
+			data->coefficients[node],
+			slots[data->left_factor[node]],
+			slots[data->right_factor[node]]
+		});
+		slots[node] = static_cast<uint32_t>(cache.bch_operations.size() + 1);
+	}
 	return true;
 }
 
@@ -379,33 +444,6 @@ void build_bch_formula_data(BchCache& cache) {
 		return;
 	throw std::invalid_argument(
 		"BCH methods support truncation degrees at most 20");
-}
-
-void build_live_bch_nodes(BchCache& cache) {
-	const uint64_t formula_size = cache.bch_coefficients.size();
-	std::vector<uint8_t> live(formula_size, 0);
-	for (uint64_t node = 2; node < formula_size; ++node)
-		live[node] = cache.bch_coefficients[node] != 0.0;
-
-	for (uint64_t node = formula_size; node-- > 2;) {
-		const uint64_t left = cache.bch_left_factor[node];
-		const uint64_t right = cache.bch_right_factor[node];
-		if (!live[node])
-			continue;
-		if (left >= 2)
-			live[left] = 1;
-		if (right >= 2)
-			live[right] = 1;
-	}
-
-	cache.live_bch_nodes.clear();
-	cache.live_bch_nodes.reserve(formula_size > 2 ? formula_size - 2 : 0);
-	for (uint32_t node = 2; node < formula_size; ++node) {
-		if (live[node])
-			cache.live_bch_nodes.push_back(node);
-	}
-	cache.all_bch_nodes_live = cache.live_bch_nodes.size()
-		== (formula_size > 2 ? formula_size - 2 : 0);
 }
 
 std::unique_ptr<BchCache> make_standard_bch_cache(
@@ -417,8 +455,8 @@ std::unique_ptr<BchCache> make_standard_bch_cache(
 	cache->dimension = dimension;
 	cache->degree = degree;
 	build_bch_formula_data(*cache);
-	build_live_bch_nodes(*cache);
 	build_standard_commutator_table(*cache, basis);
+	build_bch_operation_ranges(*cache);
 	if (dimension > UINT32_MAX)
 		throw std::overflow_error("BCH linear input is too large");
 	const uint64_t input_size = (std::min)(dimension, cache->m);

--- a/siglib/shared/preparation/log_sig/bch_cache.h
+++ b/siglib/shared/preparation/log_sig/bch_cache.h
@@ -27,6 +27,17 @@
 using SparseVec = std::vector<std::pair<uint64_t, int>>;
 using TensorElem = std::unordered_map<uint64_t, int>;
 
+struct BchOperation {
+	double coefficient = 0.0;
+	uint32_t left = 0;
+	uint32_t right = 0;
+};
+
+struct BchRange {
+	uint32_t begin = 0;
+	uint32_t end = 0;
+};
+
 struct BchCache {
 	uint64_t dimension = 0;
 	uint64_t degree = 0;
@@ -50,6 +61,7 @@ struct BchCache {
 	std::vector<uint32_t> comm_ij_ptr;
 	std::vector<uint32_t> comm_ij_k;
 	std::vector<double> comm_ij_c;
+	// Indexed by node, including inputs 0 and 1; support for a linear right input.
 	std::vector<std::pair<uint64_t, uint64_t>> linear_range;
 	std::vector<uint64_t> linear_pair_ptr;
 	std::vector<uint32_t> linear_pair_idx;
@@ -60,11 +72,18 @@ struct BchCache {
 	bool prune_linear_backprop = false;
 	std::vector<uint64_t> left_factor;
 	std::vector<uint64_t> right_factor;
-	std::vector<double> bch_coefficients;
-	std::vector<uint64_t> bch_left_factor;
-	std::vector<uint64_t> bch_right_factor;
-	std::vector<uint32_t> live_bch_nodes;
-	bool all_bch_nodes_live = true;
+	// Operation i produces node i + 2; factors name earlier nodes (0/1 are inputs).
+	std::vector<BchOperation> bch_operations;
+	// Same indexing as operations. Half-open coordinate ranges needed by the
+	// final output, assuming arbitrary inputs; weights must be sorted.
+	std::vector<BchRange> bch_ranges;
+
+	uint64_t bch_size() const noexcept {
+		return degree == 0 ? 0 : bch_operations.size() + 2;
+	}
+	const BchOperation& bch_operation(uint64_t node) const {
+		return bch_operations[node - 2];
+	}
 };
 
 void remove_zero_entries(TensorElem& element);
@@ -86,13 +105,13 @@ void build_commutator_views(BchCache& cache);
 void build_standard_commutator_table(
 	BchCache& cache,
 	const BasisCache& basis);
+void build_bch_operation_ranges(BchCache& cache);
 void configure_linear_bch_input(
 	BchCache& cache,
 	std::vector<uint32_t> input_indices,
 	bool prefix);
 bool load_hardcoded_bch_formula(BchCache& cache);
 void build_bch_formula_data(BchCache& cache);
-void build_live_bch_nodes(BchCache& cache);
 std::unique_ptr<BchCache> make_standard_bch_cache(
 	uint64_t dimension,
 	uint64_t degree,


### PR DESCRIPTION
This puts CPU and CUDA BCH evaluation on the same compact operation list, shares the ordinary and branched CUDA path reduction, and folds the two combine-backprop kernels into one template. The result is 133 fewer lines overall, including the added tests. There is also two fewer allocations (8 -> 6), resulting in a ~25% memory saving.

Workspace reuse is retained. The tests compare compact and range-pruned evaluation against the full formula, check gradients, and exercise CUDA workspace reuse and shutdown.

Validation: CPU, CUDA and benchmark builds pass; 139/139 CUDA tests and 182/186 CPU tests pass. The four CPU failures are the existing cache-test failures
